### PR TITLE
Feature.branding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ install:
     - sudo pip install -r requirements.docs.txt
 script:
     - flake8 ./f5lbaasdriver
-    - cd docs
-    - make html
-    - cd ..
+    - sphinx-build -W docs/ docs/_build/
 
 notifications:
   slack:

--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,11 @@
 f5-openstack-lbaasv2-driver
 ===========================
 
-|Build Status| |Docs Build Status|
+|Build Status| |Docs Build Status| |slack badge|
 
 Introduction
 ------------
-The F5 OpenStack LBaaSv2 plugin enables F5 services in OpenStack's Neutron LBaaSv2 service. The plugin comprises an agent and a service provider driver. This repo houses the code for the driver.
+The F5® OpenStack LBaaSv2 plugin enables F5® services in OpenStack's Neutron LBaaSv2 service. The plugin comprises an agent and a service provider driver. This repo houses the code for the driver.
 
 The code for the agent, which allows Neutron services to communicate with BIG-IP®, is in the `F5Networks/f5-openstack-agent <https://github.com/F5Networks/f5-openstack-agent>`_ repo.
 
@@ -36,11 +36,11 @@ The LBaaSv2 plugin is compatible with OpenStack releases from Liberty forward. I
 you are using an earlier release, you'll have to use the `LBaaSv1
 plugin <https://github.com/F5Networks/f5-openstack-lbaasv1>`__.
 
-For more information, please see the F5 OpenStack `Releases, Versioning, and Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_.
+For more information, please see the F5® OpenStack `Releases, Versioning, and Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_.
 
 Documentation
 -------------
-Please refer to the F5 OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2.readthedocs.org/en/>`_ for installation and configuration instructions.
+Please refer to the F5® OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2.readthedocs.org/en/>`_ for installation and configuration instructions.
 
 Filing Issues
 -------------
@@ -93,10 +93,6 @@ We use the hacking module for our style checks (installed as part of step 1 in t
     $ flake8 ./
 
 
-Contact
--------
-f5_openstack_lbaasv2@f5.com
-
 Copyright
 ---------
 Copyright 2015-2016 F5 Networks Inc.
@@ -139,3 +135,6 @@ in this project.
     :target: http://f5-openstack-lbaasv2.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. |slack badge| image:: https://f5-openstack-slack.herokuapp.com/badge.svg
+    :target: https://f5-openstack-slack.herokuapp.com/
+    :alt: Slack

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,7 +159,7 @@ html_title = 'F5 OpenStack LBaaSv2 Driver'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,16 @@
 
 import sphinx_rtd_theme
 
+# Ignore external image warnings
+import sphinx.environment
+from docutils.utils import get_source_line
+
+def _warn_node(self, msg, node):
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -132,7 +142,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'F5 OpenStack LBaaSv2'
+html_title = 'F5 OpenStack LBaaSv2 Driver'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -184,7 +194,7 @@ html_use_index = True
 #html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,15 +5,27 @@
 
 F5® OpenStack LBaaSv2 Driver
 ============================
+|Build Status|
+
+.. raw:: html
+
+    <script async defer src="https://f5-openstack-slack.herokuapp.com/slackin.js"></script>
+
 
 .. include:: ../README.rst
-    :start-line: 21
-    :end-line: 143
+    :start-line: 23
+    :end-line: 40
 
+
+Installation
+------------
+Please refer to the F5® OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2.readthedocs.org/en/>`_ for installation and configuration instructions.
 
 .. toctree::
    :hidden:
    :maxdepth: 2
 
 
+.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver.svg?branch=master
+    :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver
 


### PR DESCRIPTION
@jlongstaf @richbrowne 

Fixes #39 - add slack badge to readme & index.rst
Fixes #40 - configure travis to treat Sphinx warnings as errors

#### What's this change do?
Added slack badge to README and index.rst.
Updated the travis build script and conf.py.
Set up the RTD site.

#### Where should the reviewer start?
Changes are relatively minor and can be viewed below.

#### Any background context?
RE the read the docs site -- I would prefer for docs related to the driver to live in this repo with the code instead of in the lbaasv2 repo. I set up the rtd site for this repo so we can use it to publish docstrings for the modules and hopefully related documentation. (@swormke, fyi)