### PR TITLE
updates for release v8.0.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ For more information, please see the F5® OpenStack `Releases, Versioning, and S
 Documentation
 -------------
 
-Please refer to the F5® OpenStack LBaaSv2 Driver `project documentation <http://f5-openstack-lbaasv2.readthedocs.org/en/>`_ for installation and configuration instructions.
+Please refer to the F5® OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2-driver.readthedocs.io>`_ for installation and configuration instructions.
 
 Filing Issues
 -------------

--- a/docs/_static/f5-openstack-agent.gre.ini
+++ b/docs/_static/f5-openstack-agent.gre.ini
@@ -513,5 +513,5 @@ icontrol_password = admin
 # inherit settings from the parent you define. This must be an existing profile,
 # and if it does not exist on your BIG-IP® system the agent will use the default
 # profile, clientssl.
-#f5_parent_ssl_profile = clients
+#f5_parent_ssl_profile = clientssl
 #

--- a/docs/_static/f5-openstack-agent.gre.ini
+++ b/docs/_static/f5-openstack-agent.gre.ini
@@ -1,0 +1,517 @@
+###############################################################################
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+#                   ############
+#                 ################
+#               ###/ _ \###|     |#
+#              ###| |#| |##| |######
+#             ####| |######| |######
+#             ##|     |####\    \###    AGILITY YOUR WAY!
+#             ####| |#########| |###
+#             ####| |#########| |##
+#              ###| |########/ /##
+#               #|    |####|  /## 
+#                ##############
+#                 ###########
+#
+#                  NETWORKS
+#
+###############################################################################
+#
+[DEFAULT]
+# Show debugging output in log (sets DEBUG log level output).
+debug = True
+# The LBaaS agent will resync its state with Neutron to recover from any
+# transient notification or rpc errors. The interval is number of
+# seconds between attempts.
+#
+periodic_interval = 10
+#
+# How often should the agent throw away its service cache and 
+# resync assigned services with the neutron LBaaS plugin.
+#
+# service_resync_interval = 500
+#
+# Objects created on the BIG-IP® by this agent will have their names prefixed
+# by an environment string. This allows you set this string.  The default is
+# 'project'.
+#
+# WARNING - you should only set this before creating any objects.  If you change
+# it with established objects, the objects created with an alternative prefix,
+# will no longer be associated with this agent and all objects in neutron
+# and on the the BIG-IP® associated with the old environment will need to be managed
+# manually.
+#
+###############################################################################
+#  Environment Settings
+###############################################################################
+#
+# Since many TMOS® object names must start with an alpha character
+# the environment_prefix is used to prefix all service objects.
+#
+# environment_prefix = 'Project'
+#
+###############################################################################
+#  Static Agent Configuration Setting
+###############################################################################
+#
+# Static configuration data to sent back to the plugin. This can be used
+# on the plugin side of neutron to provide agent identification for custom
+# pool to agent scheduling. This should be a single or comma separated list
+# of name:value entries which will be sent in the agent's configuration
+# dictionary to neutron.
+#
+# static_agent_configuration_data = location:DFW1_R122_U9, service_contract:8675309, contact:jenny 
+#
+###############################################################################
+#  Device Setting
+###############################################################################
+#
+# HA model
+#
+# Device can be required to be:
+#
+# standalone - single device no HA
+# pair - active/standby two device HA(Not supported)
+# scalen - active device cluster(Not supported)
+#
+# If the device is external, the devices must be onboarded for the
+# appropriate HA mode or else the driver will not provision devices
+#
+f5_ha_type = standalone
+#
+#
+# Sync mode
+#
+# autosync - syncable policies configured on one device then
+#            synced to the group
+# replication - each device configured separately
+#
+f5_sync_mode = replication
+#
+###############################################################################
+#  L2 Segmentation Mode Settings
+###############################################################################
+#
+# Device VLAN to interface and tag mapping 
+#
+# For pools or VIPs created on networks with type VLAN we will map
+# the VLAN to a particular interface and state if the VLAN tagging
+# should be enforced by the external device or not.  This setting 
+# is a comma separated list of the following format:
+#
+#    physical_network:interface_name:tagged, physical:interface_name:tagged
+#
+# where :
+#   physical_network corresponds to provider:physical_network attributes
+#   interface_name is the name of an interface or LAG trunk 
+#   tagged is a boolean (True or False)    
+#
+# If a network does not have a provider:physical_network attribute,
+# or the provider:physical_network attribute does not match in the
+# configured list, the 'default' physical_network setting will be 
+# applied. At a minimum you must have a 'default' physical_network  
+# setting.
+#
+# standalone example:
+#   f5_external_physical_mappings = default:1.1:True
+#
+# pair or scalen (1.1 and 1.2 are used for HA purposes):
+#   f5_external_physical_mappings = default:1.3:True
+#
+f5_external_physical_mappings = default:1.1:True
+#
+# VLAN device and interface to port mappings
+#
+# Some systems require the need to bind and prune VLANs ids
+# allowed to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# tagged VLANs. When a VLAN tagged network is added to a 
+# specific BIG-IP® device, the facing switch port will need
+# to allow traffic for that VLAN tag through to the BIG-IP®'s
+# port for traffic to flow. 
+#
+# What is required is a software hook which allows the binding.
+# A vlan_binding_driver class needs to reference a subclass of the 
+# VLANBindingBase class and provides the methods to bind and prune
+# VLAN tags to ports.
+#
+# vlan_binding_driver = f5.oslbaasv1agent.drivers.bigip.vlan_binding.NullBinding
+#
+# The interface_port_static_mappings allows for a JSON encoded dictionary
+# mapping BigIP devices and interfaces to corresponding ports. A port id can be
+# any string which is meaningful to a vlan_binding_driver. It can be a 
+# switch_id and port, or it might be a neutron port_id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM interfaces will be collect
+# for each device and neutron will be queried to see if which 
+# device port_ids correspond to known neutron ports. If they do, 
+# automatic entries for all mapped port_ids will be made referencing 
+# the BIG-IP® device name and interface and the neutron port_ids.
+#
+# interface_port_static_mappings = {"device_name_1":{"interface_ida":"port_ida","interface_idb":"port_idb"}, {"device_name_2":{"interface_ida":"port_ida","interface_idb":"port_idb"}} 
+#                  
+# example:
+#
+# interface_port_static_mappings = {"bigip1":{"1.1":"switch1:g2/32","1.2":"switch1:g2/33"},"bigip2":{"1.1":"switch1:g3/32","1.2":"switch1:g3/33"}}
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a single entry or comma separated list of cidr (h/m) format
+# selfip addresses, one per BIG-IP® device, to use for VTEP addresses.
+#
+# If no gre or vxlan tunneling is required, these settings should be
+# commented out or set to None.
+#
+f5_vtep_folder = None
+f5_vtep_selfip_name = None
+#
+#
+# Tunnel types
+#
+# This is a comma separated list of tunnel types to report 
+# as available from this agent as well as to send via tunnel_sync
+# rpc messages to compute nodes. This should match your ml2
+# network types on your compute nodes. 
+#
+# If you are using only gre tunnels it should be:
+#
+advertised_tunnel_types = gre
+#
+# If you are using only vxlan tunnels it should be:
+#
+# advertised_tunnel_types = vxlan
+#
+# If this agent could get both gre and vxlan tunnel networks:
+#
+# advertised_tunnel_types = gre,vxlan
+#
+# If you are using only vlans only it should be:
+#
+# advertised_tunnel_types =
+#
+# Static ARP population for members on tunnel networks
+#
+# This is a boolean True or False value which specifies 
+# that if a Pool Member IP address is associated with a gre 
+# or vxlan tunnel network, in addition to a tunnel fdb 
+# record being added, that a static arp entry will be created to 
+# avoid the need to learn the member's MAC address via flooding.
+#
+# f5_populate_static_arp = True
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a boolean entry which determines if they BIG-IP® will use
+# L2 Population service to update its fdb tunnel entries. This needs
+# to be setup in accordance with the way the other tunnel agents are
+# setup.  If the BIG-IP® agent and other tunnel agents don't match
+# the tunnel setup will not work properly.
+#
+l2_population = True
+#
+###############################################################################
+#  L3 Segmentation Mode Settings
+###############################################################################
+#
+# Global Routed Mode - No L2 or L3 Segmentation on BIG-IP®
+#
+# This setting will cause the agent to assume that all VIPs
+# and pool members will be reachable via global device
+# L3 routes, which must be already provisioned on the BIG-IP®s.
+#
+# In f5_global_routed_mode, BIG-IP® will not assume L2
+# adjacentcy to any neutron network, therefore no
+# L2 segementation between tenant services in the data plane
+# will be provisioned by the agent. Because the routing
+# is global, no L3 self IPs or SNATs will be provisioned
+# by the agent on behalf of tenants either. You must have
+# all necessary L3 routes (including TMM default routes)
+# provisioned before LBaaS resources are provisioned for tenants.
+#
+# WARNING: setting this mode to True will override
+# the use_namespaces, setting it to False, because only
+# one global routing space will used on the BIG-IP®.  This
+# means overlapping IP addresses between tenants is no
+# longer supported.
+#
+# WARNING: setting this mode to True will override
+# the f5_snat_mode, setting it to True, because pool members
+# will never be considered L2 adjacent to the BIG-IP® by
+# the agent. All member access will be via L3 routing, which
+# will need to be set up on the BIG-IP® before LBaaS provisions
+# resources on behalf of tenants.
+#
+# WARNING: setting this mode to True will override the
+# f5_snat_addresses_per_subnet, setting it to 0 (zero).
+# This will force all VIPs to use AutoMap SNAT for which
+# enough Self IP will need to be pre-provisioned on the
+# BIG-IP® to handle all pool member connections. The SNAT,
+# an L3 mechanism, will all be global without reference
+# to any specific tenant SNAT pool.
+#
+# WARNING: setting this mode will make the VIPs listen
+# on all provisioned L2 segments (All VLANs). This is
+# because no L2 information will be taken from
+# neutron, thus making the assumption that all VIP
+# L3 addresses will be globally routable without
+# segmentation at L2 on the BIG-IP®.
+#
+f5_global_routed_mode = False 
+#
+# Allow overlapping IP subnets across multiple tenants.
+# This creates route domains on BIG-IP® in order to
+# separate the tenant networks.
+#
+# This setting is forced to False if 
+# f5_global_routed_mode = True.
+#
+use_namespaces = True
+#
+# When use_namespaces is True there is normally only one route table
+# allocated per tenant. However, this limit can be increased by
+# changing the max_namespaces_per_tenant variable. This allows one
+# tenant to have overlapping IP subnets.
+#
+# Supporting multiple IP namespaces allows establishing multiple independent
+# IP routing topologies within one tenant project, which, for example,
+# can accomodate multiple testing environments in one project, with
+# each testing environment configured to use the same IP address
+# topology as each other test environment.
+#
+# From a practical point of view, allowing multiple IP namespaces
+# per tenant results in a more complicated configuration scheme
+# for big-ip and also allows a single tenant to consumes more
+# routing tables, which are a limited resource. In order to keep
+# a simple one-to-one strategy of one tenant to one route domain,
+# it is recommended that separate projects be used if possible to
+# establish a new routing namespace rather than allowing multiple route
+# domains within one tenant.
+#
+# If a tenant attempts to use a subnet that overlaps with an existing
+# subnet that is already in use in the existing route domain(s), and
+# this setting is not high enough to accomodate a new route domain to
+# handle the new subnet, then the relevant lbaas element (vip or pool member)
+# will be set to the error state.
+#
+max_namespaces_per_tenant = 1
+#
+# Dictates the strict isolation of the routing 
+# tables.  If you set this to True, then all 
+# VIPs and Members must be in the same tenant
+# or else they can't communicate.
+#
+# This setting is only valid if use_namespaces = True.
+#
+f5_route_domain_strictness = False
+#
+# SNAT Mode and SNAT Address Counts
+#
+# This setting will force the use of SNATs. 
+#
+# If this is set to False, a SNAT will not
+# be created (routed mode) and the BIG-IP®
+# will attempt to set up a floating self IP
+# as the subnet's default gateway address.
+# and a wild card IP forwarding virtual
+# server will be set up on member's network.
+# Setting this to False will mean Neutron
+# floating self IPs will not longer work
+# if the same BIG-IP® device is not being used
+# as the Neutron Router implementation.
+#
+# This setting will be forced to True if 
+# f5_global_routed_mode = True.
+#
+f5_snat_mode = True
+#
+# This setting will specify the number of snat 
+# addresses to put in a snat pool for each 
+# subnet associated with a created local Self IP. 
+# 
+# Setting to 0 (zero) will set VIPs to AutoMap 
+# SNAT and the device's local Self IP will 
+# be used to SNAT traffic.
+#
+# In scalen HA mode, this is the number of snat
+# addresses per active traffic-group at the time
+# a service is provisioned.
+#
+# This setting will be forced to 0 (zero) if 
+# f5_global_routed_mode = True.
+#
+f5_snat_addresses_per_subnet = 1
+#
+# This setting will cause all networks with 
+# the router:external attribute set to True
+# to be created in the Common partition and
+# placed in route domain 0.
+f5_common_external_networks = True
+#
+#
+# Common Networks
+#
+# This setting contains a name value pair comma
+# separated list where if the name is a neutron
+# network id used for a vip or a pool member, 
+# the network should not be created or deleted
+# on the BIG-IP®, but rather assumed that the value
+# is the name of the network already created in
+# the Common partition with all L3 addresses 
+# assigned to route domain 0.  This is useful
+# for shared networks which are already defined
+# on the BIG-IP® prior to LBaaS configuration. The
+# network should not be managed by the LBaaS agent,
+# but can be used for VIPs or pool members
+#
+# If your Internet VLAN on your BIG-IP® is named
+# /Common/external, and that corresponds to 
+# Neutron uuid: 71718972-78e2-449e-bb56-ce47cc9d2680
+# then the entry would look like:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external
+#
+# If you had multiple common networks, they are simply
+# comma separated like this example:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external,396e06a0-05c7-4a49-8e86-04bb83d14438:vlan1222
+#
+# The default is no common networks defined
+#
+# L3 Bindings 
+#
+# Some systems require the need to bind L3 addresses
+# to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# untagged VLANs and is a nova guest instance. By 
+# default, neutron will attempt to apply security rule
+# for anti-spoofing which will not allow just any L3
+# address to be used on the neutron port. The answer is to
+# use allowed-address-pairs for the neutron port. 
+#
+# What is required is a software hook which allows the binding.
+# l3_binding_driver needs to reference a subclass of the L3BindingBase
+# class and provides the methods to bind and unbind L3 address
+# to ports.
+#
+# l3_binding_driver = f5_openstack_agent.lbaasv2.drivers.bigip.l3_binding.AllowedAddressPairs
+#
+# The l3_binding_static_mappings allows for a JSON encoded dictionary
+# mapping neutron subnet ids to lists of L2 ports and devices which 
+# require mapping. The entries for port and device mappings
+# vary between providers. They may look like a neutron port id
+# and a nova guest instance id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM MAC addresses will be collected
+# and neutron will be queried to see if the MAC addresses
+# correspond to known neutron ports. If they do, automatic entries
+# for all mapped fixed_ips will be made referencing the ports id
+# and the ports device_id.
+#
+# l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
+#
+#
+#
+###############################################################################
+#  Device Driver Setting
+###############################################################################
+#
+f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver
+#
+#
+###############################################################################
+#  Device Driver - iControl® Driver Setting
+###############################################################################
+#
+# icontrol_hostname is valid for external device type only.
+# this setting can be either a single IP address or a 
+# comma separated list contain all devices in a device 
+# service group.  For guest devices, the first fixed_address
+# on the first device interfaces will be used.
+#
+# If a single IP address is used and the HA model 
+# is not standalone, all devices in the sync failover
+# device group for the hostname specified must have 
+# their management IP address reachable to the agent.
+# If order to access devices' iControl® interfaces via
+# self IPs, you should specify them as a comma
+# separated list below. 
+#
+icontrol_hostname = 10.190.0.0
+#
+# If you are using vCMP® with VLANs, you will need to configure
+# your vCMP® host addresses, in addition to the guests addresses.
+# vCMP® Host access is necessary for provisioning VLANs to a guest.
+# Use icontrol_hostname for vCMP® guests and icontrol_vcmp_hostname
+# for vCMP® hosts. The plug-in will automatically determine
+# which host corresponds to each guest.
+#
+# icontrol_vcmp_hostname = 192.168.1.245
+#
+# icontrol_username must be a valid Administrator username
+# on all devices in a device sync failover group.
+#
+icontrol_username = admin
+#
+# icontrol_password must be a valid Administrator password
+# on all devices in a device sync failover group.
+#
+icontrol_password = admin
+#
+###############################################################################
+# Certificate Manager
+###############################################################################
+#cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+#
+# Two authentication modes are supported for BarbicanCertManager:
+#   keystone_v2, and keystone_v3
+#
+#
+# Keystone v2 authentication:
+#
+# auth_version = v2
+# os_auth_url = http://localhost:5000/v2.0
+# os_username = admin
+# os_password = changeme
+# os_tenant_name = admin
+#
+#
+# Keystone v3 authentication:
+#
+#auth_version = v3
+#os_auth_url = http://localhost:5000/v3
+#os_username = admin
+#os_password = changeme
+#os_user_domain_name = default
+#os_project_name = admin
+#os_project_domain_name = default
+#
+#
+# Parent SSL profile name
+#
+# A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+# protocol. You can define the parent profile for this profile by setting
+# f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+# inherit settings from the parent you define. This must be an existing profile,
+# and if it does not exist on your BIG-IP® system the agent will use the default
+# profile, clientssl.
+#f5_parent_ssl_profile = clients
+#

--- a/docs/_static/f5-openstack-agent.grm.ini
+++ b/docs/_static/f5-openstack-agent.grm.ini
@@ -512,5 +512,5 @@ icontrol_password = admin
 # inherit settings from the parent you define. This must be an existing profile,
 # and if it does not exist on your BIG-IP® system the agent will use the default
 # profile, clientssl.
-#f5_parent_ssl_profile = clients
+#f5_parent_ssl_profile = clientssl
 #

--- a/docs/_static/f5-openstack-agent.grm.ini
+++ b/docs/_static/f5-openstack-agent.grm.ini
@@ -1,0 +1,516 @@
+###############################################################################
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+#                   ############
+#                 ################
+#               ###/ _ \###|     |#
+#              ###| |#| |##| |######
+#             ####| |######| |######
+#             ##|     |####\    \###    AGILITY YOUR WAY!
+#             ####| |#########| |###
+#             ####| |#########| |##
+#              ###| |########/ /##
+#               #|    |####|  /## 
+#                ##############
+#                 ###########
+#
+#                  NETWORKS
+#
+###############################################################################
+#
+[DEFAULT]
+# Show debugging output in log (sets DEBUG log level output).
+debug = True
+# The LBaaS agent will resync its state with Neutron to recover from any
+# transient notification or rpc errors. The interval is number of
+# seconds between attempts.
+#
+periodic_interval = 10
+#
+# How often should the agent throw away its service cache and 
+# resync assigned services with the neutron LBaaS plugin.
+#
+# service_resync_interval = 500
+#
+# Objects created on the BIG-IP® by this agent will have their names prefixed
+# by an environment string. This allows you set this string.  The default is
+# 'Project'.
+#
+# WARNING - you should only set this before creating any objects.  If you change
+# it with established objects, the objects created with an alternative prefix,
+# will no longer be associated with this agent and all objects in neutron
+# and on the the BIG-IP® associated with the old environment will need to be managed
+# manually.
+#
+###############################################################################
+#  Environment Settings
+###############################################################################
+#
+# Since many TMOS® object names must start with an alpha character
+# the environment_prefix is used to prefix all service objects.
+#
+# environment_prefix = 'Project'
+#
+###############################################################################
+#  Static Agent Configuration Setting
+###############################################################################
+#
+# Static configuration data to sent back to the plugin. This can be used
+# on the plugin side of neutron to provide agent identification for custom
+# pool to agent scheduling. This should be a single or comma separated list
+# of name:value entries which will be sent in the agent's configuration
+# dictionary to neutron.
+#
+# static_agent_configuration_data = location:DFW1_R122_U9, service_contract:8675309, contact:jenny 
+#
+###############################################################################
+#  Device Setting
+###############################################################################
+#
+# HA model
+#
+# Device can be required to be:
+#
+# standalone - single device no HA
+# pair - active/standby two device HA(Not supported)
+# scalen - active device cluster(Not supported)
+#
+# If the device is external, the devices must be onboarded for the
+# appropriate HA mode or else the driver will not provision devices
+#
+f5_ha_type = standalone
+#
+#
+# Sync mode
+#
+# autosync - syncable policies configured on one device then
+#            synced to the group
+# replication - each device configured separately
+#
+f5_sync_mode = replication
+#
+###############################################################################
+#  L2 Segmentation Mode Settings
+###############################################################################
+#
+# Device VLAN to interface and tag mapping 
+#
+# For pools or VIPs created on networks with type VLAN we will map
+# the VLAN to a particular interface and state if the VLAN tagging
+# should be enforced by the external device or not.  This setting 
+# is a comma separated list of the following format:
+#
+#    physical_network:interface_name:tagged, physical:interface_name:tagged
+#
+# where :
+#   physical_network corresponds to provider:physical_network attributes
+#   interface_name is the name of an interface or LAG trunk 
+#   tagged is a boolean (True or False)    
+#
+# If a network does not have a provider:physical_network attribute,
+# or the provider:physical_network attribute does not match in the
+# configured list, the 'default' physical_network setting will be 
+# applied. At a minimum you must have a 'default' physical_network  
+# setting.
+#
+# standalone example:
+#   f5_external_physical_mappings = default:1.1:True
+#
+# pair or scalen (1.1 and 1.2 are used for HA purposes):
+#   f5_external_physical_mappings = default:1.3:True
+#
+f5_external_physical_mappings = default:1.1:True
+#
+# VLAN device and interface to port mappings
+#
+# Some systems require the need to bind and prune VLANs ids
+# allowed to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# tagged VLANs. When a VLAN tagged network is added to a 
+# specific BIG-IP® device, the facing switch port will need
+# to allow traffic for that VLAN tag through to the BIG-IP®'s
+# port for traffic to flow. 
+#
+# What is required is a software hook which allows the binding.
+# A vlan_binding_driver class needs to reference a subclass of the 
+# VLANBindingBase class and provides the methods to bind and prune
+# VLAN tags to ports.
+#
+# vlan_binding_driver = f5.oslbaasv1agent.drivers.bigip.vlan_binding.NullBinding
+#
+# The interface_port_static_mappings allows for a JSON encoded dictionary
+# mapping BigIP devices and interfaces to corresponding ports. A port id can be
+# any string which is meaningful to a vlan_binding_driver. It can be a 
+# switch_id and port, or it might be a neutron port_id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM interfaces will be collect
+# for each device and neutron will be queried to see if which 
+# device port_ids correspond to known neutron ports. If they do, 
+# automatic entries for all mapped port_ids will be made referencing 
+# the BIG-IP® device name and interface and the neutron port_ids.
+#
+# interface_port_static_mappings = {"device_name_1":{"interface_ida":"port_ida","interface_idb":"port_idb"}, {"device_name_2":{"interface_ida":"port_ida","interface_idb":"port_idb"}} 
+#                  
+# example:
+#
+# interface_port_static_mappings = {"bigip1":{"1.1":"switch1:g2/32","1.2":"switch1:g2/33"},"bigip2":{"1.1":"switch1:g3/32","1.2":"switch1:g3/33"}}
+#
+# Device Tunneling (VTEP) Self IPs
+#
+# This is the name of a BIG-IP® self IP address to use for VTEP addresses.
+#
+# If no gre or vxlan tunneling is required, these settings should be
+# commented out or set to None.
+#
+f5_vtep_folder = 'Common'
+f5_vtep_selfip_name = 'vtep'
+#
+#
+# Tunnel types
+#
+# This is a comma separated list of tunnel types to report 
+# as available from this agent as well as to send via tunnel_sync
+# rpc messages to compute nodes. This should match your ml2
+# network types on your compute nodes. 
+#
+# If you are using only gre tunnels it should be:
+#
+#advertised_tunnel_types = gre
+#
+# If you are using only vxlan tunnels it should be:
+#
+# advertised_tunnel_types = vxlan
+#
+# If this agent could get both gre and vxlan tunnel networks:
+#
+# advertised_tunnel_types = gre,vxlan
+#
+# If you are using only vlans only it should be:
+#
+# advertised_tunnel_types = vlan
+#
+# Static ARP population for members on tunnel networks
+#
+# This is a boolean True or False value which specifies 
+# that if a Pool Member IP address is associated with a gre 
+# or vxlan tunnel network, in addition to a tunnel fdb 
+# record being added, that a static arp entry will be created to 
+# avoid the need to learn the member's MAC address via flooding.
+#
+# f5_populate_static_arp = True
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a boolean entry which determines if they BIG-IP® will use
+# L2 Population service to update its fdb tunnel entries. This needs
+# to be setup in accordance with the way the other tunnel agents are
+# setup.  If the BIG-IP® agent and other tunnel agents don't match
+# the tunnel setup will not work properly.
+#
+l2_population = True
+#
+###############################################################################
+#  L3 Segmentation Mode Settings
+###############################################################################
+#
+# Global Routed Mode - No L2 or L3 Segmentation on BIG-IP®
+#
+# This setting will cause the agent to assume that all VIPs
+# and pool members will be reachable via global device
+# L3 routes, which must be already provisioned on the BIG-IP®s.
+#
+# In f5_global_routed_mode, BIG-IP® will not assume L2
+# adjacentcy to any neutron network, therefore no
+# L2 segementation between tenant services in the data plane
+# will be provisioned by the agent. Because the routing
+# is global, no L3 self IPs or SNATs will be provisioned
+# by the agent on behalf of tenants either. You must have
+# all necessary L3 routes (including TMM default routes)
+# provisioned before LBaaS resources are provisioned for tenants.
+#
+# WARNING: setting this mode to True will override
+# the use_namespaces, setting it to False, because only
+# one global routing space will used on the BIG-IP®.  This
+# means overlapping IP addresses between tenants is no
+# longer supported.
+#
+# WARNING: setting this mode to True will override
+# the f5_snat_mode, setting it to True, because pool members
+# will never be considered L2 adjacent to the BIG-IP® by
+# the agent. All member access will be via L3 routing, which
+# will need to be set up on the BIG-IP® before LBaaS provisions
+# resources on behalf of tenants.
+#
+# WARNING: setting this mode to True will override the
+# f5_snat_addresses_per_subnet, setting it to 0 (zero).
+# This will force all VIPs to use AutoMap SNAT for which
+# enough Self IP will need to be pre-provisioned on the
+# BIG-IP® to handle all pool member connections. The SNAT,
+# an L3 mechanism, will all be global without reference
+# to any specific tenant SNAT pool.
+#
+# WARNING: setting this mode will make the VIPs listen
+# on all provisioned L2 segments (All VLANs). This is
+# because no L2 information will be taken from
+# neutron, thus making the assumption that all VIP
+# L3 addresses will be globally routable without
+# segmentation at L2 on the BIG-IP®.
+#
+f5_global_routed_mode = True
+#
+# Allow overlapping IP subnets across multiple tenants.
+# This creates route domains on BIG-IP® in order to
+# separate the tenant networks.
+#
+# This setting is forced to False if 
+# f5_global_routed_mode = True.
+#
+use_namespaces = False
+#
+# When use_namespaces is True there is normally only one route table
+# allocated per tenant. However, this limit can be increased by
+# changing the max_namespaces_per_tenant variable. This allows one
+# tenant to have overlapping IP subnets.
+#
+# Supporting multiple IP namespaces allows establishing multiple independent
+# IP routing topologies within one tenant project, which, for example,
+# can accomodate multiple testing environments in one project, with
+# each testing environment configured to use the same IP address
+# topology as each other test environment.
+#
+# From a practical point of view, allowing multiple IP namespaces
+# per tenant results in a more complicated configuration scheme
+# for big-ip and also allows a single tenant to consumes more
+# routing tables, which are a limited resource. In order to keep
+# a simple one-to-one strategy of one tenant to one route domain,
+# it is recommended that separate projects be used if possible to
+# establish a new routing namespace rather than allowing multiple route
+# domains within one tenant.
+#
+# If a tenant attempts to use a subnet that overlaps with an existing
+# subnet that is already in use in the existing route domain(s), and
+# this setting is not high enough to accomodate a new route domain to
+# handle the new subnet, then the relevant lbaas element (vip or pool member)
+# will be set to the error state.
+#
+max_namespaces_per_tenant = 1
+#
+# Dictates the strict isolation of the routing 
+# tables.  If you set this to True, then all 
+# VIPs and Members must be in the same tenant
+# or less they can't communicate.
+#
+# This setting is only valid if use_namespaces = True.
+#
+f5_route_domain_strictness = False
+#
+# SNAT Mode and SNAT Address Counts
+#
+# This setting will force the use of SNATs. 
+#
+# If this is set to False, a SNAT will not
+# be created (routed mode) and the BIG-IP®
+# will attempt to set up a floating self IP
+# as the subnet's default gateway address.
+# and a wild card IP forwarding virtual
+# server will be set up on member's network.
+# Setting this to False will mean Neutron
+# floating self IPs will not longer work
+# if the same BIG-IP® device is not being used
+# as the Neutron Router implementation.
+#
+# This setting will be forced to True if 
+# f5_global_routed_mode = True.
+#
+f5_snat_mode = True
+#
+# This setting will specify the number of snat 
+# addresses to put in a snat pool for each 
+# subnet associated with a created local Self IP. 
+# 
+# Setting to 0 (zero) will set VIPs to AutoMap 
+# SNAT and the device's local Self IP will 
+# be used to SNAT traffic.
+#
+# In scalen HA mode, this is the number of snat
+# addresses per active traffic-group at the time
+# a service is provisioned.
+#
+# This setting will be forced to 0 (zero) if 
+# f5_global_routed_mode = True.
+#
+f5_snat_addresses_per_subnet = 0
+#
+# This setting will cause all networks with 
+# the router:external attribute set to True
+# to be created in the Common partition and
+# placed in route domain 0.
+f5_common_external_networks = True
+#
+#
+# Common Networks
+#
+# This setting contains a name value pair comma
+# separated list where if the name is a neutron
+# network id used for a vip or a pool member, 
+# the network should not be created or deleted
+# on the BIG-IP®, but rather assumed that the value
+# is the name of the network already created in
+# the Common partition with all L3 addresses 
+# assigned to route domain 0.  This is useful
+# for shared networks which are already defined
+# on the BIG-IP® prior to LBaaS configuration. The
+# network should not be managed by the LBaaS agent,
+# but can be used for VIPs or pool members
+#
+# If your Internet VLAN on your BIG-IP® is named
+# /Common/external, and that corresponds to 
+# Neutron uuid: 71718972-78e2-449e-bb56-ce47cc9d2680
+# then the entry would look like:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external
+#
+# If you had multiple common networks, they are simply
+# comma separated like this example:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external,396e06a0-05c7-4a49-8e86-04bb83d14438:vlan1222
+#
+# The default is no common networks defined
+#
+# L3 Bindings 
+#
+# Some systems require the need to bind L3 addresses
+# to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# untagged VLANs and is a nova guest instance. By 
+# default, neutron will attempt to apply security rule
+# for anti-spoofing which will not allow just any L3
+# address to be used on the neutron port. The answer is to
+# use allowed-address-pairs for the neutron port. 
+#
+# What is required is a software hook which allows the binding.
+# l3_binding_driver needs to reference a subclass of the L3BindingBase
+# class and provides the methods to bind and unbind L3 address
+# to ports.
+#
+# l3_binding_driver = f5_openstack_agent.lbaasv2.drivers.bigip.l3_binding.AllowedAddressPairs
+#
+# The l3_binding_static_mappings allows for a JSON encoded dictionary
+# mapping neutron subnet ids to lists of L2 ports and devices which 
+# require mapping. The entries for port and device mappings
+# vary between providers. They may look like a neutron port id
+# and a nova guest instance id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM MAC addresses will be collected
+# and neutron will be queried to see if the MAC addresses
+# correspond to known neutron ports. If they do, automatic entries
+# for all mapped fixed_ips will be made referencing the ports id
+# and the ports device_id.
+#
+# l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
+#
+#
+#
+###############################################################################
+#  Device Driver Setting
+###############################################################################
+#
+f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver
+#
+#
+###############################################################################
+#  Device Driver - iControl® Driver Setting
+###############################################################################
+#
+# icontrol_hostname is valid for external device type only.
+# this setting can be either a single IP address or a 
+# comma separated list contain all devices in a device 
+# service group.  For guest devices, the first fixed_address
+# on the first device interfaces will be used.
+#
+# If a single IP address is used and the HA model 
+# is not standalone, all devices in the sync failover
+# device group for the hostname specified must have 
+# their management IP address reachable to the agent.
+# If order to access devices' iControl® interfaces via
+# self IPs, you should specify them as a comma
+# separated list below. 
+#
+icontrol_hostname = 10.190.0.0
+#
+# If you are using vCMP® with VLANs, you will need to configure
+# your vCMP® host addresses, in addition to the guests addresses.
+# vCMP® Host access is necessary for provisioning VLANs to a guest.
+# Use icontrol_hostname for vCMP® guests and icontrol_vcmp_hostname
+# for vCMP® hosts. The plug-in will automatically determine
+# which host corresponds to each guest.
+#
+# icontrol_vcmp_hostname = 192.168.1.245
+#
+# icontrol_username must be a valid Administrator username
+# on all devices in a device sync failover group.
+#
+icontrol_username = admin
+#
+# icontrol_password must be a valid Administrator password
+# on all devices in a device sync failover group.
+#
+icontrol_password = admin
+#
+###############################################################################
+# Certificate Manager
+###############################################################################
+#cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+#
+# Two authentication modes are supported for BarbicanCertManager:
+#   keystone_v2, and keystone_v3
+#
+#
+# Keystone v2 authentication:
+#
+# auth_version = v2
+# os_auth_url = http://localhost:5000/v2.0
+# os_username = admin
+# os_password = changeme
+# os_tenant_name = admin
+#
+#
+# Keystone v3 authentication:
+#
+#auth_version = v3
+#os_auth_url = http://localhost:5000/v3
+#os_username = admin
+#os_password = changeme
+#os_user_domain_name = default
+#os_project_name = admin
+#os_project_domain_name = default
+#
+#
+# Parent SSL profile name
+#
+# A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+# protocol. You can define the parent profile for this profile by setting
+# f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+# inherit settings from the parent you define. This must be an existing profile,
+# and if it does not exist on your BIG-IP® system the agent will use the default
+# profile, clientssl.
+#f5_parent_ssl_profile = clients
+#

--- a/docs/_static/f5-openstack-agent.vlan.ini
+++ b/docs/_static/f5-openstack-agent.vlan.ini
@@ -513,5 +513,5 @@ icontrol_password = admin
 # inherit settings from the parent you define. This must be an existing profile,
 # and if it does not exist on your BIG-IP® system the agent will use the default
 # profile, clientssl.
-#f5_parent_ssl_profile = clients
+#f5_parent_ssl_profile = clientssl
 #

--- a/docs/_static/f5-openstack-agent.vlan.ini
+++ b/docs/_static/f5-openstack-agent.vlan.ini
@@ -1,0 +1,517 @@
+###############################################################################
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+#                   ############
+#                 ################
+#               ###/ _ \###|     |#
+#              ###| |#| |##| |######
+#             ####| |######| |######
+#             ##|     |####\    \###    AGILITY YOUR WAY!
+#             ####| |#########| |###
+#             ####| |#########| |##
+#              ###| |########/ /##
+#               #|    |####|  /## 
+#                ##############
+#                 ###########
+#
+#                  NETWORKS
+#
+###############################################################################
+#
+[DEFAULT]
+# Show debugging output in log (sets DEBUG log level output).
+debug = True
+# The LBaaS agent will resync its state with Neutron to recover from any
+# transient notification or rpc errors. The interval is number of
+# seconds between attempts.
+#
+periodic_interval = 10
+#
+# How often should the agent throw away its service cache and 
+# resync assigned services with the neutron LBaaS plugin.
+#
+# service_resync_interval = 500
+#
+# Objects created on the BIG-IP® by this agent will have their names prefixed
+# by an environment string. This allows you set this string.  The default is
+# 'project'.
+#
+# WARNING - you should only set this before creating any objects.  If you change
+# it with established objects, the objects created with an alternative prefix,
+# will no longer be associated with this agent and all objects in neutron
+# and on the the BIG-IP® associated with the old environment will need to be managed
+# manually.
+#
+###############################################################################
+#  Environment Settings
+###############################################################################
+#
+# Since many TMOS® object names must start with an alpha character
+# the environment_prefix is used to prefix all service objects.
+#
+# environment_prefix = 'Project'
+#
+###############################################################################
+#  Static Agent Configuration Setting
+###############################################################################
+#
+# Static configuration data to sent back to the plugin. This can be used
+# on the plugin side of neutron to provide agent identification for custom
+# pool to agent scheduling. This should be a single or comma separated list
+# of name:value entries which will be sent in the agent's configuration
+# dictionary to neutron.
+#
+# static_agent_configuration_data = location:DFW1_R122_U9, service_contract:8675309, contact:jenny 
+#
+###############################################################################
+#  Device Setting
+###############################################################################
+#
+# HA model
+#
+# Device can be required to be:
+#
+# standalone - single device no HA
+# pair - active/standby two device HA(Not supported)
+# scalen - active device cluster(Not supported)
+#
+# If the device is external, the devices must be onboarded for the
+# appropriate HA mode or else the driver will not provision devices
+#
+f5_ha_type = standalone
+#
+#
+# Sync mode
+#
+# autosync - syncable policies configured on one device then
+#            synced to the group
+# replication - each device configured separately
+#
+f5_sync_mode = replication
+#
+###############################################################################
+#  L2 Segmentation Mode Settings
+###############################################################################
+#
+# Device VLAN to interface and tag mapping 
+#
+# For pools or VIPs created on networks with type VLAN we will map
+# the VLAN to a particular interface and state if the VLAN tagging
+# should be enforced by the external device or not.  This setting 
+# is a comma separated list of the following format:
+#
+#    physical_network:interface_name:tagged, physical:interface_name:tagged
+#
+# where :
+#   physical_network corresponds to provider:physical_network attributes
+#   interface_name is the name of an interface or LAG trunk 
+#   tagged is a boolean (True or False)    
+#
+# If a network does not have a provider:physical_network attribute,
+# or the provider:physical_network attribute does not match in the
+# configured list, the 'default' physical_network setting will be 
+# applied. At a minimum you must have a 'default' physical_network  
+# setting.
+#
+# standalone example:
+#   f5_external_physical_mappings = default:1.1:True
+#
+# pair or scalen (1.1 and 1.2 are used for HA purposes):
+#   f5_external_physical_mappings = default:1.3:True
+#
+f5_external_physical_mappings = default:1.1:True
+#
+# VLAN device and interface to port mappings
+#
+# Some systems require the need to bind and prune VLANs ids
+# allowed to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# tagged VLANs. When a VLAN tagged network is added to a 
+# specific BIG-IP® device, the facing switch port will need
+# to allow traffic for that VLAN tag through to the BIG-IP®'s
+# port for traffic to flow. 
+#
+# What is required is a software hook which allows the binding.
+# A vlan_binding_driver class needs to reference a subclass of the 
+# VLANBindingBase class and provides the methods to bind and prune
+# VLAN tags to ports.
+#
+# vlan_binding_driver = f5.oslbaasv1agent.drivers.bigip.vlan_binding.NullBinding
+#
+# The interface_port_static_mappings allows for a JSON encoded dictionary
+# mapping BigIP devices and interfaces to corresponding ports. A port id can be
+# any string which is meaningful to a vlan_binding_driver. It can be a 
+# switch_id and port, or it might be a neutron port_id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM interfaces will be collect
+# for each device and neutron will be queried to see if which 
+# device port_ids correspond to known neutron ports. If they do, 
+# automatic entries for all mapped port_ids will be made referencing 
+# the BIG-IP® device name and interface and the neutron port_ids.
+#
+# interface_port_static_mappings = {"device_name_1":{"interface_ida":"port_ida","interface_idb":"port_idb"}, {"device_name_2":{"interface_ida":"port_ida","interface_idb":"port_idb"}} 
+#                  
+# example:
+#
+# interface_port_static_mappings = {"bigip1":{"1.1":"switch1:g2/32","1.2":"switch1:g2/33"},"bigip2":{"1.1":"switch1:g3/32","1.2":"switch1:g3/33"}}
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a single entry or comma separated list of cidr (h/m) format
+# selfip addresses, one per BIG-IP® device, to use for VTEP addresses.
+#
+# If no gre or vxlan tunneling is required, these settings should be
+# commented out or set to None.
+#
+f5_vtep_folder = None
+f5_vtep_selfip_name = None
+#
+#
+# Tunnel types
+#
+# This is a comma separated list of tunnel types to report 
+# as available from this agent as well as to send via tunnel_sync
+# rpc messages to compute nodes. This should match your ml2
+# network types on your compute nodes. 
+#
+# If you are using only gre tunnels it should be:
+#
+# advertised_tunnel_types = gre
+#
+# If you are using only vxlan tunnels it should be:
+#
+# advertised_tunnel_types = vxlan
+#
+# If this agent could get both gre and vxlan tunnel networks:
+#
+# advertised_tunnel_types = gre,vxlan
+#
+# If you are using only vlans only it should be:
+#
+advertised_tunnel_types = vlan
+#
+# Static ARP population for members on tunnel networks
+#
+# This is a boolean True or False value which specifies 
+# that if a Pool Member IP address is associated with a gre 
+# or vxlan tunnel network, in addition to a tunnel fdb 
+# record being added, that a static arp entry will be created to 
+# avoid the need to learn the member's MAC address via flooding.
+#
+# f5_populate_static_arp = True
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a boolean entry which determines if they BIG-IP® will use
+# L2 Population service to update its fdb tunnel entries. This needs
+# to be setup in accordance with the way the other tunnel agents are
+# setup.  If the BIG-IP® agent and other tunnel agents don't match
+# the tunnel setup will not work properly.
+#
+l2_population = True
+#
+###############################################################################
+#  L3 Segmentation Mode Settings
+###############################################################################
+#
+# Global Routed Mode - No L2 or L3 Segmentation on BIG-IP®
+#
+# This setting will cause the agent to assume that all VIPs
+# and pool members will be reachable via global device
+# L3 routes, which must be already provisioned on the BIG-IP®s.
+#
+# In f5_global_routed_mode, BIG-IP® will not assume L2
+# adjacentcy to any neutron network, therefore no
+# L2 segementation between tenant services in the data plane
+# will be provisioned by the agent. Because the routing
+# is global, no L3 self IPs or SNATs will be provisioned
+# by the agent on behalf of tenants either. You must have
+# all necessary L3 routes (including TMM default routes)
+# provisioned before LBaaS resources are provisioned for tenants.
+#
+# WARNING: setting this mode to True will override
+# the use_namespaces, setting it to False, because only
+# one global routing space will used on the BIG-IP®.  This
+# means overlapping IP addresses between tenants is no
+# longer supported.
+#
+# WARNING: setting this mode to True will override
+# the f5_snat_mode, setting it to True, because pool members
+# will never be considered L2 adjacent to the BIG-IP® by
+# the agent. All member access will be via L3 routing, which
+# will need to be set up on the BIG-IP® before LBaaS provisions
+# resources on behalf of tenants.
+#
+# WARNING: setting this mode to True will override the
+# f5_snat_addresses_per_subnet, setting it to 0 (zero).
+# This will force all VIPs to use AutoMap SNAT for which
+# enough Self IP will need to be pre-provisioned on the
+# BIG-IP® to handle all pool member connections. The SNAT,
+# an L3 mechanism, will all be global without reference
+# to any specific tenant SNAT pool.
+#
+# WARNING: setting this mode will make the VIPs listen
+# on all provisioned L2 segments (All VLANs). This is
+# because no L2 information will be taken from
+# neutron, thus making the assumption that all VIP
+# L3 addresses will be globally routable without
+# segmentation at L2 on the BIG-IP®.
+#
+f5_global_routed_mode = False 
+#
+# Allow overlapping IP subnets across multiple tenants.
+# This creates route domains on BIG-IP® in order to
+# separate the tenant networks.
+#
+# This setting is forced to False if 
+# f5_global_routed_mode = True.
+#
+use_namespaces = True
+#
+# When use_namespaces is True there is normally only one route table
+# allocated per tenant. However, this limit can be increased by
+# changing the max_namespaces_per_tenant variable. This allows one
+# tenant to have overlapping IP subnets.
+#
+# Supporting multiple IP namespaces allows establishing multiple independent
+# IP routing topologies within one tenant project, which, for example,
+# can accomodate multiple testing environments in one project, with
+# each testing environment configured to use the same IP address
+# topology as each other test environment.
+#
+# From a practical point of view, allowing multiple IP namespaces
+# per tenant results in a more complicated configuration scheme
+# for big-ip and also allows a single tenant to consumes more
+# routing tables, which are a limited resource. In order to keep
+# a simple one-to-one strategy of one tenant to one route domain,
+# it is recommended that separate projects be used if possible to
+# establish a new routing namespace rather than allowing multiple route
+# domains within one tenant.
+#
+# If a tenant attempts to use a subnet that overlaps with an existing
+# subnet that is already in use in the existing route domain(s), and
+# this setting is not high enough to accomodate a new route domain to
+# handle the new subnet, then the relevant lbaas element (vip or pool member)
+# will be set to the error state.
+#
+max_namespaces_per_tenant = 1
+#
+# Dictates the strict isolation of the routing 
+# tables.  If you set this to True, then all 
+# VIPs and Members must be in the same tenant
+# or else they can't communicate.
+#
+# This setting is only valid if use_namespaces = True.
+#
+f5_route_domain_strictness = False
+#
+# SNAT Mode and SNAT Address Counts
+#
+# This setting will force the use of SNATs. 
+#
+# If this is set to False, a SNAT will not
+# be created (routed mode) and the BIG-IP®
+# will attempt to set up a floating self IP
+# as the subnet's default gateway address.
+# and a wild card IP forwarding virtual
+# server will be set up on member's network.
+# Setting this to False will mean Neutron
+# floating self IPs will not longer work
+# if the same BIG-IP® device is not being used
+# as the Neutron Router implementation.
+#
+# This setting will be forced to True if 
+# f5_global_routed_mode = True.
+#
+f5_snat_mode = True
+#
+# This setting will specify the number of snat 
+# addresses to put in a snat pool for each 
+# subnet associated with a created local Self IP. 
+# 
+# Setting to 0 (zero) will set VIPs to AutoMap 
+# SNAT and the device's local Self IP will 
+# be used to SNAT traffic.
+#
+# In scalen HA mode, this is the number of snat
+# addresses per active traffic-group at the time
+# a service is provisioned.
+#
+# This setting will be forced to 0 (zero) if 
+# f5_global_routed_mode = True.
+#
+f5_snat_addresses_per_subnet = 1
+#
+# This setting will cause all networks with 
+# the router:external attribute set to True
+# to be created in the Common partition and
+# placed in route domain 0.
+f5_common_external_networks = True
+#
+#
+# Common Networks
+#
+# This setting contains a name value pair comma
+# separated list where if the name is a neutron
+# network id used for a vip or a pool member, 
+# the network should not be created or deleted
+# on the BIG-IP®, but rather assumed that the value
+# is the name of the network already created in
+# the Common partition with all L3 addresses 
+# assigned to route domain 0.  This is useful
+# for shared networks which are already defined
+# on the BIG-IP® prior to LBaaS configuration. The
+# network should not be managed by the LBaaS agent,
+# but can be used for VIPs or pool members
+#
+# If your Internet VLAN on your BIG-IP® is named
+# /Common/external, and that corresponds to 
+# Neutron uuid: 71718972-78e2-449e-bb56-ce47cc9d2680
+# then the entry would look like:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external
+#
+# If you had multiple common networks, they are simply
+# comma separated like this example:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external,396e06a0-05c7-4a49-8e86-04bb83d14438:vlan1222
+#
+# The default is no common networks defined
+#
+# L3 Bindings 
+#
+# Some systems require the need to bind L3 addresses
+# to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# untagged VLANs and is a nova guest instance. By 
+# default, neutron will attempt to apply security rule
+# for anti-spoofing which will not allow just any L3
+# address to be used on the neutron port. The answer is to
+# use allowed-address-pairs for the neutron port. 
+#
+# What is required is a software hook which allows the binding.
+# l3_binding_driver needs to reference a subclass of the L3BindingBase
+# class and provides the methods to bind and unbind L3 address
+# to ports.
+#
+# l3_binding_driver = f5_openstack_agent.lbaasv2.drivers.bigip.l3_binding.AllowedAddressPairs
+#
+# The l3_binding_static_mappings allows for a JSON encoded dictionary
+# mapping neutron subnet ids to lists of L2 ports and devices which 
+# require mapping. The entries for port and device mappings
+# vary between providers. They may look like a neutron port id
+# and a nova guest instance id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM MAC addresses will be collected
+# and neutron will be queried to see if the MAC addresses
+# correspond to known neutron ports. If they do, automatic entries
+# for all mapped fixed_ips will be made referencing the ports id
+# and the ports device_id.
+#
+# l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
+#
+#
+#
+###############################################################################
+#  Device Driver Setting
+###############################################################################
+#
+f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver
+#
+#
+###############################################################################
+#  Device Driver - iControl® Driver Setting
+###############################################################################
+#
+# icontrol_hostname is valid for external device type only.
+# this setting can be either a single IP address or a 
+# comma separated list contain all devices in a device 
+# service group.  For guest devices, the first fixed_address
+# on the first device interfaces will be used.
+#
+# If a single IP address is used and the HA model 
+# is not standalone, all devices in the sync failover
+# device group for the hostname specified must have 
+# their management IP address reachable to the agent.
+# If order to access devices' iControl® interfaces via
+# self IPs, you should specify them as a comma
+# separated list below.
+#
+icontrol_hostname = 10.190.0.0
+#
+# If you are using vCMP® with VLANs, you will need to configure
+# your vCMP® host addresses, in addition to the guests addresses.
+# vCMP® Host access is necessary for provisioning VLANs to a guest.
+# Use icontrol_hostname for vCMP® guests and icontrol_vcmp_hostname
+# for vCMP® hosts. The plug-in will automatically determine
+# which host corresponds to each guest.
+#
+# icontrol_vcmp_hostname = 192.168.1.245
+#
+# icontrol_username must be a valid Administrator username
+# on all devices in a device sync failover group.
+#
+icontrol_username = admin
+#
+# icontrol_password must be a valid Administrator password
+# on all devices in a device sync failover group.
+#
+icontrol_password = admin
+#
+###############################################################################
+# Certificate Manager
+###############################################################################
+#cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+#
+# Two authentication modes are supported for BarbicanCertManager:
+#   keystone_v2, and keystone_v3
+#
+#
+# Keystone v2 authentication:
+#
+# auth_version = v2
+# os_auth_url = http://localhost:5000/v2.0
+# os_username = admin
+# os_password = changeme
+# os_tenant_name = admin
+#
+#
+# Keystone v3 authentication:
+#
+#auth_version = v3
+#os_auth_url = http://localhost:5000/v3
+#os_username = admin
+#os_password = changeme
+#os_user_domain_name = default
+#os_project_name = admin
+#os_project_domain_name = default
+#
+#
+# Parent SSL profile name
+#
+# A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+# protocol. You can define the parent profile for this profile by setting
+# f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+# inherit settings from the parent you define. This must be an existing profile,
+# and if it does not exist on your BIG-IP® system the agent will use the default
+# profile, clientssl.
+#f5_parent_ssl_profile = clients
+#

--- a/docs/_static/f5-openstack-agent.vxlan.ini
+++ b/docs/_static/f5-openstack-agent.vxlan.ini
@@ -1,0 +1,518 @@
+###############################################################################
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+#                   ############
+#                 ################
+#               ###/ _ \###|     |#
+#              ###| |#| |##| |######
+#             ####| |######| |######
+#             ##|     |####\    \###    AGILITY YOUR WAY!
+#             ####| |#########| |###
+#             ####| |#########| |##
+#              ###| |########/ /##
+#               #|    |####|  /## 
+#                ##############
+#                 ###########
+#
+#                  NETWORKS
+#
+###############################################################################
+#
+[DEFAULT]
+# Show debugging output in log (sets DEBUG log level output).
+debug = True
+# The LBaaS agent will resync its state with Neutron to recover from any
+# transient notification or rpc errors. The interval is number of
+# seconds between attempts.
+#
+periodic_interval = 10
+#
+# How often should the agent throw away its service cache and 
+# resync assigned services with the neutron LBaaS plugin.
+#
+# service_resync_interval = 500
+#
+# Objects created on the BIG-IP® by this agent will have their names prefixed
+# by an environment string. This allows you set this string.  The default is
+# 'project'.
+#
+# WARNING - you should only set this before creating any objects.  If you change
+# it with established objects, the objects created with an alternative prefix,
+# will no longer be associated with this agent and all objects in neutron
+# and on the the BIG-IP® associated with the old environment will need to be managed
+# manually.
+#
+###############################################################################
+#  Environment Settings
+###############################################################################
+#
+# Since many TMOS® object names must start with an alpha character
+# the environment_prefix is used to prefix all service objects.
+#
+# environment_prefix = 'Project'
+#
+###############################################################################
+#  Static Agent Configuration Setting
+###############################################################################
+#
+# Static configuration data to sent back to the plugin. This can be used
+# on the plugin side of neutron to provide agent identification for custom
+# pool to agent scheduling. This should be a single or comma separated list
+# of name:value entries which will be sent in the agent's configuration
+# dictionary to neutron.
+#
+# static_agent_configuration_data = location:DFW1_R122_U9, service_contract:8675309, contact:jenny
+#
+###############################################################################
+#  Device Setting
+###############################################################################
+#
+# HA model
+#
+# Device can be required to be:
+#
+# standalone - single device no HA
+# pair - active/standby two device HA(Not supported)
+# scalen - active device cluster(Not supported)
+#
+# If the device is external, the devices must be onboarded for the
+# appropriate HA mode or else the driver will not provision devices
+#
+f5_ha_type = standalone
+#
+#
+# Sync mode
+#
+# autosync - syncable policies configured on one device then
+#            synced to the group
+# replication - each device configured separately
+#
+f5_sync_mode = replication
+#
+###############################################################################
+#  L2 Segmentation Mode Settings
+###############################################################################
+#
+# Device VLAN to interface and tag mapping 
+#
+# For pools or VIPs created on networks with type VLAN we will map
+# the VLAN to a particular interface and state if the VLAN tagging
+# should be enforced by the external device or not.  This setting 
+# is a comma separated list of the following format:
+#
+#    physical_network:interface_name:tagged, physical:interface_name:tagged
+#
+# where :
+#   physical_network corresponds to provider:physical_network attributes
+#   interface_name is the name of an interface or LAG trunk 
+#   tagged is a boolean (True or False)    
+#
+# If a network does not have a provider:physical_network attribute,
+# or the provider:physical_network attribute does not match in the
+# configured list, the 'default' physical_network setting will be 
+# applied. At a minimum you must have a 'default' physical_network  
+# setting.
+#
+# standalone example:
+#   f5_external_physical_mappings = default:1.1:True
+#
+# pair or scalen (1.1 and 1.2 are used for HA purposes):
+#   f5_external_physical_mappings = default:1.3:True
+#
+f5_external_physical_mappings = default:1.1:True
+#
+# VLAN device and interface to port mappings
+#
+# Some systems require the need to bind and prune VLANs ids
+# allowed to specific ports, often for security. 
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# tagged VLANs. When a VLAN tagged network is added to a 
+# specific BIG-IP® device, the facing switch port will need
+# to allow traffic for that VLAN tag through to the BIG-IP®'s
+# port for traffic to flow. 
+#
+# What is required is a software hook which allows the binding.
+# A vlan_binding_driver class needs to reference a subclass of the 
+# VLANBindingBase class and provides the methods to bind and prune
+# VLAN tags to ports.
+#
+# vlan_binding_driver = f5.oslbaasv1agent.drivers.bigip.vlan_binding.NullBinding
+#
+# The interface_port_static_mappings allows for a JSON encoded dictionary
+# mapping BigIP devices and interfaces to corresponding ports. A port id can be
+# any string which is meaningful to a vlan_binding_driver. It can be a 
+# switch_id and port, or it might be a neutron port_id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM interfaces will be collect
+# for each device and neutron will be queried to see if which 
+# device port_ids correspond to known neutron ports. If they do, 
+# automatic entries for all mapped port_ids will be made referencing 
+# the BIG-IP® device name and interface and the neutron port_ids.
+#
+# interface_port_static_mappings = {"device_name_1":{"interface_ida":"port_ida","interface_idb":"port_idb"}, {"device_name_2":{"interface_ida":"port_ida","interface_idb":"port_idb"}} 
+#                  
+# example:
+#
+# interface_port_static_mappings = {"bigip1":{"1.1":"switch1:g2/32","1.2":"switch1:g2/33"},"bigip2":{"1.1":"switch1:g3/32","1.2":"switch1:g3/33"}}
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a single entry or comma separated list of cidr (h/m) format
+# selfip addresses, one per BIG-IP® device, to use for VTEP addresses.
+#
+# If no gre or vxlan tunneling is required, these settings should be
+# commented out or set to None.
+#
+f5_vtep_folder = None
+f5_vtep_selfip_name = None
+#
+#
+#
+# Tunnel types
+#
+# This is a comma separated list of tunnel types to report 
+# as available from this agent as well as to send via tunnel_sync
+# rpc messages to compute nodes. This should match your ml2
+# network types on your compute nodes. 
+#
+# If you are using only gre tunnels it should be:
+#
+# advertised_tunnel_types = gre
+#
+# If you are using only vxlan tunnels it should be:
+#
+advertised_tunnel_types = vxlan
+#
+# If this agent could get both gre and vxlan tunnel networks:
+#
+# advertised_tunnel_types = gre,vxlan
+#
+# If you are using only vlans only it should be:
+#
+# advertised_tunnel_types =
+#
+# Static ARP population for members on tunnel networks
+#
+# This is a boolean True or False value which specifies 
+# that if a Pool Member IP address is associated with a gre 
+# or vxlan tunnel network, in addition to a tunnel fdb 
+# record being added, that a static arp entry will be created to 
+# avoid the need to learn the member's MAC address via flooding.
+#
+# f5_populate_static_arp = True
+#
+# Device Tunneling (VTEP) selfips
+#
+# This is a boolean entry which determines if they BIG-IP® will use
+# L2 Population service to update its fdb tunnel entries. This needs
+# to be setup in accordance with the way the other tunnel agents are
+# setup.  If the BIG-IP® agent and other tunnel agents don't match
+# the tunnel setup will not work properly.
+#
+l2_population = True
+#
+###############################################################################
+#  L3 Segmentation Mode Settings
+###############################################################################
+#
+# Global Routed Mode - No L2 or L3 Segmentation on BIG-IP®
+#
+# This setting will cause the agent to assume that all VIPs
+# and pool members will be reachable via global device
+# L3 routes, which must be already provisioned on the BIG-IP®s.
+#
+# In f5_global_routed_mode, BIG-IP® will not assume L2
+# adjacentcy to any neutron network, therefore no
+# L2 segementation between tenant services in the data plane
+# will be provisioned by the agent. Because the routing
+# is global, no L3 self IPs or SNATs will be provisioned
+# by the agent on behalf of tenants either. You must have
+# all necessary L3 routes (including TMM default routes)
+# provisioned before LBaaS resources are provisioned for tenants.
+#
+# WARNING: setting this mode to True will override
+# the use_namespaces, setting it to False, because only
+# one global routing space will used on the BIG-IP®.  This
+# means overlapping IP addresses between tenants is no
+# longer supported.
+#
+# WARNING: setting this mode to True will override
+# the f5_snat_mode, setting it to True, because pool members
+# will never be considered L2 adjacent to the BIG-IP® by
+# the agent. All member access will be via L3 routing, which
+# will need to be set up on the BIG-IP® before LBaaS provisions
+# resources on behalf of tenants.
+#
+# WARNING: setting this mode to True will override the
+# f5_snat_addresses_per_subnet, setting it to 0 (zero).
+# This will force all VIPs to use AutoMap SNAT for which
+# enough Self IP will need to be pre-provisioned on the
+# BIG-IP® to handle all pool member connections. The SNAT,
+# an L3 mechanism, will all be global without reference
+# to any specific tenant SNAT pool.
+#
+# WARNING: setting this mode will make the VIPs listen
+# on all provisioned L2 segments (All VLANs). This is
+# because no L2 information will be taken from
+# neutron, thus making the assumption that all VIP
+# L3 addresses will be globally routable without
+# segmentation at L2 on the BIG-IP®.
+#
+f5_global_routed_mode = False
+#
+# Allow overlapping IP subnets across multiple tenants.
+# This creates route domains on BIG-IP® in order to
+# separate the tenant networks.
+#
+# This setting is forced to False if
+# f5_global_routed_mode = True.
+#
+use_namespaces = True
+#
+# When use_namespaces is True there is normally only one route table
+# allocated per tenant. However, this limit can be increased by
+# changing the max_namespaces_per_tenant variable. This allows one
+# tenant to have overlapping IP subnets.
+#
+# Supporting multiple IP namespaces allows establishing multiple independent
+# IP routing topologies within one tenant project, which, for example,
+# can accomodate multiple testing environments in one project, with
+# each testing environment configured to use the same IP address
+# topology as each other test environment.
+#
+# From a practical point of view, allowing multiple IP namespaces
+# per tenant results in a more complicated configuration scheme
+# for big-ip and also allows a single tenant to consumes more
+# routing tables, which are a limited resource. In order to keep
+# a simple one-to-one strategy of one tenant to one route domain,
+# it is recommended that separate projects be used if possible to
+# establish a new routing namespace rather than allowing multiple route
+# domains within one tenant.
+#
+# If a tenant attempts to use a subnet that overlaps with an existing
+# subnet that is already in use in the existing route domain(s), and
+# this setting is not high enough to accomodate a new route domain to
+# handle the new subnet, then the relevant lbaas element (vip or pool member)
+# will be set to the error state.
+#
+max_namespaces_per_tenant = 1
+#
+# Dictates the strict isolation of the routing 
+# tables.  If you set this to True, then all 
+# VIPs and Members must be in the same tenant
+# or else they can't communicate.
+#
+# This setting is only valid if use_namespaces = True.
+#
+f5_route_domain_strictness = False
+#
+# SNAT Mode and SNAT Address Counts
+#
+# This setting will force the use of SNATs. 
+#
+# If this is set to False, a SNAT will not
+# be created (routed mode) and the BIG-IP®
+# will attempt to set up a floating self IP
+# as the subnet's default gateway address.
+# and a wild card IP forwarding virtual
+# server will be set up on member's network.
+# Setting this to False will mean Neutron
+# floating self IPs will not longer work
+# if the same BIG-IP® device is not being used
+# as the Neutron Router implementation.
+#
+# This setting will be forced to True if 
+# f5_global_routed_mode = True.
+#
+f5_snat_mode = True
+#
+# This setting will specify the number of snat 
+# addresses to put in a snat pool for each 
+# subnet associated with a created local Self IP. 
+# 
+# Setting to 0 (zero) will set VIPs to AutoMap 
+# SNAT and the device's local Self IP will 
+# be used to SNAT traffic.
+#
+# In scalen HA mode, this is the number of snat
+# addresses per active traffic-group at the time
+# a service is provisioned.
+#
+# This setting will be forced to 0 (zero) if 
+# f5_global_routed_mode = True.
+#
+f5_snat_addresses_per_subnet = 1
+#
+# This setting will cause all networks with 
+# the router:external attribute set to True
+# to be created in the Common partition and
+# placed in route domain 0.
+f5_common_external_networks = True
+#
+#
+# Common Networks
+#
+# This setting contains a name value pair comma
+# separated list where if the name is a neutron
+# network id used for a vip or a pool member, 
+# the network should not be created or deleted
+# on the BIG-IP®, but rather assumed that the value
+# is the name of the network already created in
+# the Common partition with all L3 addresses 
+# assigned to route domain 0.  This is useful
+# for shared networks which are already defined
+# on the BIG-IP® prior to LBaaS configuration. The
+# network should not be managed by the LBaaS agent,
+# but can be used for VIPs or pool members
+#
+# If your Internet VLAN on your BIG-IP® is named
+# /Common/external, and that corresponds to 
+# Neutron uuid: 71718972-78e2-449e-bb56-ce47cc9d2680
+# then the entry would look like:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external
+#
+# If you had multiple common networks, they are simply
+# comma separated like this example:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external,396e06a0-05c7-4a49-8e86-04bb83d14438:vlan1222
+#
+# The default is no common networks defined
+#
+# L3 Bindings
+#
+# Some systems require the need to bind L3 addresses
+# to specific ports, often for security.
+#
+# An example would be if a LBaaS iControl® endpoint is using
+# untagged VLANs and is a nova guest instance. By
+# default, neutron will attempt to apply security rule
+# for anti-spoofing which will not allow just any L3
+# address to be used on the neutron port. The answer is to
+# use allowed-address-pairs for the neutron port.
+#
+# What is required is a software hook which allows the binding.
+# l3_binding_driver needs to reference a subclass of the L3BindingBase
+# class and provides the methods to bind and unbind L3 address
+# to ports.
+#
+# l3_binding_driver = f5_openstack_agent.lbaasv2.drivers.bigip.l3_binding.AllowedAddressPairs
+#
+# The l3_binding_static_mappings allows for a JSON encoded dictionary
+# mapping neutron subnet ids to lists of L2 ports and devices which
+# require mapping. The entries for port and device mappings
+# vary between providers. They may look like a neutron port id
+# and a nova guest instance id.
+#
+# In addition to any static mappings, when the iControl® endpoints
+# are initialized, all their TMM MAC addresses will be collected
+# and neutron will be queried to see if the MAC addresses
+# correspond to known neutron ports. If they do, automatic entries
+# for all mapped fixed_ips will be made referencing the ports id
+# and the ports device_id.
+#
+# l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
+#
+#
+#
+###############################################################################
+#  Device Driver Setting
+###############################################################################
+#
+f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver
+#
+#
+###############################################################################
+#  Device Driver - iControl® Driver Setting
+###############################################################################
+#
+# icontrol_hostname is valid for external device type only.
+# this setting can be either a single IP address or a 
+# comma separated list contain all devices in a device 
+# service group.  For guest devices, the first fixed_address
+# on the first device interfaces will be used.
+#
+# If a single IP address is used and the HA model 
+# is not standalone, all devices in the sync failover
+# device group for the hostname specified must have 
+# their management IP address reachable to the agent.
+# If order to access devices' iControl® interfaces via
+# self IPs, you should specify them as a comma
+# separated list below.
+#
+icontrol_hostname = 10.190.0.0
+#
+# If you are using vCMP® with VLANs, you will need to configure
+# your vCMP® host addresses, in addition to the guests addresses.
+# vCMP® Host access is necessary for provisioning VLANs to a guest.
+# Use icontrol_hostname for vCMP® guests and icontrol_vcmp_hostname
+# for vCMP® hosts. The plug-in will automatically determine
+# which host corresponds to each guest.
+#
+# icontrol_vcmp_hostname = 192.168.1.245
+#
+# icontrol_username must be a valid Administrator username
+# on all devices in a device sync failover group.
+#
+icontrol_username = admin
+#
+# icontrol_password must be a valid Administrator password
+# on all devices in a device sync failover group.
+#
+icontrol_password = admin
+#
+###############################################################################
+# Certificate Manager
+###############################################################################
+#cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+#
+# Two authentication modes are supported for BarbicanCertManager:
+#   keystone_v2, and keystone_v3
+#
+#
+# Keystone v2 authentication:
+#
+# auth_version = v2
+# os_auth_url = http://localhost:5000/v2.0
+# os_username = admin
+# os_password = changeme
+# os_tenant_name = admin
+#
+#
+# Keystone v3 authentication:
+#
+#auth_version = v3
+#os_auth_url = http://localhost:5000/v3
+#os_username = admin
+#os_password = changeme
+#os_user_domain_name = default
+#os_project_name = admin
+#os_project_domain_name = default
+#
+#
+# Parent SSL profile name
+#
+# A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+# protocol. You can define the parent profile for this profile by setting
+# f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+# inherit settings from the parent you define. This must be an existing profile,
+# and if it does not exist on your BIG-IP® system the agent will use the default
+# profile, clientssl.
+#f5_parent_ssl_profile = clients
+#

--- a/docs/_static/f5-openstack-agent.vxlan.ini
+++ b/docs/_static/f5-openstack-agent.vxlan.ini
@@ -514,5 +514,5 @@ icontrol_password = admin
 # inherit settings from the parent you define. This must be an existing profile,
 # and if it does not exist on your BIG-IP® system the agent will use the default
 # profile, clientssl.
-#f5_parent_ssl_profile = clients
+#f5_parent_ssl_profile = clientssl
 #

--- a/docs/coding-example-lbaasv2.rst
+++ b/docs/coding-example-lbaasv2.rst
@@ -53,7 +53,7 @@ Use the command below to create a health monitor for the pool specifying the del
 Create a tls load balancer
 ``````````````````````````
 
-The example command below shows how to create a listener that uses the ``TERMINATED_HTTPS`` protocol.
+The example command below shows how to create a listener that uses the ``TERMINATED_HTTPS`` protocol. You'll need to specify the protocol (``TERMINATED_HTTPS``); port; and the location of the `Barbican container <http://docs.openstack.org/developer/barbican/api/quickstart/containers.html>`_ where the certificate is stored.
 
 .. code-block:: shell
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ VERSION = f5lbaasdriver.__version__
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -61,7 +61,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'F5 OpenStack LBaaSv2 Driver'
+project = u'F5 OpenStack LBaaSv2 Plugin'
 copyright = u'2016, F5 Networks Inc.'
 author = u'F5 Networks'
 
