### PR TITLE
Fix documentation link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ For more information, please see the F5® OpenStack `Releases, Versioning, and S
 Documentation
 -------------
 
-Please refer to the F5® OpenStack LBaaSv2 Driver `project documentation <http://f5-openstack-lbaasv2.readthedocs.org/en/>`_ for installation and configuration instructions.
+Please refer to the F5® OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2-driver.readthedocs.io>`_ for installation and configuration instructions.
 
 Filing Issues
 -------------

--- a/docs/includes/topic_ha-modes.rst
+++ b/docs/includes/topic_ha-modes.rst
@@ -6,8 +6,8 @@ HA mode
 - ``f5_ha_type``: Defines the high availability (HA) mode used by the BIG-IP®.
 
     * ``standalone``: Single BIG-IP® device; no HA.
-    * ``pair``: Active/standby two device HA. [#fn1]_
-    * ``scalen``: Active device cluster. [#fn1]_
+    * ``pair``: Active/standby two device HA.
+    * ``scalen``: Active device cluster.
 
     .. code-block:: text
 
@@ -15,7 +15,7 @@ HA mode
         #
         # ...
         #
-        f5_ha_type = standalone
+        f5_ha_type = standalone \\ pair \\ scalen
         #
         #
 

--- a/docs/includes/topic_restrictions.rst
+++ b/docs/includes/topic_restrictions.rst
@@ -5,10 +5,10 @@ Unsupported Features
 
 The following features are unsupported in |release|; they will be introduced in future releases.
 
-* vCMP® (multi-tenancy)
-* Agent High Availability
-* BIG-IP® Device Service Clustering
-* Multiple environments (Prod, Dev, Test)
+* `BIG-IP® vCMP® <https://f5.com/resources/white-papers/virtual-clustered-multiprocessing-vcmp>`_
+* Agent High Availability (HA)
+* :ref:`Auto-sync mode <Sync mode>` for clustered devices
+* Differentiated environments [#]_
 
 
 .. note::
@@ -24,3 +24,5 @@ The following features are unsupported in |release|; they will be introduced in 
         |                || (e.g., ``neutron lbaas-loadbalancer-stats``)      |
         +----------------+----------------------------------------------------+
 
+
+.. [#] Running multiple F5® agents on the same host to manage separate BIG-IP® environments.

--- a/docs/includes/topic_supported-features-intro.rst
+++ b/docs/includes/topic_supported-features-intro.rst
@@ -4,3 +4,4 @@ Introduction
 ````````````
 
 The LBaaSv2 features supported in release |release| are noted below. See the agent configuration file -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- for more information about each feature.
+

--- a/docs/includes/topic_sync-mode.rst
+++ b/docs/includes/topic_sync-mode.rst
@@ -5,8 +5,8 @@ Sync mode
 
 * ``f5_sync_mode``: Defines the model by which policies configured on one BIG-IP® are shared with other BIG-IP®s.
 
-   * ``autosync``: configurations are synced automatically across all BIG-IP®s in a device cluster. [#fn1]_
-   * ``replication``: each device is configured separately.
+   * ``autosync``: uses BIG-IP® sync mode to sync LBaaS changes across all devices in a cluster. [#]_
+   * ``replication``: the agent configures each device in a cluster directly, in real time.
 
     .. code-block:: text
 
@@ -18,3 +18,4 @@ Sync mode
         #
 
 
+.. [#] This feature is not supported in release |release|.

--- a/docs/map_lbaasv2-features.rst
+++ b/docs/map_lbaasv2-features.rst
@@ -19,4 +19,3 @@ Supported Features
 
 
 
-.. [#fn1] Not supported in this release.

--- a/docs/map_release-summary.rst
+++ b/docs/map_release-summary.rst
@@ -1,0 +1,14 @@
+New Supported Features
+----------------------
+
+Support for the following features is introduced in v |release|:
+
+* Listener :ref:`TERMINATED_HTTPS <Certificate Manager>` protocol (`SSL offloading <https://f5.com/glossary/ssl-offloading>`_)
+* BIG-IP® device clusters (:ref:`f5_ha_type <HA mode>`)
+
+
+Unsupported Features
+--------------------
+
+.. include:: includes/topic_restrictions.rst
+    :start-line: 5

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,17 +9,7 @@ Release Highlights
 ------------------
 This release provides a limited set of configuration objects for use by OpenStack Neutron LBaaSv2 service plugin. It has support for L3 binding and L2 orchestration for standalone BIG-IP® devices.
 
-Supported Features
-------------------
-
-.. include:: map_lbaasv2-features.rst
-    :start-line: 5
-
-Unsupported Features
---------------------
-
-.. include:: includes/topic_restrictions.rst
-    :start-line: 5
+.. include:: map_release-summary.rst
 
 
 .. toctree::

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,7 +7,9 @@ This release provides an implementation of the OpenStack Neutron LBaaSv2 driver 
 
 Release Highlights
 ------------------
-This release provides a limited set of configuration objects for use by OpenStack Neutron LBaaSv2 service plugin. It has support for L3 binding and L2 orchestration for standalone BIG-IP® devices.
+
+This release introduces support for SSL offloading and for BIG-IP® clustering (active-standby and scalen configurations).
+
 
 .. include:: map_release-summary.rst
 


### PR DESCRIPTION
@swormke @jlongstaf 

#### What issues does this address?
Fixes #121 #114 

#### What's this change do?
- I changed the documentation link in the README to point to http://f5-openstack-lbaasv2-driver.readthedocs.io.
- I updated the release notes for the supported and unsupported features in the upcoming release (8.0.3).

#### Where should the reviewer start?
view changes below

#### Any background context?
I updated the docs URL to point to the new lbaasv2-driver doc set.

@jlongstaf -- this PR should be merged in before liberty is merged up to master / the mitaka branch is created.