### PR TITLE
Fix the driver reference the plugin properly

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -116,7 +116,7 @@ class LoadBalancerManager(object):
             'status': q_const.PORT_STATUS_ACTIVE
         }
         port_data[portbindings.HOST_ID] = agent['host']
-        self.plugin.db._core_plugin.update_port(
+        driver.plugin.db._core_plugin.update_port(
             context,
             loadbalancer.vip_port_id,
             {'port': port_data}


### PR DESCRIPTION
The create_loadbalancer method uses a reference to the plugin object to update ports.  This change fixes a bug where the call to update_port dereferences the wrong object to access the plugin.