@@ -141,7 +141,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'F5 OpenStack LBaaSv2 Driver'
+html_title = 'F5 OpenStack LBaaSv2 Plugin'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -243,7 +243,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'F5OpenStackLBaaSv2Driver.tex', u'F5 OpenStack LBaaSv2 Driver'
+    (master_doc, 'F5OpenStackLBaaSv2.tex', u'F5 OpenStack LBaaSv2 Plugin'
                                             u'Documentation',
      u'F5 Networks', 'manual'),
 ]
@@ -289,9 +289,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'F5OpenStackLBaaSv2Driver', u'F5 OpenStack LBaaSv2 '
-                                       u'Driver Documentation',
-     author, 'F5OpenStackLBaaSv2Driver', 'One line description of project.',
+    (master_doc, 'F5OpenStackLBaaSv2', u'F5 OpenStack LBaaSv2'
+                                       u'Plugin Documentation',
+     author, 'F5OpenStackLBaaSv2Plugin', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'F5 OpenStack LBaaSv2 Plugin'
+project = u'F5 OpenStack LBaaSv2'
 copyright = u'2016, F5 Networks Inc.'
 author = u'F5 Networks'
 
@@ -141,7 +141,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'F5 OpenStack LBaaSv2 Plugin'
+html_title = 'F5 OpenStack LBaaSv2'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -221,7 +221,7 @@ html_show_copyright = True
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'F5OpenStackLBaaSv2Driverdoc'
+htmlhelp_basename = 'F5OpenStackLBaaSv2doc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -243,7 +243,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'F5OpenStackLBaaSv2.tex', u'F5 OpenStack LBaaSv2 Plugin'
+    (master_doc, 'F5OpenStackLBaaSv2.tex', u'F5 OpenStack LBaaSv2'
                                             u'Documentation',
      u'F5 Networks', 'manual'),
 ]
