### PR TITLE
doc updates for mitaka

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ version = VERSION
 release = VERSION
 
 # OpenStack release
-openstack_release = "Liberty"
+openstack_release = "Mitaka"
 rst_epilog = """
 .. |openstack| replace:: {0}
 """.format(openstack_release)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -311,13 +311,13 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 
 intersphinx_mapping = {'heat': (
-     'http://f5-openstack-heat.readthedocs.io/en/liberty', None),
+     'http://f5-openstack-heat.readthedocs.io/en/latest', None),
      'heatplugins': (
-     'http://f5-openstack-heat-plugins.readthedocs.io/en/liberty', None),
+     'http://f5-openstack-heat-plugins.readthedocs.io/en/latest', None),
      'lbaasv1': (
-     'http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/', None),
+     'http://f5-openstack-lbaasv1.readthedocs.io/en/mitaka/', None),
      'agent': (
-     'http://f5-openstack-agent.readthedocs.io/en/liberty/', None),
+     'http://f5-openstack-agent.readthedocs.io/en/mitaka/', None),
      'f5sdk': (
      'http://f5-sdk.readthedocs.io/en/latest/', None),
  }

--- a/docs/includes/topic_new-supported-features.rst
+++ b/docs/includes/topic_new-supported-features.rst
@@ -1,0 +1,16 @@
+New Supported Features
+======================
+
+Support for the following F5® features (also referred to as 'configurable features') is introduced in v |release|:
+
+* BIG-IP® device clusters (:ref:`f5_ha_type <HA mode>`)
+* `SSL offloading <https://f5.com/glossary/ssl-offloading>`_
+
+
+Support for the following OpenStack |openstack| `features <http://docs.openstack.org/releasenotes/neutron-lbaas/unreleased.html#new-features>`_ is introduced in v |release|:
+
+* Listener :ref:`TERMINATED_HTTPS <Certificate Manager>` protocol
+* Shared pools [#]
+
+
+.. [#] Multiple listeners can be associated with a single pool.

--- a/docs/includes/topic_restrictions.rst
+++ b/docs/includes/topic_restrictions.rst
@@ -3,26 +3,19 @@
 Unsupported Features
 --------------------
 
-The following features are unsupported in |release|; they will be introduced in future releases.
+The following F5® features are unsupported in |release|; they will be introduced in future releases.
 
 * `BIG-IP® vCMP® <https://f5.com/resources/white-papers/virtual-clustered-multiprocessing-vcmp>`_
 * Agent High Availability (HA)
 * :ref:`Auto-sync mode <Sync mode>` for clustered devices
 * Differentiated environments [#]_
 
+The following OpenStack |openstack| `features <http://docs.openstack.org/releasenotes/neutron-lbaas/unreleased.html#new-features>`_ are unsupported in |release|:
 
-.. note::
-
-    The features supported in |release| are a subset of the `Neutron LBaaSv2 API <https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0>`_ delivered in the OpenStack |openstack| release. The following restriction(s) apply:
-
-    .. table::
-
-        +----------------+----------------------------------------------------+
-        | Object         | Unsupported                                        |
-        +================+====================================================+
-        | Loadbalancer   || Statistics                                        |
-        |                || (e.g., ``neutron lbaas-loadbalancer-stats``)      |
-        +----------------+----------------------------------------------------+
+* L7 Routing
+* Unattached pools [#]_
+* Loadbalancer statistics  (e.g., ``neutron lbaas-loadbalancer-stats``)
 
 
 .. [#] Running multiple F5® agents on the same host to manage separate BIG-IP® environments.
+.. [#] Creating a pool with no listener.

--- a/docs/includes/topic_supported-features-intro.rst
+++ b/docs/includes/topic_supported-features-intro.rst
@@ -3,5 +3,5 @@
 Introduction
 ````````````
 
-The LBaaSv2 features supported in release |release| are noted below. See the :ref:`agent configuration file` -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- for more information about each feature.
+The configurable LBaaSv2 features supported in release |release| are noted below. See the :ref:`agent configuration file` -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- for more information about each feature.
 

--- a/docs/map_release-summary.rst
+++ b/docs/map_release-summary.rst
@@ -1,11 +1,8 @@
 New Supported Features
 ----------------------
 
-Support for the following features is introduced in v |release|:
-
-* Listener :ref:`TERMINATED_HTTPS <Certificate Manager>` protocol (`SSL offloading <https://f5.com/glossary/ssl-offloading>`_)
-* BIG-IP® device clusters (:ref:`f5_ha_type <HA mode>`)
-
+.. include:: includes/topic_new-supported-features.rst
+    :start-line: 3
 
 Unsupported Features
 --------------------


### PR DESCRIPTION
@jlongstaf @dflanigan 

#### What issues does this address?
Fixes #130 


#### What's this change do?
Updates documentation for release supporting Mitaka.
- update mitaka unsupported features
- update Mitaka supported features summary
- added 'configurable' to supported features intro to clarify that only features configurable on the f5 agent are being documented
- separated supported / unsupported feature lists into F5 and OpenStack sections

#### Where should the reviewer start?
Review changes below, or build the docs locally (clone my fork, pip install requirements.docs.txt, and run `sphinx-build docs/ docs/_build`

#### Any background context?

