### PR TITLE
Merge doc updates from Liberty into Mitaka

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,8 @@ in this project.
 .. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver.svg?branch=master
     :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver
 
-.. |Docs Build Status| image:: https://readthedocs.org/projects/f5-openstack-lbaasv2/badge/?version=latest
-    :target: http://f5-openstack-lbaasv2.readthedocs.io/en/latest/?badge=latest
+.. |Docs Build Status| image:: https://readthedocs.org/projects/f5-openstack-lbaasv2-driver/badge/?version=latest
+    :target: http://f5-openstack-lbaasv2-driver.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. |slack badge| image:: https://f5-openstack-slack.herokuapp.com/badge.svg

--- a/docs/includes/ref_prerequisites.rst
+++ b/docs/includes/ref_prerequisites.rst
@@ -19,7 +19,7 @@
 
 - F5 :ref:`agent <agent:home>` and :ref:`service provider driver <Install the F5 LBaaSv2 Driver>` installed on the Neutron controller and all other hosts from which you want to provision LBaaS services.
 
-- Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/liberty/>`_ for more information.
+- Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/mitaka/>`_ for more information.
 
 
 - Basic understanding of `BIG-IP® system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
@@ -28,7 +28,7 @@
 
 - Basic understanding of `BIG-IP® device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
 
-- Knowledge of `OpenStack Networking <http://docs.openstack.org/liberty/networking-guide/>`_ concepts.
+- Knowledge of `OpenStack Networking <http://docs.openstack.org/mitaka/networking-guide/>`_ concepts.
 
 - Knowledge of BIG-IP `system configuration`_, `local traffic management`_, & `device service clustering`_.
 .. must include the following at end of document:

--- a/docs/includes/topic_basic-environment-reqs.rst
+++ b/docs/includes/topic_basic-environment-reqs.rst
@@ -82,16 +82,16 @@ BIG-IP Requirements
 
 
 
-.. _Installation Guide for Red Hat Enterprise Linux 7 and CentOS 7: http://docs.openstack.org/liberty/install-guide-rdo/environment.html
-.. _Installation Guide for Ubuntu 14.04 (LTS): http://docs.openstack.org/liberty/install-guide-ubuntu/environment.html
-.. _OpenStack Installation Guide for openSUSE and SUSE Linux Enterprise: http://docs.openstack.org/liberty/install-guide-obs/environment.html
-.. _Nova: http://www.openstack.org/software/releases/liberty/components/nova
-.. _Neutron: http://www.openstack.org/software/releases/liberty/components/neutron
-.. _Keystone: http://www.openstack.org/software/releases/liberty/components/keystone
-.. _Glance: http://www.openstack.org/software/releases/liberty/components/glance
-.. _Horizon: http://www.openstack.org/software/releases/liberty/components/horizon
-.. _Heat: http://www.openstack.org/software/releases/liberty/components/heat
-.. _Barbican: http://www.openstack.org/software/releases/liberty/components/barbican
+.. _Installation Guide for Red Hat Enterprise Linux 7 and CentOS 7: http://docs.openstack.org/mitaka/install-guide-rdo/environment.html
+.. _Installation Guide for Ubuntu 14.04 (LTS): http://docs.openstack.org/mitaka/install-guide-ubuntu/environment.html
+.. _OpenStack Installation Guide for openSUSE and SUSE Linux Enterprise: http://docs.openstack.org/mitaka/install-guide-obs/environment.html
+.. _Nova: http://www.openstack.org/software/releases/mitaka/components/nova
+.. _Neutron: http://www.openstack.org/software/releases/mitaka/components/neutron
+.. _Keystone: http://www.openstack.org/software/releases/mitaka/components/keystone
+.. _Glance: http://www.openstack.org/software/releases/mitaka/components/glance
+.. _Horizon: http://www.openstack.org/software/releases/mitaka/components/horizon
+.. _Heat: http://www.openstack.org/software/releases/mitaka/components/heat
+.. _Barbican: http://www.openstack.org/software/releases/mitaka/components/barbican
 .. _license: https://f5.com/products/how-to-buy/simplified-licensing
 .. _BIG-IP LTM Release Notes: https://support.f5.com/kb/en-us/search.res.html?q=+inmeta:archived%3DArchived%2520documents%2520excluded+inmeta:product%3DBIG%252DIP%2520LTM+inmeta:kb_doc_type%3DRelease%2520Note+inmeta:archived%3DArchived%2520documents%2520excluded+inmeta:BIG%252DIP%2520LTM%3D12%252E1%252E0&dnavs=inmeta:product%3DBIG%252DIP%2520LTM+inmeta:kb_doc_type%3DRelease%2520Note+inmeta:archived%3DArchived%2520documents%2520excluded+inmeta:BIG%252DIP%2520LTM%3D12%252E1%252E0&filter=p&num=
 .. _RDO Packstack Quickstart: https://www.rdoproject.org/install/quickstart/

