### PR TITLE
Fixing an issue with the member creation on server subnet.  This subnet

### DIFF
--- a/test/functional/test_env.json
+++ b/test/functional/test_env.json
@@ -25,6 +25,6 @@
   "os_tenant_id":     "",
   "os_username":      "barbican",
   "os_password":      "orange",
-  "os_auth_version":  "v3"
+  "os_auth_version":  "v3",
   "nc_interval":      1
 }

--- a/test/functional/test_env.json
+++ b/test/functional/test_env.json
@@ -26,4 +26,5 @@
   "os_username":      "barbican",
   "os_password":      "orange",
   "os_auth_version":  "v3"
+  "nc_interval":      1
 }

--- a/test/functional/test_solution.py
+++ b/test/functional/test_solution.py
@@ -61,6 +61,7 @@ class ExecTestEnv(object):
         self.symbols['guest_password']        = symbols_data.guest_password
         self.symbols['server_http_port']      = symbols_data.server_http_port
         self.symbols['server_client_ip']      = symbols_data.server_client_ip
+        self.symbols['nc_interval']           = symbols_data.nc_interval
 
 
 def nclientmanager(symbols):
@@ -69,7 +70,7 @@ def nclientmanager(symbols):
         'password': symbols['tenant_password'],
         'tenant_name': symbols['tenant_name'],
         'auth_url': symbols['openstack_auth_url'],
-        'interval': 1
+        'interval': symbols['nc_interval']
     }
 
     return NeutronClientPollingManager(**nclient_config)
@@ -298,7 +299,7 @@ class LBaaSv2(object):
     def create_lbaas_member(self, p_id):
         subnet_id = None
         for sn in self.ncm.list_subnets()['subnets']:
-            if 'server-v4' in sn['name']:
+            if 'client-v4' in sn['name']:
                 subnet_id = sn['id']
                 break
 


### PR DESCRIPTION
@mattgreene @jlongstaf @dflanigan @zancas 


#### What's this change do?
We have 2 problems with the test_solution traffic test.
1.  The member creation mismatches the ip_address and subnet.  That is it creates a member with an IP on the client subnet, but specifies the server subnet name.  This is incorrect for a one armed test.  I tested that this works when I create a 2 armed test setup, but extra work is necessary on the server side to make the server routable.

2.  The other issue that I fix with this commit is that I add the ability to specify a longer delay in the neutron client library for polling.  There is an issue where we continuously delete objects if they have not been deleted.
#### Where should the reviewer start?
Test_solution.py

#### Any background context?

should contain the member ip address.

Adding an option to increase the latency on operations in the neutron client
in the openstack-test repo.

remove server server ip