### PR TITLE
CLUDS test_loadbalancer fails because of wrong driver and folder name

### DIFF
--- a/test/functional/test_CLUDS.py
+++ b/test/functional/test_CLUDS.py
@@ -38,7 +38,7 @@ def test_loadbalancer_CLUDS(setup_with_nclientmanager, bigip):
     lbid = active_lb['loadbalancer']['id']
     assert active_lb['loadbalancer']['description'] == ''
     assert active_lb['loadbalancer']['provisioning_status'] == 'ACTIVE'
-    assert active_lb['loadbalancer']['provider'] == 'f5networkstest'
+    assert active_lb['loadbalancer']['provider'] == 'f5networks'
     # Test show and update
     nclientmanager.update_loadbalancer(
         lbid, {'loadbalancer': {'description': 'as;iofnypq3489'}})
@@ -50,7 +50,7 @@ def test_loadbalancer_CLUDS(setup_with_nclientmanager, bigip):
     for sf in active_folders:
         assert sf.name == '/' or\
             sf.name == 'Common' or\
-            sf.name.startswith('Test_')
+            sf.name.startswith('Project_')
     # delete
     nclientmanager.delete_loadbalancer(lbid)
     # verify removal from OS on delete


### PR DESCRIPTION
@mattgreene @richbrowne @zancas 
#### What issues does this address?
Fixes #80

#### What's this change do?
Updates test to match changes in driver code, where default class name
is f5networks, not f5networkstest, and default folder prefix is Project_, not Test_.

#### Any background context?
LBaaS driver changes were recently made as part of preparation for the release.

Issues:
Fixes #80

Problem: F5 driver changed default class name and default folder
which causes test_loadbalancer_CLUDS to fail.

Analysis: Fix to change 'f5networkstest' to 'f5networks'; change
test of folder name from 'Test_' prefix to 'Project_'

Tests: test_CLUDS.py