### PR TITLE
Adding missing pool_id to the healthmonitor dictionary

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -122,8 +122,10 @@ class LBaaSv2ServiceBuilder(object):
                         context,
                         healthmonitor_id)
                     if healthmonitor:
+                        healthmonitor_dict = healthmonitor.to_dict(pool=False)
+                        healthmonitor_dict['pool_id'] = pool_id
                         service['healthmonitors'].append(
-                            healthmonitor.to_dict(pool=False))
+                            healthmonitor_dict)
 
         return service
 


### PR DESCRIPTION
The healthmonitor object does not contain pool_id.  This fix adds it.