--- a/docs/includes/topic_ha-modes.rst
+++ b/docs/includes/topic_ha-modes.rst
@@ -39,7 +39,7 @@ Prerequisites
 
 - Administrator access to both BIG-IP device(s) and OpenStack cloud.
 
-- Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/liberty/>`_ for more information.
+- Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/mitaka/>`_ for more information.
 
 - Basic understanding of `BIG-IP® Local Traffic Management <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/ltm-basics-12-0-0.html>`_
 

--- a/docs/includes/topic_install-f5-lbaasv2-driver.rst
+++ b/docs/includes/topic_install-f5-lbaasv2-driver.rst
@@ -3,11 +3,64 @@
 Install the F5 LBaaSv2 Driver
 -----------------------------
 
-.. rubric:: To install the ``f5-openstack-lbaasv2-driver`` package for v |release|:
+Quick Start
+```````````
+
+.. rubric:: Install the ``f5-openstack-lbaasv2-driver`` package for v |release|:
 
 .. code-block:: text
 
-    $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@<release_tag>
+    $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v9.0.2
+
+
+.. tip::
+
+    You can install packages from HEAD on a specific branches by adding ``@<branch_name>`` to the end of the install command instead of the release tag.
+
+    .. rubric:: Example:
+    .. code-block:: text
+
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@mitaka
+
+
+.. warning::
+
+    You must :ref:`install the f5-openstack-agent <agent:home>` package, and its dependencies, **before** installing the f5-openstack-lbaasv2-driver via ``dpkg`` or ``rpm``.
+
+
+Debian Package
+``````````````
+
+The ``f5-openstack-lbaasv2-driver`` package can be installed using ``dpkg``.
+
+1. Download the package:
+
+.. code-block:: bash
+
+    $ curl –L –O https://github.com/F5Networks/f5-common-python/releases/download/v9.0.2/python-f5-openstack-agent_9.0.2-1_1404_all.deb
+
+2. Install the package on the Neutron controller:
+
+.. code-block:: bash
+
+    $ sudo dpkg –i python-f5-openstack-driver_9.0.2-1_1404_all.deb
+
+RPM Package
+```````````
+
+The ``f5-openstack-lbaasv2-driver`` package can be installed using ``rpm``.
+
+1. Download the package:
+
+.. code-block:: bash
+
+    $ curl –L –O https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v9.0.2/f5-openstack-lbaasv2-driver-9.0.2-1.el7.noarch.rpm
+
+2. Install the package on the Neutron controller:
+
+.. code-block:: bash
+
+    $ sudo rpm –ivh f5-openstack-lbaasv2-driver-9.0.2-1.el7.noarch.rpm
 
 .. tip:: Release tags always use the format "vx.x.x"
 

--- a/docs/includes/topic_l2-l3-segmentation-modes.rst
+++ b/docs/includes/topic_l2-l3-segmentation-modes.rst
@@ -52,7 +52,7 @@ Prerequisites
 
 - Administrator access to both the BIG-IP device(s) and the OpenStack cloud.
 
