### PR TITLE
Adding the support for clustering to test_CLUDS.py

### DIFF
--- a/test/functional/test_CLUDS.py
+++ b/test/functional/test_CLUDS.py
@@ -12,23 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from f5.bigip import ManagementRoot
 from pprint import pprint as pp
 import sys
 import time
+import pytest
+import yaml
+
+@pytest.fixture
+def BigIPSetup(symbols):
+    bigipdict = symbols.__dict__.get("clusterbigips", {})
+    bigiplist = []
+    for bigip, attr in bigipdict.iteritems():
+         bigiplist.append(ManagementRoot(attr['netloc'],
+                                         attr['username'],
+                                         attr['password']))
+    return bigiplist
 
 
-def test_loadbalancer_CLUDS(setup_with_nclientmanager, bigip):
-    # NOTE:  list-on-agent is still untested
-    # set initial state
+def test_loadbalancer_CLUDS(setup_with_nclientmanager, BigIPSetup):
     nclientmanager = setup_with_nclientmanager
     subnets = nclientmanager.list_subnets()['subnets']
     for sn in subnets:
         if 'client-v4' in sn['name']:
             lbconf = {'vip_subnet_id': sn['id'],
-                      'tenant_id':     sn['tenant_id'],
-                      'name':          'testlb_01'}
-    start_folders = bigip.sys.folders.get_collection()
+                    'tenant_id':     sn['tenant_id'],
+                    'name':          'testlb_01'}
+    start_folders = BigIPSetup[0].tm.sys.folders.get_collection()
     # check that the bigip partitions are correct pre-create
     assert len(start_folders) == 2
     for sf in start_folders:
@@ -36,6 +46,7 @@ def test_loadbalancer_CLUDS(setup_with_nclientmanager, bigip):
     # Initialize lb and wait for confirmation from neutron
     active_lb = nclientmanager.create_loadbalancer({'loadbalancer': lbconf})
     lbid = active_lb['loadbalancer']['id']
+    print lbid
     assert active_lb['loadbalancer']['description'] == ''
     assert active_lb['loadbalancer']['provisioning_status'] == 'ACTIVE'
     assert active_lb['loadbalancer']['provider'] == 'f5networks'
@@ -44,153 +55,165 @@ def test_loadbalancer_CLUDS(setup_with_nclientmanager, bigip):
         lbid, {'loadbalancer': {'description': 'as;iofnypq3489'}})
     shown_lb = nclientmanager.show_loadbalancer(lbid)
     assert shown_lb['loadbalancer']['description'] == 'as;iofnypq3489'
-    # verify the creation of the appropriate partition on the bigip
-    active_folders = bigip.sys.folders.get_collection()
-    assert len(active_folders) == 3
-    for sf in active_folders:
-        assert sf.name == '/' or\
-            sf.name == 'Common' or\
-            sf.name.startswith('Project_')
+        # verify the creation of the appropriate partition on the bigip
+    for bigip in BigIPSetup:
+        active_folders = bigip.tm.sys.folders.get_collection()
+        assert len(active_folders) == 3
+        for sf in active_folders:
+            assert sf.name == '/' or\
+                sf.name == 'Common' or\
+                sf.name.startswith('Project_')
     # delete
     nclientmanager.delete_loadbalancer(lbid)
     # verify removal from OS on delete
     assert not nclientmanager.list_loadbalancers()['loadbalancers']
-    final_folders = bigip.sys.folders.get_collection()
-    # verify removal of partition from bigip on delete
-    assert len(final_folders) == 2
-    for sf in final_folders:
-        assert sf.name == '/' or sf.name == 'Common'
+    for bigip in BigIPSetup:
+        final_folders = bigip.tm.sys.folders.get_collection()
+        # verify removal of partition from bigip on delete
+        assert len(final_folders) == 2
+        for sf in final_folders:
+            assert sf.name == '/' or sf.name == 'Common'
 
+def test_listener_CLUDS(setup_with_loadbalancer, BigIPSetup):
+     nclientmanager, loadbalancer = setup_with_loadbalancer
+     listener_config =\
+         {'listener': {'name': 'test_listener',
+                       'loadbalancer_id': loadbalancer['loadbalancer']['id'],
+                       'protocol': 'HTTP',
+                       'protocol_port': 80}}
+     for bigip in BigIPSetup:
+         init_virts = bigip.tm.ltm.virtuals.get_collection()
+         assert init_virts == []
 
