### PR TITLE
Add extended network description to service

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -171,6 +171,8 @@ class LBaaSv2ServiceBuilder(object):
             network_id
         )
 
+        member_dict['network_id'] = network_id
+
         # Use the fixed ip.
         filter = {'fixed_ips': {'subnet_id': [subnet_id],
                                 'ip_address': [member.address]}}


### PR DESCRIPTION
Issues:
Fixes #32

Problem:
In order to support use-cases beyond global routed mode.  The service
object needs to include more detailed networking.

Analysis:
Adding network and vtep information for loadbalancer and members.

Tests:
Functional.