-- Knowledge of `OpenStack Networking <http://docs.openstack.org/liberty/networking-guide/>`_ concepts.
+- Knowledge of `OpenStack Networking <http://docs.openstack.org/mitaka/networking-guide/>`_ concepts.
 
 - Knowledge of BIG-IP `system configuration`_, `local traffic management`_, & `device service clustering`_.
 

--- a/docs/includes/topic_lbaasv2-plugin-overview.rst
+++ b/docs/includes/topic_lbaasv2-plugin-overview.rst
@@ -13,7 +13,7 @@ The F5 LBaaSv2 plugin consists of an :ref:`agent <agent:home>` and a service pro
 
 The F5 agent manages services on your BIG-IP. When it first receives a task from the F5 driver, it starts and communicates with the BIG-IP(s) identified in the :ref:`agent configuration file`. Then, it registers its own named queue. The F5 driver assigns all ``lbaas`` tasks in the Neutron messaging queue to the agent's queue. The F5 agent makes callbacks to the F5 driver to query additional Neutron network, port, and subnet information; to allocate Neutron objects (for example, fixed IP addresses); and to report provisioning and pool status.
 
-.. image:: http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/_images/f5-lbaas-architecture.png
+.. image:: http://f5-openstack-lbaasv1.readthedocs.io/en/mitaka/_images/f5-lbaas-architecture.png
     :alt: F5 LBaaSv2 Plugin architecture
 
 

--- a/docs/includes/topic_multi-tenancy.rst
+++ b/docs/includes/topic_multi-tenancy.rst
@@ -27,7 +27,7 @@ Prerequisites
 
 - F5 :ref:`agent <agent:home>` and :ref:`service provider driver <Install the F5 LBaaSv2 Driver>` installed on the Neutron controller and all other hosts from which you want to provision LBaaS services.
 
-- Knowledge of `OpenStack Networking <http://docs.openstack.org/liberty/networking-guide/>`_ concepts.
+- Knowledge of `OpenStack Networking <http://docs.openstack.org/mitaka/networking-guide/>`_ concepts.
 
 - Knowledge of BIG-IP `system configuration`_, `local traffic management`_, & `device service clustering`_.
 

