### PR TITLE
Bug fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,22 +24,19 @@ f5-openstack-lbaasv2-driver
 Introduction
 ------------
 
-The F5® OpenStack LBaaSv2 service provider driver (also called the 'F5® LBaaSv2 driver') makes it possible to provision F5® BIG-IP® local traffic management (LTM®) services in an OpenStack cloud.
+The F5® OpenStack LBaaSv2 service provider driver (also called the 'F5 LBaaSv2 driver') makes it possible to provision F5 BIG-IP® Local Traffic Manager® (LTM®) services in an OpenStack cloud.
 
-The F5® LBaaSv2 driver works in conjunction with the F5® OpenStack agent, which uses the :ref:`f5-sdk <f5sdk:home>` to translate Neutron API calls into BIG-IP® REST API calls.
+The F5 LBaaSv2 driver works in conjunction with the F5® OpenStack agent, which uses the `f5-sdk <http://f5-sdk.readthedocs.io/en/latest/>`_ to translate Neutron API calls into BIG-IP REST API calls.
 
 Compatibility
 -------------
 
-The F5® LBaaSv2 driver is compatible with OpenStack releases from Liberty forward. If
-you are using an earlier release, you'll need the `F5® OpenStack LBaaSv1 plugin <http://f5-openstack-lbaasv1.readthedocs.io>`_.
-
-For more information, please see the F5® OpenStack `Releases, Versioning, and Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_.
+See the `F5 OpenStack Releases, Versioning, and Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_.
 
 Documentation
 -------------
 
-Please refer to the F5® OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2-driver.readthedocs.io>`_ for installation and configuration instructions.
+Please refer to the F5 OpenStack LBaaSv2 `project documentation <http://f5-openstack-lbaasv2-driver.readthedocs.io>`_ for installation and configuration instructions.
 
 Filing Issues
 -------------
@@ -83,7 +80,7 @@ limitations under the License.
 Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Individuals or business entities who contribute to this project must
-have completed and submitted the `F5® Contributor License
+have completed and submitted the `F5 Contributor License
 Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`_
 to Openstack_CLA@f5.com prior to their code submission being included
 in this project.
@@ -93,7 +90,7 @@ in this project.
     :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver
 
 .. |Docs Build Status| image:: https://readthedocs.org/projects/f5-openstack-lbaasv2/badge/?version=latest
-    :target: http://f5-openstack-lbaasv2.readthedocs.org/en/latest/?badge=latest
+    :target: http://f5-openstack-lbaasv2.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. |slack badge| image:: https://f5-openstack-slack.herokuapp.com/badge.svg

--- a/docs/_static/f5-openstack-agent.gre.ini
+++ b/docs/_static/f5-openstack-agent.gre.ini
@@ -171,8 +171,8 @@ f5_external_physical_mappings = default:1.1:True
 # If no gre or vxlan tunneling is required, these settings should be
 # commented out or set to None.
 #
-f5_vtep_folder = None
-f5_vtep_selfip_name = None
+f5_vtep_folder = Common
+f5_vtep_selfip_name = vtep
 #
 #
 # Tunnel types

--- a/docs/_static/f5-openstack-agent.vxlan.ini
+++ b/docs/_static/f5-openstack-agent.vxlan.ini
@@ -171,8 +171,8 @@ f5_external_physical_mappings = default:1.1:True
 # If no gre or vxlan tunneling is required, these settings should be
 # commented out or set to None.
 #
-f5_vtep_folder = None
-f5_vtep_selfip_name = None
+f5_vtep_folder = Common
+f5_vtep_selfip_name = vtep
 #
 #
 #

--- a/docs/coding-example-lbaasv2.rst
+++ b/docs/coding-example-lbaasv2.rst
@@ -1,7 +1,7 @@
 .. _f5-openstack-lbaasv2-coding-example:
 
-F5® OpenStack LBaaSv2 Coding Example
-====================================
+F5 OpenStack LBaaSv2 Coding Example
+===================================
 
 We've provided some code examples below to help you get started with the F5® OpenStack LBaaSv2 agent and driver. This series demonstrates how to configure basic load balancing via the Neutron CLI. To access the full Neutron LBaaS command set, please see the `OpenStack CLI Documentation <http://docs.openstack.org/cli-reference/neutron.html>`_. LBaaSv2 commands all begin with ``lbaas``.
 

