### PR TITLE
changes to use the symbols plugin to allow external env data

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,10 @@
+# app
+-e git+https://github.com/openstack/neutron#egg=neutron
+-e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
+git+https://bldr-git.int.lineratesystems.com/tools/pytest-symbols.git
+
+# Test Requirements
+mock==1.3.0
+pytest==2.9.1
+decorator==4.0.9
+paramiko==1.16.0

--- a/test/functional/README
+++ b/test/functional/README
@@ -1,0 +1,45 @@
+
+In the test_env.json file,
+
+    *  Replace angle-bracketed data locations with required IP Addresses.
+    *  Change any other default data as needed.
+
+The following test files need to be run with the pytest symbols plugin:
+
+    *  test_balancer_updates_scans.py
+    *  test_solution.py
+
+Install the pytest_symbols plugin:
+
+    https://bldr-git.int.lineratesystems.com/tools/pytest-symbols
+
+After configuring the envirnomental data in test_env.json,
+execute those tests similar to this:
+
+    py.test --symbols ./test_env.json -sv -- test_solution.py
+
+
+
+Reference test data preserved for Matt Greene:
+
+lbaasv2 undercloud
+------------------
+  "auth_url":  "http://10.190.4.146:5000/v2.0",
+  "bigip_ip":  "10.190.7.211",
+  "client_ip": "10.190.3.24",
+  "server_ip": "10.190.3.23"
+
+lbaasv1 undercloud
+------------------
+  "auth_url":  "http://10.190.4.144:5000/v2.0",
+  "bigip_ip":  "10.190.3.60",
+  "client_ip": "10.190.3.58",
+  "server_ip": "10.190.3.59"
+
+lbaasv2 overcloud
+-----------------
+  "auth_url":  "http://10.190.4.129:5000/v2.0",
+  "bigip_ip":  "10.190.3.37",
+  "client_ip": "10.190.3.38",
+  "server_ip": "10.190.3.39"
+

--- a/test/functional/test_balancer_updates_scans.py
+++ b/test/functional/test_balancer_updates_scans.py
@@ -6,12 +6,15 @@ from pprint import pprint as pp
 from f5_os_test.polling_clients import NeutronClientPollingManager
 from neutronclient.common.exceptions import BadRequest
 
+from pytest import symbols as symbols_data
+
 
 nclient_config = {
-    'username': 'testlab',
-    'password': 'changeme',
-    'tenant_name': 'testlab',
-    'auth_url': 'http://FIXMEHARDCODED:5000/v2.0'}
+    'username':    symbols_data.username,
+    'password':    symbols_data.password,
+    'tenant_name': symbols_data.tenant_name,
+    'auth_url':    symbols_data.auth_url
+}
 
 
 class UnexpectedTypeFromJson(TypeError):

--- a/test/functional/test_env.json
+++ b/test/functional/test_env.json
@@ -1,0 +1,9 @@
+{
+  "username":    "testlab",
+  "password":    "changeme",
+  "tenant_name": "testlab",
+  "auth_url":    "http://<controller floating IP>:5000/v2.0",
+  "bigip_ip":    "<BipIP floating IP>",
+  "client_ip":   "<Client floating IP>",
+  "server_ip":   "<Serrver floating IP>"
+}

--- a/test/functional/test_solution.py
+++ b/test/functional/test_solution.py
@@ -372,38 +372,17 @@ class LBaaSv2(object):
 
 
 @pytest.fixture
-def tst_setup(request):
+def tst_setup(request, symbols):
     print 'test setup'
     # change the following settings to use your TLC session
     # temp solution until we integrate with Kevin's py-symbols module.
-    symbols = {
-        'bigip_public_mgmt_ip':     '10.190.7.xxx',
-        'client_public_mgmt_ip':    '10.190.3.xxx',
-        'server_public_mgmt_ip':    '10.190.3.xxx',
-        'openstack_auth_url':       'http://10.190.4.xxx:5000/v2.0'
+    symbols_env = {
+        'bigip_public_mgmt_ip':     symbols.bigip_ip,
+        'client_public_mgmt_ip':    symbols.client_ip,
+        'server_public_mgmt_ip':    symbols.server_ip,
+        'openstack_auth_url':       symbols.auth_url
     }
-    # lbaasv2 undercloud
-    symbols_mgreene_lbv2_u = {
-        'bigip_public_mgmt_ip':     '10.190.7.211',
-        'client_public_mgmt_ip':    '10.190.3.24',
-        'server_public_mgmt_ip':    '10.190.3.23',
-        'openstack_auth_url':       'http://10.190.4.146:5000/v2.0'
-    }
-    # lbaasv1 undercloud
-    symbols_mgreene_lbv2_u2 = {
-        'bigip_public_mgmt_ip':     '10.190.3.60',
-        'client_public_mgmt_ip':    '10.190.3.58',
-        'server_public_mgmt_ip':    '10.190.3.59',
-        'openstack_auth_url':       'http://10.190.4.144:5000/v2.0'
-    }
-    # lbaasv2 overcloud
-    symbols_mgreene_lbv2_o = {
-        'bigip_public_mgmt_ip':     '10.190.3.37',
-        'client_public_mgmt_ip':    '10.190.3.38',
-        'server_public_mgmt_ip':    '10.190.3.39',
-        'openstack_auth_url':       'http://10.190.4.129:5000/v2.0'
-    }
-    testenv = ExecTestEnv(symbols_mgreene_lbv2_u)
+    testenv = ExecTestEnv(symbols_env)
 
     def tst_teardown():
         print 'test teardown'


### PR DESCRIPTION
@<reviewer_id>
#### What issues does this address?
Fixes # openstack-298

#### What's this change do?
Moves environmental data settings up a level to an external json file.
Employs pytest-symbols plugin to accomplishthis using the symbols fixture in pytest.

#### Where should the reviewer start?
Changes plus new files.  README begins with some explanation from a user pov.

#### Any background context?
The changed files are functional test scripts for the lbaasv2 plugin.
