### PR TITLE
Only call _populate_member_network if the member port is discovered

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -186,10 +186,11 @@ class LBaaSv2ServiceBuilder(object):
         # There should be only one.
         if len(ports) == 1:
             member_dict['port'] = ports[0]
+            self._populate_member_network(context, member_dict, network)
         else:
+            # FIXME(RJB: raise an exception here and let the driver handle
+            # the port that is not on the network.
             LOG.error("Unexpected number of ports returned for member")
-
-        self._populate_member_network(context, member_dict, network)
 
         return (member_dict, subnet, network)
 


### PR DESCRIPTION
The _populate_member_network function uses information in the member port on the subnet to discover host binding, etc.  If a member is created that does not have a port on the specified subnet, no port can be discovered and no special network information should be assumed.