--- a/docs/includes/ref_neutron-to-bigip-configs-table.rst
+++ b/docs/includes/ref_neutron-to-bigip-configs-table.rst
@@ -3,7 +3,7 @@
 Neutron Command to BIG-IP Configuration Mapping Table
 =====================================================
 
-F5 LBaaSv2 uses the :ref:`f5-sdk <f5sdk:home>` to communicate with BIG-IP via the iControl® REST API. The table below shows the corresponding iControl endpoint and BIG-IP object for each neutron lbaas- ‘create’ command.
+F5 LBaaSv2 uses the `f5-sdk <http://f5-sdk.readthedocs.io/en/latest/>`_ to communicate with BIG-IP via the iControl® REST API. The table below shows the corresponding iControl endpoint and BIG-IP object for each neutron lbaas- ‘create’ command.
 
 +----------------------------------------+-----------------------------------------------------------------------------------------+-----------------------------------+
 | Command                                | URI                                                                                     | BIG-IP Configurations Applied     |

--- a/docs/includes/topic_l2-l3-segmentation-modes.rst
+++ b/docs/includes/topic_l2-l3-segmentation-modes.rst
@@ -150,7 +150,7 @@ Device Tunneling (VTEP) selfips
 
 - ``f5_vtep_folder``: This is the name of the BIG-IP folder or partition in which the `VTEP`_ (VxLAN tunnel endpoint) resides; the default partition is 'Common'.
 
-- ``f5_vtep_selfip_name``: The name of the self IP assigned to the VTEP.
+- ``f5_vtep_selfip_name``: The name of the self IP assigned to the VTEP. The self IP should be configured on the BIG-IP **before** you configure the F5 agent.
 
 .. topic:: Example
 
@@ -165,8 +165,8 @@ Device Tunneling (VTEP) selfips
         # If no gre or vxlan tunneling is required, these settings should be
         # commented out or set to None.
         #
-        f5_vtep_folder = None
-        f5_vtep_selfip_name = None
+        f5_vtep_folder = Common
+        f5_vtep_selfip_name = vtep
         #
 
 
@@ -323,14 +323,13 @@ Namespaces and Routing
 SNAT Mode and SNAT Address Counts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``f5_snat_mode``: Value must be True or False; indicates whether or not `SNATs`_ should be used.
+.. tip:: SNATs ensure that server responses always return through the BIG-IP; they also allow you to hide the source addresses of server-initiated requests from external devices. Use of SNATs is recommended to ensure traffic is routed through the BIG-IP properly.
 
-.. tip:: SNATs should be used when you need to ensure that server responses always return through the BIG-IP® system, or when you want to hide the source addresses of server-initiated requests from external devices.
+- ``f5_snat_mode``: Value must be True or False; indicates whether or not `SNATs`_ should be used.
 
 - ``f5_snat_addresses_per_subnet``: Value must be an integer; indicates the number of `self IP`_ addresses the BIG-IP should put in a SNAT pool for each subnet associated with a self IP.
 
 - ``f5_common_external_networks``: Value must be True or False; when set to True, traffic on all Neutron networks for which the router type is ``external`` will be routed according to the global routing table.
-
 
 .. topic:: Example
 

--- a/docs/includes/topic_l2-l3-segmentation-modes.rst
+++ b/docs/includes/topic_l2-l3-segmentation-modes.rst
@@ -150,7 +150,7 @@ Device Tunneling (VTEP) selfips
 
 - ``f5_vtep_folder``: This is the name of the BIG-IP folder or partition in which the `VTEP`_ (VxLAN tunnel endpoint) resides; the default partition is 'Common'.
 
-- ``f5_vtep_selfip_name``: The name of the self IP assigned to the VTEP. The self IP should be configured on the BIG-IP **before** you configure the F5 agent.
+- ``f5_vtep_selfip_name``: The name of the self IP assigned to the VTEP. The self IP must be configured on the BIG-IP **before** you configure the F5 agent.
 
 .. topic:: Example
 

