### PR TITLE
correct subnet name in test_solution.py; streamline requirements.test…

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,9 +1,6 @@
-# app
--e git+https://github.com/openstack/neutron#egg=neutron
--e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
 git+https://bldr-git.int.lineratesystems.com/tools/pytest-symbols.git
+git+https://bldr-git.int.lineratesystems.com/tools/pytest-meta.git
 
-# Test Requirements
 mock==1.3.0
 pytest==2.9.1
 decorator==4.0.9

--- a/test/functional/test_solution.py
+++ b/test/functional/test_solution.py
@@ -58,7 +58,7 @@ class ExecTestEnv(object):
             'tenant_name':      'testlab',
             'tenant_username':  'testlab',
             'tenant_password':  'changeme',
-            'client_subnet':    'client-v4-subnet',
+            'client_subnet':    'testlab-client-v4-subnet',
             'guest_username':   'centos',
             'guest_password':   'changeme',
             'server_http_port': '8080',


### PR DESCRIPTION
….txt to no longer install neutron locally

@<reviewer_id>
#### What issues does this address?
Fixes #  Openstack-298, also Openstack-327 to install pytest-meta plugin
WIP #<issueid>
...

#### What's this change do?
--  removes neutron install from requirements.test.txt
--  adds install of gitlab pytest-symbols and pytest-meta  plugins to same
--  corrects  client-subnet hard-coded setting within test_solution.py to be prefixed with "testlab-"

#### Where should the reviewer start?
-- Code changes

#### Any background context?
-- Testing does not require a local install of neutron
-- Traffic tests fail without correction to get the test script inline with changes to TLC.