@@ -274,7 +274,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'f5openstacklbaasv2driver', u'F5 OpenStack LBaaSv2 Driver'
+    (master_doc, 'f5openstacklbaasv2', u'F5 OpenStack LBaaSv2'
                                           u'Documentation',
      [author], 1)
 ]
@@ -290,8 +290,8 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'F5OpenStackLBaaSv2', u'F5 OpenStack LBaaSv2'
-                                       u'Plugin Documentation',
-     author, 'F5OpenStackLBaaSv2Plugin', 'One line description of project.',
+                                       u'Documentation',
+     author, 'F5OpenStackLBaaSv2', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/includes/ref_agent-config-file.rst
+++ b/docs/includes/ref_agent-config-file.rst
@@ -1,0 +1,27 @@
+Agent Configuration File
+========================
+
+The agent configuration file -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- controls how the agent interacts with your BIG-IP®(s). The file contains detailed descriptions of each available configuration option.
+
+For reference, we've provided here a set of 'pre-configured' agent config files. These examples can help guide you in setting up the agent to work with your specific environment.
+
+:ref:`Global Routed Mode`
+-------------------------
+
+Can be used for standalone, :ref:`overcloud <Before You Begin>` BIG-IP® VE deployments.
+
+* :download:`f5-openstack-agent.grm.ini <../_static/f5-openstack-agent.grm.ini>`
+
+
+:ref:`L2/L3 Segmentation Modes`
+-------------------------------
+
+Can be used for standalone or clustered :ref:`undercloud <Before You Begin>` BIG-IP® hardware or VE deployments.
+
+* :download:`f5-openstack-agent.gre.ini <../_static/f5-openstack-agent.gre.ini>`
+
+* :download:`f5-openstack-agent.vlan.ini <../_static/f5-openstack-agent.vlan.ini>`
+
+* :download:`f5-openstack-agent.vxlan.ini <../_static/f5-openstack-agent.gre.ini>`
+
+