--- a/docs/map_quick-start-guide.rst
+++ b/docs/map_quick-start-guide.rst
@@ -30,9 +30,26 @@ The table below contains a summary of the recommended F5 LBaaSv2 :ref:`configura
 * Tagged VLANs (without tunnels) :download:`f5-openstack-agent.vlan.ini <_static/f5-openstack-agent.vlan.ini>`
 
 
-
 .. include:: includes/topic_configure-neutron-lbaasv2.rst
     :start-line: 4
+
+.. important::
+
+    The Neutron configurations required may differ depending on your OS. Please see our partners' documentation for more information.
+
+    - `Hewlett Packard Enterprise <http://docs.hpcloud.com/#3.x/helion/networking/lbaas_admin.html>`_
+    - `Mirantis <https://www.mirantis.com/partners/f5-networks/>`_
+    - `RedHat <https://access.redhat.com/ecosystem/software/1446683>`_
+    
+
+.. include:: includes/topic_start-f5-agent.rst
+    :start-line: 4
+
+Next Steps
+==========
+
+- See the :ref:`Coding Example <f5-openstack-lbaasv2-coding-example>` for the commands to use to configure basic load balancing via the Neutron CLI.
+- See :ref:`F5 LBaaSv2 to BIG-IP Configuration Mapping` to discover what the F5 agent configures on the BIG-IP.
 
 
 .. _license: https://f5.com/products/how-to-buy/simplified-licensing

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,5 +1,5 @@
 Troubleshooting
----------------
+===============
 
 .. tip::
 
@@ -9,7 +9,7 @@ Troubleshooting
 
 
 Set Logging Level to DEBUG
-``````````````````````````
+--------------------------
 
 To troubleshoot general problems, set the Neutron and the F5® agent ``debug`` setting to ``True``.
 
@@ -36,8 +36,8 @@ Extensive logging will then appear in the ``neutron-server`` and ``f5-oslbaasv1-
         DEBUG = T
 
 
