### PR TITLE
Create loadbalancer for tenant fails in global routed mode

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -351,7 +351,10 @@ class LBaaSv2ServiceBuilder(object):
             agent_configs = self.deserialize_agent_configurations(
                 agent['configurations'])
 
-            common_networks = agent_configs['common_networks']
+            if 'common_networks' in agent_configs:
+                common_networks = agent_configs['common_networks']
+            else:
+                common_networks = {}
             common_external_networks = (
                 agent_configs['f5_common_external_networks'])
 


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #142 

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

Issues:
Fixes #142

Problem: Check for common network fails when global routed mode
is enabled.

Analysis: _is_common_network() assumes 'common_networks' is
defined in agent_configs object, but this is only true in global routed
mode. Check is bypassed when user tenant id and network tenant id
are the same, so the failure only happens when admin (or other)
tenant is creating a loadbalancer. Modified _is_common_network
method to check first for presence of 'common_networks' attribute
and set to empty object if not.

Tests: Manual.