### PR TITLE
Branding compliance updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,15 +15,13 @@ limitations under the License.
 -->
 
 # Contributing Guide for openstack-f5-lbaasv2-driver
-If you have found this that means you you want to help us out.  Thanks in advance for lending a hand! This guide should
-get you up and running quickly and make it easy for you to contribute.  If we don't answer your questions here and you
-help or just want to say hi shoot us an email at <f5_openstack_lbaasv2-driver@f5.com>.
+If you have found this that means you you want to help us out. Thanks in advance for lending a hand! This guide should get you up and running quickly and make it easy for you to contribute.  If we don't answer your questions here and you need help or just want to say hi, shoot us an email at <f5_openstack_lbaasv2-driver@f5.com>.
 
 ## Issues
-Creating issues is good, creating good issues is even better.  By filing meaningful bug reports will lots of information in them helps us figure out what to fix when and how it impacts our users.  We like bugs because it means people are using our code, and we like fixing them even more.
+Creating issues is good, creating good issues is even better. Filing meaningful bug reports with lots of information in them helps us figure out what to fix when and how it impacts our users. We like bugs because it means people are using our code, and we like fixing them even more.
  
 ## Pull Requests
-If you are submitting a pull request you need to make sure that you have done a few things first.
+If you are submitting a pull request, you need to make sure that you have done a few things first.
 
 * If an issue doesn't exist, file one.
 * Make sure you have tested your code because we are going to do that when when you make your PR.  You don't want _The Hat_ because your request fails unit tests.
@@ -46,14 +44,15 @@ WIP #<issueid>
 ```
 
 ## Testing
-Creating tests is pretty straight forward and we need you to help us keep ensure the quality of our code.  We write both our unit tests and functional tests using [pytest](http://pytest.org).  We know it is extra work to write these tests but the maintainers and consumers of this code appreciate the effort and writing the tests is pretty easy.
+Creating tests is pretty straight forward and we need you to help us keep ensure the quality of our code. We write both our unit tests and functional tests using [pytest](http://pytest.org). We know it is extra work to write these tests but the maintainers and consumers of this code appreciate the effort and writing the tests is pretty easy.
  
 Running those tests is even easier.
-```
-shell
+
+```shell
 $ py.test --cov ./ --cov-report=html
 $ open htmlcov/index.html
 ```
+
 If you are running our functional tests you will need a real BIG-IP® to run
 them against, but you can get one of those pretty easily in [Amazon EC2](https://aws.amazon.com/marketplace/pp/B00JL3UASY/ref=srh_res_product_title?ie=UTF8&sr=0-10&qid=1449332167461).
 
@@ -73,5 +72,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their code submission being included in this project.
+Individuals or business entities who contribute to this project must have completed and submitted the [F5® Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their code submission being included in this project.
 

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ limitations under the License.
 Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
+have completed and submitted the `F5® Contributor License
 Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`_
 to Openstack_CLA@f5.com prior to their code submission being included
 in this project.

--- a/SUPPORT
+++ b/SUPPORT
@@ -1,5 +1,5 @@
-Maintenance and support of the unmodified F5 code is provided only to customers
-who have an existing support contract, purchased separately subject to F5’s
+Maintenance and support of the unmodified F5® code is provided only to customers
+who have an existing support contract, purchased separately subject to F5®’s
 support policies available at http://www.f5.com/about/guidelines-policies/ and 
-http://askf5.com.  F5 will not provide maintenance and support services of
-modified F5 code or code that does not have an existing support contract.
+http://askf5.com. F5® will not provide maintenance and support services of
+modified F5® code or code that does not have an existing support contract.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-F5 OpenStack LBaaSv2 Driver
-===========================
+F5® OpenStack LBaaSv2 Driver
+============================
 
 .. include:: ../README.rst
     :start-line: 21

--- a/f5lbaasdriver/v2/bigip/agent_rpc.py
+++ b/f5lbaasdriver/v2/bigip/agent_rpc.py
@@ -1,4 +1,4 @@
-"""RPC Calls to Agents for f5 LBaaSv2."""
+"""RPC Calls to Agents for F5® LBaaSv2."""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -139,7 +139,7 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
 
             # There is no existing loadbalancer agent binding.
             # Find all active agent candidates in this env.
-            # We use environment_prefix to find f5 agents
+            # We use environment_prefix to find F5® agents
             # rather then map to the agent binary name.
             candidates = self.get_active_agent_in_env(plugin,
                                                       context,

--- a/f5lbaasdriver/v2/bigip/constants_v2.py
+++ b/f5lbaasdriver/v2/bigip/constants_v2.py
@@ -1,4 +1,4 @@
-"""Constants for F5 LBaaSv2 Driver."""
+"""Constants for F5® LBaaSv2 Driver."""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -1,4 +1,4 @@
-"""F5 Networks LBaaSv2 Driver Implementation."""
+"""F5 Networks® LBaaSv2 Driver Implementation."""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,7 +49,7 @@ cfg.CONF.register_opts(OPTS)
 
 
 class F5DriverV2(object):
-    """F5 Networks LBaaSv2 Driver."""
+    """F5 Networks® LBaaSv2 Driver."""
 
     def __init__(self, plugin=None, env=None):
         """Driver initialization."""

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -1,4 +1,4 @@
-"""RPC Callbacks for f5 LBaaSv2 Plugins."""
+"""RPC Callbacks for F5® LBaaSv2 Plugins."""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -1,4 +1,4 @@
-"""Service Module for F5 LBaaSv2."""
+"""Service Module for F5® LBaaSv2."""
 # Copyright 2014 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes #34 

@jlongstaf @swormke 


#### What's this change do?
- added the appropriate trademarks for F5, F5 Networks, BIG-IP, etc..

#### Where should the reviewer start?
It's probably easiest to clone my fork and just do a search to verify that the trademark was added after every public-facing reference to F5 properties.

#### Any background context?