### PR TITLE
test_solution.py fails during startup.

### DIFF
--- a/test/functional/test_env.json
+++ b/test/functional/test_env.json
@@ -26,5 +26,6 @@
   "os_username":      "barbican",
   "os_password":      "orange",
   "os_auth_version":  "v3",
+  "debug":            false,
   "nc_interval":      1
 }


### PR DESCRIPTION
@dflanigan 

Issues:
Fixes #191

Problem:
The traffic tests test_solution.py will not run unless the http simple server is first started up on the server instance. The problem: When test_solution starts up it first tries to clean up from any previous runs. Part of that is killing any existing http simpler servers running on the server instance. The pkill command returns 1 (error) because at first there is no existing running http simple server.

Analysis:
Add an ignore_error option to exec_command to not care if the command ends in failure.  Tearing down the server during startup is best-effort.

This PR also cleans up a majority of flake8 violations, even though it is not automatically run in test/.

Tests:
Ran test_solution multiple times in a row with debug on and off to test delayed and immediate cleanup of lb config after the actual traffic test.
Executed on a mitaka deployment with 12.1HF1