-def test_listener_CLUDS(setup_with_loadbalancer, bigip):
-    nclientmanager, loadbalancer = setup_with_loadbalancer
-    listener_config =\
-        {'listener': {'name': 'test_listener',
-                      'loadbalancer_id': loadbalancer['loadbalancer']['id'],
-                      'protocol': 'HTTP',
-                      'protocol_port': 80}}
-    init_virts = bigip.ltm.virtuals.get_collection()
-    assert init_virts == []
-    # Test list_listeners
-    assert not nclientmanager.list_listeners()['listeners']
-    listener = nclientmanager.create_listener(listener_config)
-    listener_id = listener['listener']['id']
-    assert listener['listener']['description'] == ''
-    assert len(nclientmanager.list_listeners()['listeners']) == 1
-    active_virts = bigip.ltm.virtuals.get_collection()
-    assert active_virts[0].name == 'test_listener'
-    # Test show and update
-    nclientmanager.update_listener(
-        listener_id, {'listener': {'description': 'awfoip8934'}})
-    shown = nclientmanager.show_listener(listener_id)
-    assert shown['listener']['description'] == 'awfoip8934'
-    # Test delete
-    nclientmanager.delete_listener(listener['listener']['id'])
-    virts = bigip.ltm.virtuals.get_collection()
-    assert virts == []
+     # Test list_listeners
+     assert not nclientmanager.list_listeners()['listeners']
+     listener = nclientmanager.create_listener(listener_config)
+     listener_id = listener['listener']['id']
+     assert listener['listener']['description'] == ''
+     assert len(nclientmanager.list_listeners()['listeners']) == 1
 
+     for bigip in BigIPSetup:
+         active_virts = bigip.tm.ltm.virtuals.get_collection()
+         assert active_virts[0].name == 'test_listener'
+     # Test show and update
+     nclientmanager.update_listener(
+         listener_id, {'listener': {'description': 'awfoip8934'}})
+     shown = nclientmanager.show_listener(listener_id)
+     assert shown['listener']['description'] == 'awfoip8934'
 
-def test_pool_CLUDS(setup_with_listener, bigip):
-    nclientmanager, listener = setup_with_listener
-    pool_config = {'pool': {
-                   'name': 'test_pool_anur23rgg',
-                   'lb_algorithm': 'ROUND_ROBIN',
-                   'listener_id': listener['listener']['id'],
-                   'protocol': 'HTTP'}}
-    # The bigip starts life with 0 pools
-    # Test lbaas_list_pools
-    assert not nclientmanager.list_lbaas_pools()['pools']
-    assert not bigip.ltm.pools.get_collection()
-    pool = nclientmanager.create_lbaas_pool(pool_config)
-    pool_id = pool['pool']['id']
-    assert pool['pool']['description'] == ''
-    assert len(nclientmanager.list_lbaas_pools()['pools']) == 1
-    # The create_lbaas_pool call adds a pool to the bigip
-    assert bigip.ltm.pools.get_collection()[0].name == 'test_pool_anur23rgg'
-    # Test Update, Show
-    nclientmanager.update_lbaas_pool(
-        pool_id, {'pool': {'description': '5978iuw34ghle'}})
-    shown = nclientmanager.show_lbaas_pool(pool_id)
-    assert shown['pool']['description'] == '5978iuw34ghle'
-    # Test Delete
-    nclientmanager.delete_lbaas_pool(pool_id)
-    assert not bigip.ltm.pools.get_collection()
+     # Test delete
+     nclientmanager.delete_listener(listener['listener']['id'])
+     for bigip in BigIPSetup:
+         virts = bigip.tm.ltm.virtuals.get_collection()
+         assert virts == []
 
+def test_pool_CLUDS(setup_with_listener, BigIPSetup):
+     nclientmanager, listener = setup_with_listener
+     pool_config = {'pool': {
+                    'name': 'test_pool_anur23rgg',
+                    'lb_algorithm': 'ROUND_ROBIN',
+                    'listener_id': listener['listener']['id'],
+                    'protocol': 'HTTP'}}
+     # The bigip starts life with 0 pools
+     # Test lbaas_list_pools
+     assert not nclientmanager.list_lbaas_pools()['pools']
+     for bigip in BigIPSetup:
+        assert not bigip.tm.ltm.pools.get_collection()
 
