### PR TITLE
Fixes #166

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -311,15 +311,15 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 
 intersphinx_mapping = {'heat': (
-     'http://f5-openstack-heat.readthedocs.io/en/liberty', None),
+     'http://f5-openstack-heat.readthedocs.io/en/mitaka', None),
      'heatplugins': (
-     'http://f5-openstack-heat-plugins.readthedocs.io/en/liberty', None),
+     'http://f5-openstack-heat-plugins.readthedocs.io/en/mitaka', None),
      'lbaasv1': (
-     'http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/', None),
+     'http://f5-openstack-lbaasv1.readthedocs.io/en/mitaka/', None),
      'agent': (
-     'http://f5-openstack-agent.readthedocs.io/en/liberty/', None),
+     'http://f5-openstack-agent.readthedocs.io/en/mitaka/', None),
      'f5sdk': (
      'http://f5-sdk.readthedocs.io/en/latest/', None),
      'docs': (
-     'http://f5-openstack-docs.readthedocs.io/en/liberty/', None),
+     'http://f5-openstack-docs.readthedocs.io/en/mitaka/', None),
  }

--- a/docs/includes/ref_see-also.rst
+++ b/docs/includes/ref_see-also.rst
@@ -5,7 +5,7 @@ See Also
 
 .. seealso::
 
-    * `F5® BIG-IP® LTM® Product Support <https://support.f5.com/kb/en-us/products/big-ip_ltm.html>`_
+    * `F5 BIG-IP LTM Product Support <https://support.f5.com/kb/en-us/products/big-ip_ltm.html>`_
 
-    * `F5® BIG-IP® User Guides <https://support.f5.com/kb/en-us/search.res.html?productList=big-ip_ltm&versionList=11-6-0&searchType=advanced&isFromGSASearch=false&query=&site=support_internal&client=support-f5-com&prodName=BIG-IP+LTM&prodVersText=11.6.0&docTypeName=Manual&q=&submit_form=&product=big-ip_ltm&pubDateFilter=all&productVersion=11-6-0&updatedDateFilter=all&documentType=manualpage&includeArchived=false>`_
+    * `F5 BIG-IP User Guides <https://support.f5.com/kb/en-us/search.res.html?productList=big-ip_ltm&versionList=11-6-0&searchType=advanced&isFromGSASearch=false&query=&site=support_internal&client=support-f5-com&prodName=BIG-IP+LTM&prodVersText=11.6.0&docTypeName=Manual&q=&submit_form=&product=big-ip_ltm&pubDateFilter=all&productVersion=11-6-0&updatedDateFilter=all&documentType=manualpage&includeArchived=false>`_
 

--- a/docs/includes/topic_before-you-begin.rst
+++ b/docs/includes/topic_before-you-begin.rst
@@ -15,7 +15,7 @@ In order to use F5® LBaaSv2 services, you will need the following:
 
 - Basic understanding of `OpenStack networking concepts`_.
 
-- Basic understanding of `BIG-IP® Local Traffic Management <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/ltm-basics-12-0-0.html>`_
+- Basic understanding of `BIG-IP Local Traffic Management <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/ltm-basics-12-0-0.html>`_
 
 - F5 :ref:`service provider package <Install the F5 Service Provider Package>` installed on Neutron controller.
 

--- a/docs/includes/topic_device-driver-settings.rst
+++ b/docs/includes/topic_device-driver-settings.rst
@@ -17,7 +17,7 @@ Use Case
 
 If you want to use the F5 agent to manage BIG-IP from within your OpenStack cloud, you **must** provide the correct information in this section of the agent config file. The F5 agent can manage a :term:`standalone` device or a :term:`device service cluster`.
 
-.. seealso:: :ref:`Managing BIG-IP Clusters`
+.. seealso:: :ref:`Managing BIG-IP Clusters with F5 LBaaS`
 
 
 Prerequisites
@@ -38,7 +38,6 @@ Caveats
 -------
 
 - vCMP® is unsupported in this release (v |release|).
-- Clustering is limited to two (2) BIG-IP devices in this release.
 
 
 Configuration

--- a/docs/includes/topic_install-f5-lbaasv2-driver.rst
+++ b/docs/includes/topic_install-f5-lbaasv2-driver.rst
@@ -2,25 +2,16 @@
 
 .. _install-f5-lbaasv2-driver:
 
