### PR TITLE
Fixing member construction in service builder

### DIFF
--- a/f5lbaasdriver/v2/bigip/agent_rpc.py
+++ b/f5lbaasdriver/v2/bigip/agent_rpc.py
@@ -18,7 +18,7 @@ from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 import oslo_messaging as messaging
 
-from neutron.common.rpc import get_client
+from neutron.common import rpc
 
 from f5lbaasdriver.v2.bigip import constants_v2 as constants
 
@@ -38,7 +38,7 @@ class LBaaSv2AgentRPC(object):
             self.topic = self.topic + "_" + self.driver.env
         target = messaging.Target(topic=self.topic,
                                   version=constants.BASE_RPC_API_VERSION)
-        self._client = get_client(target, version_cap=None)
+        self._client = rpc.get_client(target, version_cap=None)
 
     def make_msg(self, method, **kwargs):
         return {'method': method,

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -253,7 +253,7 @@ class LBaaSv2PluginCallbacksRPC(object):
                 )
         except Exception:
             LOG.debug('Entity Not Found')
-                
+
     @log_helpers.log_method_call
     def healthmonitor_destroyed(self, context, healthmonitor_id=None):
         """Agent confirmation hook that health_monitor has been destroyed."""

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -108,7 +108,12 @@ class LBaaSv2ServiceBuilder(object):
             service['members'] = []
             service['healthmonitors'] = []
             for pool in service['pools']:
-                for member in pool['members']:
+                pool_id = pool['id']
+                members = self.plugin.db.get_pool_members(
+                    context,
+                    filters={'pool_id': [pool_id]}
+                )
+                for member in members:
                     service['members'].append(member.to_dict(pool=False))
 
                 healthmonitor_id = pool['healthmonitor_id']


### PR DESCRIPTION
the change from api_to_dict() to to_dict() invalidated the way that the service builder was populating the members structure.