--- a/docs/includes/topic_cert-manager.rst
+++ b/docs/includes/topic_cert-manager.rst
@@ -16,6 +16,7 @@ The certificate manager settings are for use with the ``TERMINATED_HTTPS`` featu
     - ``os_user_domain_name``: OpenStack domain in which the user account resides (v3 only)
     - ``os_project_name``: OpenStack project name (v3 only; refers to the same data as ``os_tenant_name`` in v2)
     - ``os_project_domain_name``: OpenStack domain in which the project resides
+    - ``f5_parent_ssl_profile``: The parent SSL profile on the BIG-IP® from which the agent SSL profile should inherit settings
 
     .. code-block:: text
 
@@ -44,4 +45,15 @@ The certificate manager settings are for use with the ``TERMINATED_HTTPS`` featu
         os_user_domain_name = default
         os_project_name = admin
         os_project_domain_name = default
+        #
+        # Parent SSL profile name
+        #
+        # A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+        # protocol. You can define the parent profile for this profile by setting
+        # f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+        # inherit settings from the parent you define. This must be an existing profile,
+        # and if it does not exist on your BIG-IP® system the agent will use the default
+        # profile, clientssl.
+        #f5_parent_ssl_profile = clientssl
+        #
 

--- a/docs/includes/topic_config-agent-overview.rst
+++ b/docs/includes/topic_config-agent-overview.rst
@@ -3,7 +3,7 @@
 Overview
 ````````
 