-Install the F5® LBaaSv2 Driver
-------------------------------
+Install the F5 LBaaSv2 Driver
+-----------------------------
 
 .. include:: topic_tip-sudo-pip-git.rst
+    :start-line: 2
 
-.. topic:: To install the ``f5-openstack-lbaasv2-driver`` package:
-
-    .. code-block:: text
-
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver
-
-
-.. important::
-
-    The command above will install the package from the default branch (liberty). You can install specific releases by adding ``@<release_tag>`` to the end of the install command.
-
-    For example:
+.. topic:: To install the ``f5-openstack-lbaasv2-driver`` package for the v |release| release:
 
     .. code-block:: text
 
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v8.0.3
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v9.0.1
+
 

--- a/docs/includes/topic_lbaasv2-plugin-overview.rst
+++ b/docs/includes/topic_lbaasv2-plugin-overview.rst
@@ -3,14 +3,14 @@
 Overview
 ========
 
-The F5® OpenStack LBaaSv2 service provider driver and agent (also called the 'F5® LBaaSv2 plugin') make it possible to provision F5 BIG-IP® `Local Traffic Manager <https://f5.com/products/modules/local-traffic-manager>`_ (LTM®) services in an OpenStack cloud.
+The F5® OpenStack LBaaSv2 service provider driver and agent (also called, simply, 'F5 LBaaSv2') make it possible to provision F5 BIG-IP® `Local Traffic Manager <https://f5.com/products/modules/local-traffic-manager>`_ (LTM®) services in an OpenStack cloud.
 
 How the plugin works
 --------------------
 
 The F5 LBaaSv2 plugin consists of an :ref:`agent <agent:home>` and a service provider driver (also just called 'driver', for short). The driver listens to the Neutron RPC messaging queue. When you make a call to the LBaaSv2 API -- for example, ``neutron lbaas-loadbalancer-create`` -- the F5 LBaaSv2 service provider driver picks it up and directs it to the agent.
 
-The F5 agent manages services on your BIG-IP. When it first receives a task from the F5 driver, it starts and communicates with the BIG-IP(s) identified in the :ref:`agent configuration file`. Then, it registers its own named queue. The F5 driver assigns all ``lbaas`` tasks in the Neutron messaging queue to the agent's queue. The F5 agent makes callbacks to the F5® driver to query additional Neutron network, port, and subnet information; to allocate Neutron objects (for example, fixed IP addresses); and to report provisioning and pool status.
+The F5 agent manages services on your BIG-IP. When it first receives a task from the F5 driver, it starts and communicates with the BIG-IP(s) identified in the :ref:`agent configuration file`. Then, it registers its own named queue. The F5 driver assigns all ``lbaas`` tasks in the Neutron messaging queue to the agent's queue. The F5 agent makes callbacks to the F5 driver to query additional Neutron network, port, and subnet information; to allocate Neutron objects (for example, fixed IP addresses); and to report provisioning and pool status.
 
 .. image:: http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/_images/f5-lbaas-architecture.png
     :alt: F5 LBaaSv2 Plugin architecture

--- a/docs/includes/topic_new-supported-features.rst
+++ b/docs/includes/topic_new-supported-features.rst
@@ -1,16 +1,5 @@
 New Supported Features
 ======================
 
-Support for the following F5® features (also referred to as 'configurable features') is introduced in v |release|:
+All :ref:`supported features` for previous releases are also supported in v |release|.
 
