### PR TITLE
Implement lbaas-loadbalancer-stats command

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -200,10 +200,19 @@ class LBaaSv2PluginCallbacksRPC(object):
         return loadbalancers
 
     @log_helpers.log_method_call
-    def update_service_stats(self, context, service_id=None,
-                             stats=None, host=None):
+    def update_loadbalancer_stats(self, context, loadbalancer_id=None,
+                             stats=None):
         """Update service stats."""
-        pass
+        with context.session.begin(subtransactions=True):
+            try:
+                self.driver.plugin.db.update_loadbalancer_stats(
+                    context,
+                    loadbalancer_id,
+                    stats
+                )
+            except Exception as e:
+                LOG.error('Exception: update_loadbalancer_stats: %s',
+                          e.message)
 
     @log_helpers.log_method_call
     def update_loadbalancer_status(self, context,

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -200,8 +200,10 @@ class LBaaSv2PluginCallbacksRPC(object):
         return loadbalancers
 
     @log_helpers.log_method_call
-    def update_loadbalancer_stats(self, context, loadbalancer_id=None,
-                             stats=None):
+    def update_loadbalancer_stats(self,
+                                  context,
+                                  loadbalancer_id=None,
+                                  stats=None):
         """Update service stats."""
         with context.session.begin(subtransactions=True):
             try:


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #29 


#### What's this change do?
Adds update loadbalancer stats function.

#### Where should the reviewer start?
plugin_rpc.py

#### Any background context?
See corresponding agent code.

Issues:
Fixes #29

Problem: Need to add support for lbaas-loadbalancer-stats.

Analysis: Added new method for updating lodbalancer stats.

Tests: test_solution.py modified as in this PR.

Results:

`Running test_solution
('waiting for member to become active...',)
COMPLETE
('sending request from client....',)
BEFORE STATS
{u'stats': {u'active_connections': 0,
            u'bytes_in': 0,
            u'bytes_out': 0,
            u'total_connections': 0}}
Waiting to get updated stats...
AFTER STATS
{u'stats': {u'active_connections': 0,
            u'bytes_in': 507,
            u'bytes_out': 750,
            u'total_connections': 1}}
SUCCESS
PASSED`