-def test_member_CLUDS(setup_with_pool, bigip):
+     pool = nclientmanager.create_lbaas_pool(pool_config)
+     pool_id = pool['pool']['id']
+     assert pool['pool']['description'] == ''
+     assert len(nclientmanager.list_lbaas_pools()['pools']) == 1
+     # The create_lbaas_pool call adds a pool to the bigip
+     for bigip in BigIPSetup:
+        assert bigip.tm.ltm.pools.get_collection()[0].name == 'test_pool_anur23rgg'
+     # Test Update, Show
+     nclientmanager.update_lbaas_pool(
+         pool_id, {'pool': {'description': '5978iuw34ghle'}})
+     shown = nclientmanager.show_lbaas_pool(pool_id)
+     assert shown['pool']['description'] == '5978iuw34ghle'
+     # Test Delete
+     nclientmanager.delete_lbaas_pool(pool_id)
+     for bigip in BigIPSetup:
+         assert not bigip.tm.ltm.pools.get_collection()
+
+def test_member_CLUDS(setup_with_pool, BigIPSetup):
     nclientmanager, pool = setup_with_pool
     poolname = pool['pool']['name']
     pool_id = pool['pool']['id']
-    bigip_pool_members = bigip.ltm.pools.get_collection()[0].members_s
-    # Test List
-    assert not nclientmanager.list_lbaas_members(pool_id)['members']
-    for sn in nclientmanager.list_subnets()['subnets']:
-        if 'server-v4' in sn['name']:
-            address = sn['allocation_pools'][0]['start']
-            subnet_id = sn['id']
-            break
+    for bigip in BigIPSetup:
+        bigip_pool_members = bigip.tm.ltm.pools.get_collection()[0].members_s
+        # Test List
+        assert not nclientmanager.list_lbaas_members(pool_id)['members']
+        for sn in nclientmanager.list_subnets()['subnets']:
+            if 'server-v4' in sn['name']:
+                address = sn['allocation_pools'][0]['start']
+                subnet_id = sn['id']
+                break
 