-To use the F5® OpenStack agent, edit the agent configuration file -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- as appropriate for your environment.
+To use the F5® OpenStack agent, edit the :ref:`agent configuration file` as appropriate for your environment.
 
 .. topic:: Example:
 
@@ -12,6 +12,6 @@ To use the F5® OpenStack agent, edit the agent configuration file -- :file:`/et
         $ sudo vi /etc/neutron/services/f5/f5-openstack-agent.ini
 
 
-All of the agent's functions are described in detail in the :ref:`agent configuration file <agent:agent-configuration-file>`. Please see :ref:`Supported features` for a list of the features supported in |version| with configuration examples for each feature.
+All of the agent's functions are described in detail in the configuration file. Please see :ref:`Supported features` for a list of the features supported in |version|, with configuration examples for each feature.
 
 

--- a/docs/includes/topic_ha-modes.rst
+++ b/docs/includes/topic_ha-modes.rst
@@ -6,8 +6,8 @@ HA mode
 - ``f5_ha_type``: Defines the high availability (HA) mode used by the BIG-IP®.
 
     * ``standalone``: Single BIG-IP® device; no HA.
-    * ``pair``: Active/standby two device HA. [#fn1]_
-    * ``scalen``: Active device cluster. [#fn1]_
+    * ``pair``: Active/standby two device HA.
+    * ``scalen``: Active device cluster.
 
     .. code-block:: text
 
@@ -15,7 +15,7 @@ HA mode
         #
         # ...
         #
-        f5_ha_type = standalone
+        f5_ha_type = standalone \\ pair \\ scalen
         #
         #
 

--- a/docs/includes/topic_lbaasv2-plugin-overview.rst
+++ b/docs/includes/topic_lbaasv2-plugin-overview.rst
@@ -8,7 +8,7 @@ How the plugin works
 
 The F5 LBaaSv2 plugin consists of an :ref:`agent <agent:home>` and a service provider driver (also just called 'driver', for short). The driver listens to the Neutron RPC messaging queue. When you make a call to the LBaaSv2 API -- for example, ``neutron lbaas-loadbalancer-create`` -- the F5® LBaaSv2 service provider driver picks it up and directs it to the agent.
 
-The F5® agent manages services on your BIG-IP®. When it first receives a task from the F5® driver, it starts and communicates with the BIG-IP®(s) identified in the :ref:`agent configuration file <agent:agent-configuration-file>`. Then, it registers its own named queue. The F5® driver assigns all ``lbaas`` tasks in the Neutron messaging queue to the agent's queue. The F5® agent makes callbacks to the F5® driver to query additional Neutron network, port, and subnet information; to allocate Neutron objects (for example, fixed IP addresses); and to report provisioning and pool status.
+The F5® agent manages services on your BIG-IP®. When it first receives a task from the F5® driver, it starts and communicates with the BIG-IP®(s) identified in the :ref:`agent configuration file`. Then, it registers its own named queue. The F5® driver assigns all ``lbaas`` tasks in the Neutron messaging queue to the agent's queue. The F5® agent makes callbacks to the F5® driver to query additional Neutron network, port, and subnet information; to allocate Neutron objects (for example, fixed IP addresses); and to report provisioning and pool status.
 
 .. image:: http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/_images/f5-lbaas-architecture.png
     :alt: F5 LBaaSv2 Plugin architecture

--- a/docs/includes/topic_restrictions.rst
+++ b/docs/includes/topic_restrictions.rst
@@ -5,10 +5,10 @@ Unsupported Features
 
 The following features are unsupported in |release|; they will be introduced in future releases.
 
-* vCMP® (multi-tenancy)
-* Agent High Availability
-* BIG-IP® Device Service Clustering
-* Multiple environments (Prod, Dev, Test)
+* `BIG-IP® vCMP® <https://f5.com/resources/white-papers/virtual-clustered-multiprocessing-vcmp>`_
+* Agent High Availability (HA)
+* :ref:`Auto-sync mode <Sync mode>` for clustered devices
+* Differentiated environments [#]_
 
 
 .. note::
@@ -24,3 +24,5 @@ The following features are unsupported in |release|; they will be introduced in 
         |                || (e.g., ``neutron lbaas-loadbalancer-stats``)      |
         +----------------+----------------------------------------------------+
 
+
+.. [#] Running multiple F5® agents on the same host to manage separate BIG-IP® environments.

--- a/docs/includes/topic_supported-features-intro.rst
+++ b/docs/includes/topic_supported-features-intro.rst
@@ -3,5 +3,5 @@
 Introduction
 ````````````
 
-The LBaaSv2 features supported in release |release| are noted below. See the agent configuration file -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- for more information about each feature.
+The LBaaSv2 features supported in release |release| are noted below. See the :ref:`agent configuration file` -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- for more information about each feature.
 

--- a/docs/includes/topic_supported-features-intro.rst
+++ b/docs/includes/topic_supported-features-intro.rst
@@ -4,3 +4,4 @@ Introduction
 ````````````
 
 The LBaaSv2 features supported in release |release| are noted below. See the agent configuration file -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- for more information about each feature.
+

--- a/docs/includes/topic_sync-mode.rst
+++ b/docs/includes/topic_sync-mode.rst
@@ -5,8 +5,8 @@ Sync mode
 
 * ``f5_sync_mode``: Defines the model by which policies configured on one BIG-IP® are shared with other BIG-IP®s.
 
-   * ``autosync``: configurations are synced automatically across all BIG-IP®s in a device cluster. [#fn1]_
-   * ``replication``: each device is configured separately.
+   * ``autosync``: uses BIG-IP® sync mode to sync LBaaS changes across all devices in a cluster. [#]_
+   * ``replication``: the agent configures each device in a cluster directly, in real time.
 
     .. code-block:: text
 
@@ -18,3 +18,4 @@ Sync mode
         #
 
 
+.. [#] This feature is not supported in release |release|.

--- a/docs/includes/topic_usage.rst
+++ b/docs/includes/topic_usage.rst
@@ -3,7 +3,7 @@ See Also
 
 * :ref:`Coding Example <f5-openstack-lbaasv2-coding-example>`
 
-* :ref:`Troubleshooting <agent:troubleshooting>`
+* :ref:`Troubleshooting`
 
 
 .. include:: ref_see-also.rst

--- a/docs/map_lbaasv2-features.rst
+++ b/docs/map_lbaasv2-features.rst
@@ -19,4 +19,3 @@ Supported Features
 
 
 
-.. [#fn1] Not supported in this release.

--- a/docs/map_release-summary.rst
+++ b/docs/map_release-summary.rst
@@ -1,0 +1,14 @@
+New Supported Features
+----------------------
+
+Support for the following features is introduced in v |release|:
+
+* Listener :ref:`TERMINATED_HTTPS <Certificate Manager>` protocol (`SSL offloading <https://f5.com/glossary/ssl-offloading>`_)
+* BIG-IP® device clusters (:ref:`f5_ha_type <HA mode>`)
+
+
+Unsupported Features
+--------------------
+
+.. include:: includes/topic_restrictions.rst
+    :start-line: 5

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,19 +7,11 @@ This release provides an implementation of the OpenStack Neutron LBaaSv2 driver 
 
 Release Highlights
 ------------------
-This release provides a limited set of configuration objects for use by OpenStack Neutron LBaaSv2 service plugin. It has support for L3 binding and L2 orchestration for standalone BIG-IP® devices.
 
-Supported Features
-------------------
+This release introduces support for SSL offloading and for BIG-IP® clustering (active-standby and scalen configurations).
 
-.. include:: map_lbaasv2-features.rst
-    :start-line: 5
 
-Unsupported Features
---------------------
-
-.. include:: includes/topic_restrictions.rst
-    :start-line: 5
+.. include:: map_release-summary.rst
 
 
 .. toctree::


### PR DESCRIPTION
@jlongstaf @richbrowne 

#### What issues does this address?
Fixes #123 #114 #129

#### What's this change do?

- updates supported/unsupported features for v8.0.3 release (including TERMINATED_HTTPS)
- adds sample agent config files for reference (global routed mode, gre, vlan, vxlan)
- changes doc set name from LBaaSv2 Driver to LBaaSv2 Plugin

#### Where should the reviewer start?

Build the documentation (`sphinx-build docs/ docs/_build`) and view the html files in your browser. Review for accuracy and completeness.

#### Any background context?
These changes should be merged up to master before the Mitaka branch is created. I can update the docs with the Mitaka-specific information from there.
