### PR TITLE
Implemented Disconnected Service Deployment

### DIFF
--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -1,0 +1,63 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from neutron.plugins.ml2 import db
+from neutron.plugins.ml2 import models
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class DisconnectedService(object):
+    def __init__(self):
+        pass
+
+    # Retain this method for future use in case a particular ML2 implementation
+    # decouples network_id from physical_network name.  The implementation in
+    # neutron db.py requires a network_id.
+    def get_network_segments(self, session):
+        with session.begin(subtransactions=True):
+            query = (session.query(models.NetworkSegment).
+                     order_by(models.NetworkSegment.segment_index))
+            records = query.all()
+            result = {}
+            for record in records:
+                if record.network_id not in result:
+                    result[record.network_id] = []
+                result[record.network_id].append(db._make_segment_dict(record))
+            return result
+
+    def get_segmentation_id(self, context, agent_configuration, network):
+        segmentation_id = 0
+        network_segment_physical_network = \
+            agent_configuration.get('network_segment_physical_network', None)
+        if network_segment_physical_network:
+            # look up segment id provided by ml2_network_segments table
+            segments = db.get_network_segments(context.session, network['id'])
+            data = None
+            for segment in segments:
+                if (network_segment_physical_network ==
+                        segment['physical_network']):
+                    data = segment
+                    break
+            if data:
+                segmentation_id = data['segmentation_id']
+            else:
+                LOG.error('network_id %s does not match physical_network %s' %
+                          (network['id'], network_segment_physical_network))
+        else:
+            if 'provider:segmentation_id' in network:
+                segmentation_id = network['provider:segmentation_id']
+        return segmentation_id

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -116,7 +116,7 @@ class LoadBalancerManager(object):
             )
             service = driver.service_builder.build(context,
                                                    loadbalancer,
-                                                   agent=agent)
+                                                   agent)
             # Update the port for the VIP to show ownership by this driver
             port_data = {
                 'admin_state_up': True,
@@ -166,7 +166,9 @@ class LoadBalancerManager(object):
                 loadbalancer.id,
                 driver.env
             )
-            service = driver.service_builder.build(context, loadbalancer)
+            service = driver.service_builder.build(context,
+                                                   loadbalancer,
+                                                   agent)
             driver.agent_rpc.update_loadbalancer(
                 context,
                 old_loadbalancer.to_api_dict(),
@@ -196,7 +198,9 @@ class LoadBalancerManager(object):
                 loadbalancer.id,
                 driver.env
             )