-    member_config = {'member': {
+        member_config = {'member': {
                      'subnet_id': subnet_id,
                      'address': address,
                      'protocol_port': 80}}
-    member = nclientmanager.create_lbaas_member(pool_id, member_config)
-    member_id = member['member']['id']
-    assert member['member']['weight'] == 1
-    attempts = 0
-    while not bigip_pool_members.get_collection():
-        attempts = attempts + 1
-        time.sleep(.5)
-        if attempts > 8:
-            sys.exit(9999)
+        member = nclientmanager.create_lbaas_member(pool_id, member_config)
+        member_id = member['member']['id']
+        assert member['member']['weight'] == 1
+        attempts = 0
+        while not bigip_pool_members.get_collection():
+            attempts = attempts + 1
+            time.sleep(.5)
+            if attempts > 8:
+                sys.exit(9999)
 
-    bigip_pool_member = bigip_pool_members.get_collection()[0]
-    assert poolname in bigip_pool_member.selfLink
-    address_plus_port =\
-        '%s:%s' % (address, member_config['member']['protocol_port'])
-    assert address_plus_port in bigip_pool_member.selfLink
-    # Test Update, Show
-    nclientmanager.update_lbaas_member(
-        member_id, pool_id, {'member': {'weight': 5}})
-    shown = nclientmanager.show_lbaas_member(member_id, pool_id)
-    assert shown['member']['weight'] == 5
-    nclientmanager.delete_lbaas_member(member['member']['id'], pool_id)
-    assert not bigip_pool_members.get_collection()
+        bigip_pool_member = bigip_pool_members.get_collection()[0]
+        assert poolname in bigip_pool_member.selfLink
+        address_plus_port =\
+            '%s:%s' % (address, member_config['member']['protocol_port'])
+        assert address_plus_port in bigip_pool_member.selfLink
+        # Test Update, Show
+        nclientmanager.update_lbaas_member(
+            member_id, pool_id, {'member': {'weight': 5}})
+        shown = nclientmanager.show_lbaas_member(member_id, pool_id)
+        assert shown['member']['weight'] == 5
+        nclientmanager.delete_lbaas_member(member['member']['id'], pool_id)
+        assert not bigip_pool_members.get_collection()
 
-
-def test_healthmonitor_CLUDS(setup_with_pool_member, bigip):
-    nclientmanager, pool, member = setup_with_pool_member
-    # Test List
-    assert not nclientmanager.list_lbaas_healthmonitors()['healthmonitors']
-    init_bip_http_monitors = bigip.ltm.monitor.https.get_collection()
-    assert len(init_bip_http_monitors) == 2
-    monitor_dict = {}
-    for monitor in init_bip_http_monitors:
-        monitor_dict[monitor.selfLink] = monitor
-    monitor_config = {'healthmonitor': {
-                      'delay': 3,
-                      'pool_id': pool['pool']['id'],
-                      'type': 'HTTP',
-                      'timeout': 13,
-                      'max_retries': 7}}
-    healthmonitor = nclientmanager.create_lbaas_healthmonitor(monitor_config)
-    healthmonitor_id = healthmonitor['healthmonitor']['id']
-    assert healthmonitor['healthmonitor']['delay'] == 3
-    assert\
-        len(nclientmanager.list_lbaas_healthmonitors()['healthmonitors']) == 1
-    interval = .05
-    total = 0
-    while len(bigip.ltm.monitor.https.get_collection()) == 2:
-        time.sleep(interval)
-        total = total + interval
-    pp(total)
-    assert len(bigip.ltm.monitor.https.get_collection()) == 3
-    # Test show, update
-    nclientmanager.update_lbaas_healthmonitor(
-        healthmonitor_id,
-        {'healthmonitor': {'delay': 77}}
-    )
-    shown = nclientmanager.show_lbaas_healthmonitor(healthmonitor_id)
-    assert shown['healthmonitor']['delay'] == 77
-    nclientmanager.delete_lbaas_healthmonitor(healthmonitor_id)
-    assert len(bigip.ltm.monitor.https.get_collection()) == 2
+def test_healthmonitor_CLUDS(setup_with_pool_member, BigIPSetup):
+     nclientmanager, pool, member = setup_with_pool_member
+     # Test List
+     assert not nclientmanager.list_lbaas_healthmonitors()['healthmonitors']
+     for bigip in BigIPSetup:
+        init_bip_http_monitors = bigip.tm.ltm.monitor.https.get_collection()
+        assert len(init_bip_http_monitors) == 2
+     monitor_dict = {}
+     for monitor in init_bip_http_monitors:
+         monitor_dict[monitor.selfLink] = monitor
+     monitor_config = {'healthmonitor': {
+                       'delay': 3,
+                       'pool_id': pool['pool']['id'],
+                       'type': 'HTTP',
+                       'timeout': 13,
+                       'max_retries': 7}}
+     healthmonitor = nclientmanager.create_lbaas_healthmonitor(monitor_config)
+     healthmonitor_id = healthmonitor['healthmonitor']['id']
+     assert healthmonitor['healthmonitor']['delay'] == 3
+     assert\
+         len(nclientmanager.list_lbaas_healthmonitors()['healthmonitors']) == 1
+     interval = .05
+     total = 0
+     for bigip in BigIPSetup:
+        while len(bigip.tm.ltm.monitor.https.get_collection()) == 2:
+            time.sleep(interval)
+            total = total + interval
+        pp(total)
+        assert len(bigip.tm.ltm.monitor.https.get_collection()) == 3
+     # Test show, update
+     nclientmanager.update_lbaas_healthmonitor(
+         healthmonitor_id,
+         {'healthmonitor': {'delay': 77}}
+     )
+     shown = nclientmanager.show_lbaas_healthmonitor(healthmonitor_id)
+     assert shown['healthmonitor']['delay'] == 77
+     nclientmanager.delete_lbaas_healthmonitor(healthmonitor_id)
+     for bigip in BigIPSetup:
+        assert len(bigip.tm.ltm.monitor.https.get_collection()) == 2

--- a/test/functional/test_bigips.yaml
+++ b/test/functional/test_bigips.yaml
@@ -1,0 +1,32 @@
+clusterbigips:
+# add one or more Bigips to this list
+  bigip1:
+      netloc: <bigip floating ip address>
+      username: <bigip username>
+      password: <bigip password>
+
+
+lbaas_version:    2
+auth_url:         http://<auth ip address>:5000/v2.0
+heatclient_url:   http://<auth ip address>:8004/v1/<tenant ID>
+glanceclient_url: http://<auth ip address>:9292
+client_ip:        <client floating ip address>
+server_ip:        <server floating ip address>
+tenant_name:      testlab
+tenant_username:  testlab
+tenant_password:  changeme
+admin_name:       admin
+admin_username:   admin
+admin_password:   changeme
+bigip_username:   admin
+bigip_password:   admin
+guest_username:   centos
+guest_password:   changeme
+server_http_port: 8080
+server_client_ip: 10.2.2.3
+provider:         f5networks
+partition_prefix: Project
+os_tentant_name:
+os_tenant_id:
+os_username:
+os_password:


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #140
I don't think there is any open issue.

#### What's this change do?
This change adds the clustering support to the Agent test_CLUDS test. The test_bigips.yaml file accepts a list of one or more bigips then the bigip list will be used in the test_CLUDS to create loadbalancer, listener, member, pool and health monitor. I tested 5 tests in the test_CLUDS.py and they passed.

#### Where should the reviewer start?
test_CLUDS.py and test_bigips.yaml

#### Any background context?