-* BIG-IP® device clusters (:ref:`f5_ha_type <HA mode>`)
-* SSL offloading (:ref:`Certificate Manager / SSL Offloading`)
-
-
-Support for the following OpenStack |openstack| `features <http://docs.openstack.org/releasenotes/neutron-lbaas/unreleased.html#new-features>`_ is introduced in v |release|:
-
-* Listener :ref:`TERMINATED_HTTPS <Certificate Manager>` protocol
-* Shared pools [#]_
-
-
-.. [#] Multiple listeners can be associated with a single pool.

--- a/docs/includes/topic_restrictions.rst
+++ b/docs/includes/topic_restrictions.rst
@@ -1,32 +1,25 @@
 .. _f5-agent-unsupported-features:
 
 Unsupported Features
-====================
+--------------------
 
-The following features are unsupported in |release|; they will be introduced in future releases.
+The following F5® features are unsupported in |release|; they will be introduced in future releases.
 
 * `BIG-IP® vCMP® <https://f5.com/resources/white-papers/virtual-clustered-multiprocessing-vcmp>`_
 * Agent High Availability (HA) [#]_
 * Differentiated environments [#]_
 
 
-.. note::
+The following OpenStack |openstack| `features <http://docs.openstack.org/releasenotes/neutron-lbaas/unreleased.html#new-features>`_ are unsupported in |release|:
 
-    The features supported in |release| are a subset of the `Neutron LBaaSv2 API <https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0>`_ delivered in the OpenStack |openstack| release. The following restriction(s) apply:
-
-    .. table::
-
-        +----------------+----------------------------------------------------+
-        | Object         | Unsupported                                        |
-        +================+====================================================+
-        | Loadbalancer   || Statistics                                        |
-        |                || (e.g., ``neutron lbaas-loadbalancer-stats``)      |
-        +----------------+----------------------------------------------------+
-
+* L7 Routing
+* Unattached pools [#]_
+* Loadbalancer statistics  (e.g., ``neutron lbaas-loadbalancer-stats``)
 
 .. rubric:: Footnotes
 .. [#] Similar to BIG-IP :term:`high availability`, but applies to the F5 agent processes.
 .. [#] Multiple F5 agents running on the same host, managing *separate* BIG-IP environments.
+.. [#] Creating a pool with no listener.
 
 
 

--- a/docs/includes/topic_upgrading-f5-lbaasv2-plugin.rst
+++ b/docs/includes/topic_upgrading-f5-lbaasv2-plugin.rst
@@ -47,7 +47,7 @@ Red Hat/CentOS
 Install the new version of the F5 agent
 ---------------------------------------
 
-Follow the :ref:`agent <agent:home>` and installation instructions to install the version to which you'd like to upgrade.
+Follow the :ref:`agent <agent:home>` installation instructions to install the version to which you'd like to upgrade.
 
 Restore the F5 agent configuration file
 ---------------------------------------

--- a/docs/map_f5-lbaasv2-user-guide.rst
+++ b/docs/map_f5-lbaasv2-user-guide.rst
@@ -17,6 +17,6 @@ This guide provides instructions for installing and using the F5® OpenStack LBa
     map_configure-f5-agent
     Deployments <map_deployments>
     troubleshooting
-    glossary
+    
 
 

--- a/docs/map_release-summary.rst
+++ b/docs/map_release-summary.rst
@@ -4,10 +4,7 @@ Release Summary
 New Supported Features
 ======================
 
-Support for the following features is introduced in v |release|:
-
-* Listener :ref:`TERMINATED_HTTPS <Certificate Manager>` protocol (`SSL offloading <https://f5.com/glossary/ssl-offloading>`_)
-* BIG-IP® device clusters (:ref:`f5_ha_type <HA mode>`)
+N/A
 
 
 Unsupported Features

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,19 +1,19 @@
 .. _lbaasv2-driver-release-notes:
 
-Release Notes |version|
-#######################
+Release Notes v |version|
+#########################
 
-This release provides an implementation of the OpenStack Neutron LBaaSv2 driver and agent to support F5 Networks® BIG-IP® systems.
+This release introduces support for OpenStack |openstack|.
 
 Release Highlights
 ==================
 
-This release introduces support for SSL offloading and for BIG-IP® clustering (:term:`pair` and :term:`scalen` configurations).
+This is the initial release for OpenStack |openstack|.
 
 
-.. include:: map_release-summary.rst
-    :start-line: 2
+.. include:: includes/topic_new-supported-features.rst
+    :start-line: 3
+
+.. include:: includes/topic_restrictions.rst
 
 
-.. toctree::
-    :hidden:


### PR DESCRIPTION
@jlongstaf @mattgreene -- FYI

#### What issues does this address?
Fixes #166 

#### What's this change do?
- fixes the Mitaka / v9.0.1 release notes
- some additional corrections of typos
- some additional updates to match branding requirements (® doesn't have to be used in headings, only needs to be used at first mention)

#### Where should the reviewer start?

#### Any background context?

fix mitaka release notes

committing changes to release notesd

final edits to mitaka release notes; removed glossary from user guide toctree

fix broken ref to clustering doc

fix reused content ('orphan' tag from original doc is showing)

update intersphinx refs to point to mitaka versions of other projects' documentation