--- a/docs/includes/topic_upgrading-f5-lbaasv2-plugin.rst
+++ b/docs/includes/topic_upgrading-f5-lbaasv2-plugin.rst
@@ -18,9 +18,19 @@ Make a copy of the F5 agent configuration file
 
 The existing configuration file in */etc/neutron/services/f5/* will be overwritten when you install the new package.
 
-    .. code-block:: text
+.. code-block:: text
 
-        $ cp /etc/neutron/services/f5/f5-openstack-agent.ini ~/
+    $ cp /etc/neutron/services/f5/f5-openstack-agent.ini ~/
+
+Rename the F5 agent log file
+----------------------------
+
+Your new F5 agent will not start if it finds an existing agent log file. Either rename the existing log file, or move it to a new location.
+
+.. code-block:: text
+
+    $ mv /var/log/neutron/f5-openstack-agent.log ~/
+
 
 Stop and remove the current version of the F5 agent
 ---------------------------------------------------
@@ -47,7 +57,7 @@ Red Hat/CentOS
 Install the new version of the F5 agent
 ---------------------------------------
 
-Follow the :ref:`agent <agent:home>` installation instructions to install the version to which you'd like to upgrade.
+Follow the :ref:`agent installation <agent:home>` instructions to install the new version to which you'd like to upgrade.
 
 Restore the F5 agent configuration file
 ---------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,9 +35,9 @@ Contents
 .. include:: includes/topic_lbaasv2-plugin-overview.rst
     :start-line: 2
 
-.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver.svg?branch=liberty
+.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver.svg?branch=mitaka
     :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver
     :alt: Build Status
-.. |Docs Build Status| image:: http://readthedocs.org/projects/f5-openstack-lbaasv2-driver/badge/?version=latest
-    :target: http://f5-openstack-lbaasv2-driver.readthedocs.io/en/latest/?badge=latest
+.. |Docs Build Status| image:: http://readthedocs.org/projects/f5-openstack-lbaasv2-driver/badge/?version=mitaka
+    :target: http://f5-openstack-lbaasv2-driver.readthedocs.io/en/latest/?badge=mitaka
     :alt: Documentation Status

--- a/docs/map_before-you-begin.rst
+++ b/docs/map_before-you-begin.rst
@@ -26,7 +26,7 @@ In order to use F5® LBaaSv2 services, you will need the following:
 Install the F5 Service Provider Package
 ---------------------------------------
 
-.. warning:: If the F5 service provider package isn't isntalled on your Neutron controller, F5 LBaaSv2 will not work.
+.. warning:: If the F5 service provider package isn't installed on your Neutron controller, F5 LBaaSv2 will not work.
 
 .. rubric:: Download the F5 LBaaSv2 service provider package and add it to the python path for ``neutron_lbaas``.
 
@@ -59,7 +59,11 @@ Install the F5 Agent
 
     .. code-block:: text
 
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@<release_tag>
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@v9.0.2
+
+    .. tip::
+
+        See the :ref:`F5 Agent documentation <agent:home>` for rpm and dpkg installation instructions.
 
 
 Install the F5 LBaaSv2 Driver
@@ -69,19 +73,8 @@ Install the F5 LBaaSv2 Driver
     :start-line: 5
 
 
-.. tip::
-
-    You can install packages from HEAD on a specific branches by adding ``@<branch_name>`` to the end of the install command instead of the release tag.
-
-    .. rubric:: Example:
-    .. code-block:: text
-
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@liberty
-
-
-
 .. seealso:: :ref:`Basic Environment Requirements for F5 LBaaSv2`
 
 
 .. _license: https://f5.com/products/how-to-buy/simplified-licensing
-.. _OpenStack Networking Concepts: http://docs.openstack.org/liberty/networking-guide/
+.. _OpenStack Networking Concepts: http://docs.openstack.org/mitaka/networking-guide/

--- a/docs/map_quick-start-guide.rst
+++ b/docs/map_quick-start-guide.rst
@@ -53,5 +53,5 @@ Next Steps
 
 
 .. _license: https://f5.com/products/how-to-buy/simplified-licensing
-.. _OpenStack Networking Concepts: http://docs.openstack.org/liberty/networking-guide/
+.. _OpenStack Networking Concepts: http://docs.openstack.org/mitaka/networking-guide/
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,15 +3,24 @@
 Release Notes v |version|
 #########################
 
-.. rubric:: Summary
-This release introduces support for OpenStack |openstack|.
+Summary
+-------
 
-.. rubric:: Release Highlights
-This is the initial release for OpenStack |openstack|.
+This release provides an implementation of the F5® service provider driver to support the use of F5 Networks® BIG-IP® systems with OpenStack Neutron LBaaSv2.
 
-See the `changelog <https://github.com/F5Networks/f5-openstack-lbaasv2-driver/compare/v8.0.4...v9.0.1>`_ for the full list of changes in this release.
+Release Highlights
+------------------
 
-.. rubric:: Caveats
+This release introduces the following:
+
+- Installation via rpm
+- Installation via dpkg
+- Bug fixes
+
+See the `changelog <https://github.com/F5Networks/f5-openstack-lbaasv2-driver/compare/v9.0.1...v9.0.2>`_ for the full list of changes in this release.
+
+Caveats
+-------
 
 The following are not supported in this release:
 
@@ -22,7 +31,8 @@ The following are not supported in this release:
 * Unattached pools
 * Loadbalancer statistics (e.g., ``neutron lbaas-loadbalancer-stats``)
 
-.. rubric:: Open Issues
+Open Issues
+-----------
 
 See the project `issues page <https://github.com/F5Networks/f5-openstack-lbaasv2-driver/issues>`_ for a full list of open issues in this release.
 


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Fixes #200 #180 

#### What's this change do?
- merges doc updates from liberty into mitaka
- replaces all references to liberty in documentation to mitaka (usually in URLs)

#### Where should the reviewer start?

#### Any background context?