-F5 Agent is not running
-```````````````````````
+F5 agent is not running
+-----------------------
 
 If ``f5-openstack-agent`` or ``f5-oslbaasv2-agent`` doesn't appear in the Horizon agent list, or when you run ``neutron agent-list``, the agent is not running.
 
@@ -53,14 +53,13 @@ Here are a few things you can try:
 
     .. code-block:: text
 
-        $ sudo service f5-oslbaasv2-agent status           \\ Debian/Ubuntu
-        $ sudo systemctl status f5-openstack-agent.service \\ RedHat/CentOS
+        $ sudo systemctl status f5-openstack-agent.service \\ CentOS
+        $ sudo service f5-oslbaasv2-agent status           \\ Ubuntu
 
 
-3. Make sure you can connect to the BIG-IP® and that the iControl® hostname, username, and password in the config file are correct.
+3. Make sure you can connect to the BIG-IP® and that the iControl® hostname, username, and password in the :ref:`agent configuration file` are correct.
 
-
-4. If you're using ``global_routed_mode``, comment out (#) the ``vtep`` lines (shown below) in the agent config file.
+4. If you're using ``global_routed_mode``, comment out (#) the ``vtep`` lines (shown below) in the :ref:`agent configuration file`.
 
     .. code-block:: text
 
@@ -69,7 +68,7 @@ Here are a few things you can try:
         #f5_vtep_selfip_name = 'vtep'
         #
 
-5. If you're using L2 segmentation, make sure the ``advertised_tunnel_types`` setting matches the ``provider:network_type``.
+5. If you're using L2 segmentation, make sure the ``advertised_tunnel_types`` setting from the :ref:`agent configuration file` matches the ``provider:network_type`` displayed for the network in Neutron. If it doesn't, the network may be configured incorrectly.
 
     .. code-block:: text
         :emphasize-lines: 9
@@ -93,8 +92,8 @@ Here are a few things you can try:
         +---------------------------+--------------------------------------+
 
 
-F5 Agent is not provisioning LBaaS tasks correctly
-``````````````````````````````````````````````````
+F5 agent is not provisioning LBaaS tasks correctly
+--------------------------------------------------
 
 1. Make sure you don't have more than one agent running on the same host.
 
@@ -112,5 +111,126 @@ F5 Agent is not provisioning LBaaS tasks correctly
         \\ list the loadbalancers on the agent.
 
         $ neutron lbaas-loadbalancer-show <loadbalancer_id>
-        \\ Show the details for a specific loadbalancer
+        \\ show the details for a specific loadbalancer
 
+
+2. Make sure you're not running LBaaSv1 and LBaaSv2 at the same time.
+
+    In the :ref:`Neutron configuration file <configure-neutron-lbaasv2>` (:file:`/etc/neutron/neutron.conf`), remove the entry for the lbaasv1 plugin, if it exists.
+
+    **Correct**
+
+    .. code-block:: text
+
+        service_plugins = router,lbaasv2
+        \\ OR \\
+        service_plugins = router,neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2
+
+
+    **Incorrect**
+
+    .. code-block:: text
+
+        service_plugins = router,lbaas,lbaasv2
+
+
+    In the Neutron LBaaS configuration file (:file:`/etc/neutron/neutron_lbaas.conf`), remove or comment out (#) the entry for the F5 LBaaSv1 service provider driver.
+
+    .. code-block:: text
+        :emphasize-lines: 2, 9
+
+        [service_providers]
+        service_provider = LOADBALANCERV2:F5Networks:neutron_lbaas.drivers.f5.driver_v2.F5LBaaSV2Driver:default
+        # Must be in form:
+        # service_provider = <service_type>:<name>:<driver>[:default]
+        # List of allowed service types includes LOADBALANCER
+        # Combination of <service type> and <name> must be unique; <driver> must also be unique
+        # This is multiline option
+        # service_provider = LOADBALANCER:name:lbaas_plugin_driver_path:default
+        # service_provider = LOADBALANCER:F5:f5.oslbaasv1driver.drivers.plugin_driver.F5PluginDriver:default
+        # service_provider = LOADBALANCER:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+        # service_provider = LOADBALANCER:radware:neutron_lbaas.services.loadbalancer.drivers.radware.driver.LoadBalancerDriver:default
+        # service_provider = LOADBALANCER:NetScaler:neutron_lbaas.services.loadbalancer.drivers.netscaler.netscaler_driver.NetScalerPluginDriver
+        # service_provider = LOADBALANCER:Embrane:neutron_lbaas.services.loadbalancer.drivers.embrane.driver.EmbraneLbaas:default
+        # service_provider = LOADBALANCER:A10Networks:neutron_lbaas.services.loadbalancer.drivers.a10networks.driver_v1.ThunderDriver:default
+        # service_provider = LOADBALANCER:VMWareEdge:neutron_lbaas.services.loadbalancer.drivers.vmware.edge_driver.EdgeLoadbalancerDriver:default
+
+        # LBaaS v2 drivers
+        # service_provider = LOADBALANCERV2:Octavia:neutron_lbaas.drivers.octavia.driver.OctaviaDriver:default
+        # service_provider = LOADBALANCERV2:radwarev2:neutron_lbaas.drivers.radware.v2_driver.RadwareLBaaSV2Driver:default
+        # service_provider = LOADBALANCERV2:LoggingNoop:neutron_lbaas.drivers.logging_noop.driver.LoggingNoopLoadBalancerDriver:default
+        # service_provider = LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+        # service_provider = LOADBALANCERV2:A10Networks:neutron_lbaas.drivers.a10networks.driver_v2.ThunderDriver:default
+        # service_provider = LOADBALANCERV2:brocade:neutron_lbaas.drivers.brocade.driver_v2.BrocadeLoadBalancerDriver:default
+        # service_provider = LOADBALANCERV2:kemptechnologies:neutron_lbaas.drivers.kemptechnologies.driver_v2.KempLoadMasterDriver:default
+
+
+VxLAN traffic is not reaching BIG-IP
+------------------------------------
+
+1. Make sure the vtep endpoint identified in the :ref:`agent configuration file` is set to 'Allow All'.
+
+    The default setting for `port lockdown behavior`_ does not include VxLAN traffic. Setting the vtep to 'Allow All' will ensure that VxLAN traffic from the OpenStack cloud is not blocked by the BIG-IP.
+
+2. Check the VxLAN port binding.
+
+    If you're using the default Open vSwitch (ovs) core plugin, you can run the command ``ovs-vsctl show`` to view a list of configured bridges and associated ports. As shown in the example below, there should be a ``remote_ip`` address for a VxLAN tunnel that corresponds to the self IP identified in the :ref:`agent configuration file`.
+
+    **Example**: The code blocks below demonstrate that the ovs ``br-tun`` interface contains a port on which the ``remote_ip`` address matches that of the ``vtep`` self IP.
+
+    .. code-block:: text
+        :emphasize-lines: 1, 17
+
+        [user@host-19 ~(keystone_user)]$ sudo ovs-vsctl show
+        f08cd9da-cf33-4bc6-bdd2-960caed1136c
+        Bridge br-ex
+            ...
+        Bridge br-tun
+            fail_mode: secure
+            Port "vxlan-c9001901"
+                Interface "vxlan-c9001901"
+                    type: vxlan
+                    options: {df_default="true", in_key=flow, local_ip="201.0.20.1", out_key=flow, remote_ip="201.0.25.1"}
+            Port br-tun
+                Interface br-tun
+                    type: internal
+            Port "vxlan-0a020264"
+                Interface "vxlan-0a020264"
+                    type: vxlan
+                    options: {df_default="true", in_key=flow, local_ip="201.0.20.1", out_key=flow, remote_ip="10.2.2.100"}
+            Port patch-int
+                Interface patch-int
+                    type: patch
+                    options: {peer=patch-tun}
+            Port "gre-c9001901"
+                Interface "gre-c9001901"
+                    type: gre
+                    options: {df_default="true", in_key=flow, local_ip="201.0.20.1", out_key=flow, remote_ip="201.0.25.1"}
+            Port "vxlan-c9001801"
+                Interface "vxlan-c9001801"
+                    type: vxlan
+                    options: {df_default="true", in_key=flow, local_ip="201.0.20.1", out_key=flow, remote_ip="201.0.24.1"}
+            Port "gre-c9001801"
+                Interface "gre-c9001801"
+                    type: gre
+                    options: {df_default="true", in_key=flow, local_ip="201.0.20.1", out_key=flow, remote_ip="201.0.24.1"}
+        Bridge br-int
+            ...
+        ovs_version: "2.5.0"
+
+\
+    .. code-block:: text
+        :emphasize-lines: 3
+
+        root@(localhost)(cfg-sync Standalone)(Active)(/Common)(tmos.net)# list self vtep
+        net self vtep {
+            address 10.2.2.100/16
+            allow-service all
+            traffic-group traffic-group-local-only
+            vlan external
+        }
+
+
+
+
+.. _port lockdown behavior: https://support.f5.com/kb/en-us/solutions/public/17000/300/sol17333.html


### PR DESCRIPTION
@richbrowne @jlongstaf 

#### What issues does this address?
Fixes #181 #182 #185 

#### What's this change do?

This pull request contains bugfixes that either correct or enhance the documentation.
- adds info about VxLAN tunnel troubleshooting
- corrects tunneling section of 2 sample agent config files
- adds/clarifies info about vtep & snats to L2 adjacent mode doc
- updates README
- adds links to partner documentation to quick start guide
- adds instructions for starting the agent to quick start guide


#### Where should the reviewer start?
View the staged docs:
- [Quick Start Guide](http://lbaasv2-test.readthedocs.io/en/bugfix.docs/map_quick-start-guide.html)
- [Troubleshooting](http://lbaasv2-test.readthedocs.io/en/bugfix.docs/troubleshooting.html)
- [L2 Adjacent Mode](http://lbaasv2-test.readthedocs.io/en/bugfix.docs/includes/topic_l2-l3-segmentation-modes.html)

#### Any background context?
Please pay particular attention to the new information in the troubleshooting doc. Thanks!
