### PR TITLE
Unable to delete pool

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -335,7 +335,7 @@ class PoolManager(object):
         driver = self.driver
         try:
             if pool.attached_to_loadbalancer():
-                loadbalancer = pool.listener.loadbalancer
+                loadbalancer = pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -364,7 +364,7 @@ class PoolManager(object):
         driver = self.driver
         try:
             if pool.attached_to_loadbalancer():
-                loadbalancer = pool.listener.loadbalancer
+                loadbalancer = pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -392,7 +392,7 @@ class PoolManager(object):
         driver = self.driver
         try:
             if pool.attached_to_loadbalancer():
-                loadbalancer = pool.listener.loadbalancer
+                loadbalancer = pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -427,7 +427,7 @@ class MemberManager(object):
         driver = self.driver
         try:
             if member.attached_to_loadbalancer():
-                loadbalancer = member.pool.listener.loadbalancer
+                loadbalancer = member.pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -456,7 +456,7 @@ class MemberManager(object):
         try:
             driver = self.driver
             if member.attached_to_loadbalancer():
-                loadbalancer = member.pool.listener.loadbalancer
+                loadbalancer = member.pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -484,7 +484,7 @@ class MemberManager(object):
         driver = self.driver
         try:
             if member.attached_to_loadbalancer():
-                loadbalancer = member.pool.listener.loadbalancer
+                loadbalancer = member.pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -519,7 +519,7 @@ class HealthMonitorManager(object):
         driver = self.driver
         try:
             if health_monitor.attached_to_loadbalancer():
-                loadbalancer = health_monitor.pool.listener.loadbalancer
+                loadbalancer = health_monitor.pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -548,7 +548,7 @@ class HealthMonitorManager(object):
         driver = self.driver
         try:
             if health_monitor.attached_to_loadbalancer():
-                loadbalancer = health_monitor.pool.listener.loadbalancer
+                loadbalancer = health_monitor.pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,
@@ -576,7 +576,7 @@ class HealthMonitorManager(object):
         driver = self.driver
         try:
             if health_monitor.attached_to_loadbalancer():
-                loadbalancer = health_monitor.pool.listener.loadbalancer
+                loadbalancer = health_monitor.pool.loadbalancer
                 agent = driver.scheduler.schedule(
                     driver.plugin,
                     context,


### PR DESCRIPTION
@richbrowne 

Issues:
Fixes #192

Problem:
server.log contained a backtrace indicating the pool object did not contain a loadbalancer attribute.

Analysis:
The driver code uses a neutron-lbaas API to check if the pool is attached to a loadbalancer, which checks for the existence of pool.loadbalancer.  If true, the driver then references pool.listener.loadbalancer, which would generally be ok except in failed state for my deployment.  Clean up references to use pool.loadbalancer.

Tests:
After change, was able to delete stuck pool objects. Ran traffic test multiple times, but unable to recreate the original half-deployed state.

Other:
I code-inspected neutron-lbaas for both liberty and mitaka.  Upstream mitaka changed the pool object model to not go through pool.listener.