-            service = driver.service_builder.build(context, loadbalancer)
+            service = driver.service_builder.build(context,
+                                                   loadbalancer,
+                                                   agent)
             driver.agent_rpc.delete_loadbalancer(
                 context,
                 loadbalancer.to_api_dict(),
@@ -245,7 +249,7 @@ class ListenerManager(object):
                 )
                 service = driver.service_builder.build(context,
                                                        loadbalancer,
-                                                       agent=agent)
+                                                       agent)
                 driver.agent_rpc.create_listener(
                     context,
                     listener.to_dict(loadbalancer=False, default_pool=False),
@@ -272,7 +276,9 @@ class ListenerManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.update_listener(
                     context,
                     old_listener.to_dict(loadbalancer=False,
@@ -301,7 +307,9 @@ class ListenerManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.delete_listener(
                     context,
                     listener.to_dict(loadbalancer=False, default_pool=False),
@@ -344,7 +352,7 @@ class PoolManager(object):
                 )
                 service = driver.service_builder.build(context,
                                                        loadbalancer,
-                                                       agent=agent)
+                                                       agent)
                 driver.agent_rpc.create_pool(
                     context,
                     self._get_pool_dict(pool),
@@ -371,7 +379,9 @@ class PoolManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.update_pool(
                     context,
                     self._get_pool_dict(old_pool),
@@ -399,7 +409,9 @@ class PoolManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.delete_pool(
                     context,
                     self._get_pool_dict(pool),
@@ -436,7 +448,7 @@ class MemberManager(object):
                 )
                 service = driver.service_builder.build(context,
                                                        loadbalancer,
-                                                       agent=agent)
+                                                       agent)
                 driver.agent_rpc.create_member(
                     context,
                     member.to_dict(pool=False),
@@ -463,7 +475,9 @@ class MemberManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.update_member(
                     context,
                     old_member.to_dict(pool=False),
@@ -491,7 +505,9 @@ class MemberManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.delete_member(
                     context,
                     member.to_dict(pool=False),
@@ -528,7 +544,7 @@ class HealthMonitorManager(object):
                 )
                 service = driver.service_builder.build(context,
                                                        loadbalancer,
-                                                       agent=agent)
+                                                       agent)
                 driver.agent_rpc.create_health_monitor(
                     context,
                     health_monitor.to_dict(pool=False),
@@ -555,7 +571,9 @@ class HealthMonitorManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.update_health_monitor(
                     context,
                     old_health_monitor.to_dict(pool=False),
@@ -583,7 +601,9 @@ class HealthMonitorManager(object):
                     loadbalancer.id,
                     driver.env
                 )
-                service = driver.service_builder.build(context, loadbalancer)
+                service = driver.service_builder.build(context,
+                                                       loadbalancer,
+                                                       agent)
                 driver.agent_rpc.delete_health_monitor(
                     context,
                     health_monitor.to_dict(pool=False),

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -103,7 +103,16 @@ class LBaaSv2PluginCallbacksRPC(object):
                     context,
                     id=loadbalancer_id
                 )
-                service = self.driver.service_builder.build(context, lb)
+                agent = self.driver.plugin.db.get_agent_hosting_loadbalancer(
+                    context,
+                    loadbalancer_id
+                )
+                # the preceeding get call returns a nested dict, unwind
+                # one level if necessary
+                agent = (agent['agent'] if 'agent' in agent else agent)
+                service = self.driver.service_builder.build(context,
+                                                            lb,
+                                                            agent)
             except Exception as e:
                 LOG.error("Exception: get_service_by_loadbalancer_id: %s",
                           e.message)

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -21,6 +21,7 @@ from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 
 from f5lbaasdriver.v2.bigip import constants_v2
+from f5lbaasdriver.v2.bigip.disconnected_service import DisconnectedService
 from f5lbaasdriver.v2.bigip import exceptions as f5_exc
 
 LOG = logging.getLogger(__name__)
@@ -47,8 +48,9 @@ class LBaaSv2ServiceBuilder(object):
         self.subnet_cache = {}
         self.last_cache_update = datetime.datetime.fromtimestamp(0)
         self.plugin = self.driver.plugin
+        self.disconnected_service = DisconnectedService()
 
-    def build(self, context, loadbalancer, agent=None):
+    def build(self, context, loadbalancer, agent):
         """Get full service definition from loadbalancer ID."""
         # Invalidate cache if it is too old
         if ((datetime.datetime.now() - self.last_cache_update).seconds >
@@ -85,6 +87,14 @@ class LBaaSv2ServiceBuilder(object):
                 context,
                 network_id
             )
+            # Override the segmentation ID for this network if we are running
+            # in disconnected service mode
+            agent_config = self.deserialize_agent_configurations(
+                agent['configurations'])
+            network['provider:segmentation_id'] = \
+                self.disconnected_service.get_segmentation_id(context,
+                                                              agent_config,
+                                                              network)
             network_map[network_id] = network
 
             # Check if the tenant can create a loadbalancer on the network.


### PR DESCRIPTION
@richbrowne 

Issues:
Fixes #117

Problem:
F5 LBaaSV2 Plugin driver must be capable of handling a delay in the ML2 plugin driver populating the network segmentation_id.

Analysis:
Look for new field in agent configuration to toggle using the segmentation_id from the neutron network structure vs. probing the segments table.

Tests:
Traffic and agent functional tests.
Manual injection of conditions to trigger timeout, delay in finding the segmentation_id, etc.