### PR TITLE
Issue 227

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -361,22 +361,25 @@ class LBaaSv2ServiceBuilder(object):
 
     @log_helpers.log_method_call
     def _is_common_network(self, network, agent):
+        common_external_networks = False
+        common_networks = {}
+
         if agent and "configurations" in agent:
             agent_configs = self.deserialize_agent_configurations(
                 agent['configurations'])
 
             if 'common_networks' in agent_configs:
                 common_networks = agent_configs['common_networks']
-            else:
-                common_networks = {}
-            common_external_networks = (
-                agent_configs['f5_common_external_networks'])
 
-            return (network['shared'] or
-                    (network['id'] in common_networks) or
-                    ('router:external' in network and
-                     network['router:external'] and
-                     common_external_networks))
+            if 'f5_common_external_networks' in agent_configs:
+                common_external_networks = (
+                    agent_configs['f5_common_external_networks'])
+
+        return (network['shared'] or
+                (network['id'] in common_networks) or
+                ('router:external' in network and
+                 network['router:external'] and
+                 common_external_networks))
 
     def _valid_tenant_ids(self, network, lb_tenant_id, agent):
         if (network['tenant_id'] == lb_tenant_id):

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -105,6 +105,12 @@ class LBaaSv2ServiceBuilder(object):
             if (agent and not self._valid_tenant_ids(network,
                                                      loadbalancer.tenant_id,
                                                      agent)):
+                LOG.error("Creating a loadbalancer %s for tenant %s on a"
+                          "  non-shared network %s owned by %s." % (
+                              loadbalancer.id,
+                              loadbalancer.tenant_id,
+                              network['id'],
+                              network['tenant_id']))
                 raise f5_exc.F5MismatchedTenants()
 
             # Get the network VTEPs if the network provider type is


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #227 

Issues:
Fixes #227

Problem:
Create a loadbalancer where the loadbalancer tenant id does not
match the network tenant id and global routed mode is enabled.
This fails because the agent configuration does not contain
the 'f5_common_external_networks' item.

Analysis:
In the service builder modify the test to check if a network is a
shared network by testing for the 'f5_common_external_networks'
element in the configuration.

Tests:
Create a loadbalancing service on a shared admin network for a
tenant and pass traffic.