### PR TITLE
Adding initial documentation for multiagent support in LBaaSv2

### DIFF
--- a/docs/includes/topic_capacity-based-scaleout.rst
+++ b/docs/includes/topic_capacity-based-scaleout.rst
@@ -1,0 +1,53 @@
+Capacity-Based Scale Out
+````````````````````````
+
+In a differentiated service environment, you can configure multiple F5® agents. Each of the agents is associated with a distinct iControl® endpoint (in other words, different BIG-IP® devices). When environment grouping is configured, the service provider scheduler will consider the grouping along with an ``environment_capacity_score`` reported by the agents. Together, the agent grouping and the capacity score allow the scheduler to scale out a single environment across multiple BIG-IP® device service groups.
+
+To enable environment grouping, edit the ``environment_group_number`` setting in :file:`/etc/neutron/f5-openstack-agent.ini` (excerpt shown below).
+
+.. code-block:: text
+
+    # When using service differentiated environments, the environment can be
+    # scaled out to multiple device service groups by providing a group number.
+    # Each agent associated with a specific device service group should have
+    # the same environment_group_number.
+    #
+    # environment_group_number = 1
+
+
+All agents in the same group should have the same ``environment_group_number`` setting.
+
+Each agent measures its BIG-IP® devices' capacity. The agent reports a single ``environment_capacity_score`` for its group every time it reports its status to the Neutron controller.
+
+The ``environment_capacity_score`` value is the highest capacity recorded on several collected statistics specified in the ``capacity_policy`` setting in the agent configuration. The ``capacity_policy`` setting is a dictionary, where the key is the metric name and the value is the max allowed value for that metric. The score is determined by dividing the metric collected by the max specified for that metric in the ``capacity_policy`` setting. An acceptable reported ``environment_capacity_score`` is between zero (0) and one (1). **If an agent in the group reports an ``environment_capacity_score`` of one (1) or greater, the device is considered to be at capacity.**
+
+.. code-block:: shell
+
+    # capacity_policy = throughput:1000000000, active_connections: 250000, route_domain_count: 512, tunnel_count: 2048
+
+
+.. warning::
+
+    If you set the ``capacity_policy`` and all agents in all groups for an environment are at capacity, services will no longer be scheduled. When pools are created for an environment which has no capacity left, the pools will be placed in the error state.
+
+
+The following metrics implemented by the iControl® driver can also be configured in :file:`/etc/neutron/f5-openstack-agent.ini`.
+
+.. code-block:: shell
+
+    # throughput - total throughput in bps of the TMOS devices
+    # inbound_throughput - throughput in bps inbound to TMOS devices
+    # outbound_throughput - throughput in bps outbound from TMOS devices
+    # active_connections - number of concurrent active actions on a TMOS device
+    # tenant_count - number of tenants associated with a TMOS device
+    # node_count - number of nodes provisioned on a TMOS device
+    # route_domain_count - number of route domains on a TMOS device
+    # vlan_count - number of VLANs on a TMOS device
+    # tunnel_count - number of GRE and VxLAN overlay tunnels on a TMOS device
+    # ssltps - the current measured SSL TPS count on a TMOS device
+    # clientssl_profile_count - the number of clientside SSL profiles defined
+    #
+    # You can specify one or multiple metrics.
+
+
+When you create a new pool in an environment where multiple agent groups are configured, and the pool's ``tenant_id`` is not already associated with an agent group, the scheduler will attempt to assign the pool to the agent group which last reported the lowest ``environment_capacity_score``. If the pool's ``tenant_id`` is already associated with an agent group that is at capacity, the scheduler binds the pool to an agent in another group in the environment that is not at capacity.

--- a/docs/includes/topic_custom-env.rst
+++ b/docs/includes/topic_custom-env.rst
@@ -1,0 +1,4 @@
+This can be done by Za or by linking to the docs in that utility
+
+Custom Environments
+```````````````````

--- a/docs/includes/topic_default-env-options.rst
+++ b/docs/includes/topic_default-env-options.rst
@@ -1,0 +1,24 @@
+Default Environment
+```````````````````
+
+The F5® OpenStack LBaaSv2 plugin provides one default environment name, Project, as defined in the excerpt from :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` below, the
+agent's unique ``environment_prefix`` defines the environment to which it belongs.  Additionally, an environment can be serviced by mulitple device service groups by assigning a
+``environment_group_number`` to each.  Each agent associated with a specific device service group should have the same ``environment_group_number``.  See capacity based scale out.
+
+
+.. code-block:: shell
+
+    ###############################################################################
+    #  Environment Settings
+    ###############################################################################
+    #
+    # Since many TMOS® object names must start with an alpha character
+    # the environment_prefix is used to prefix all service objects.
+    #
+    # environment_prefix = 'Project'
+    #
+	# environment_group_number = 1
+	#
+
+After making changes to  :file:`/etc/neutron/service/f5f5-openstack-agent.ini` and :file:`/etc/neutron/neutron_lbaas.conf`, restart the ``neutron-server`` process.
+

--- a/docs/includes/topic_differentiated-services-scaleout.rst
+++ b/docs/includes/topic_differentiated-services-scaleout.rst
@@ -1,0 +1,18 @@
+Differentiated Services and Scale Out
+-------------------------------------
+
+The F5® LBaaSv2 plugin supports deployments where multiple BIG-IP® environments are required. In a differentiated service environment, each F5® driver will work as described above **with the exception** that each environment has its own messaging queue. The Tenant scheduler for each environment only considers agents within that environment. Configuring multiple environments with corresponding distinct ``neutron_lbaas`` service provider entries is the only way to allow a tenant to select its environment through the LBaaS API. The first section of :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` provides information regarding configuration of multiple environments.
+
+.. topic:: To configure differentiated LBaaSv2 provisioning:
+
+    1. Install the agent and driver on each host that requires LBaaSv2 provisioning.
+
+    2. Assign the agent an environment-specific name in :file:`/etc/neutron/services/f5/f5-openstack-agent.ini`.
+
+    3. Create a service provider entry for each agent in :file:`/etc/neutron/neutron_lbaas` that corresponds to the unique agent name you assigned.
+
+.. warning::
+
+    A differentiated BIG-IP® environment can not share anything.
+
+

--- a/docs/includes/topic_multiple-controllers-agent-redundancy.rst
+++ b/docs/includes/topic_multiple-controllers-agent-redundancy.rst
@@ -1,0 +1,34 @@
+Multiple Controllers and Agent Redundancy
+-----------------------------------------
+
+The F5® LBaaSv2 plugin driver runs within the Neutron controller. When the Neutron community LBaaS plugin loads the
+driver, it creates a global messaging queue that will be used for all inbound
+callbacks and status update requests from F5® LBaaSv2 agents.
+
+.. tip::
+
+    To run multiple queues, see the :ref:`differentiated services <differentiated-services-scaleout>` section.
+
+In an environment with multiple Neutron controllers, the F5® drivers all listen to the same
+named message queue, providing controller redundancy and scale out. The drivers handle requests from the global queue in a round-robin fashion. All Neutron controllers must use the same Neutron database to avoid state problems with concurrently-running controller instances.
+
+.. note::
+
+    The agent service will expect to find an :file:`/etc/neutron/neutron.conf` file on its host; this file contains the configurations for Neutron messaging. To make sure the messaging settings match those of the controller, we recommend copying the :file:`/etc/neutron/neutron.conf` file from the controller to each additional host.
+
+If you choose to deploy multiple agents with the same BIG-IP® ``environment_prefix``, each agent **must** run on a different host. Each agent will communicate with its configured iControl® endpoint(s) to do the following:
+
+ * Verify that the BIG-IP® systems meet minimal requirements.
+ * Create a specific named queue unique to itself for processing provisioning requests from service provider drivers.
+ * Report as a valid F5® LBaaSv2 agent via the standard Neutron controller agent status queue.
+
+The agents continue to report their status to the agent queue on a periodic basis (every 10 seconds, by
+default; this can be configured in :file:`/etc/neutron/services/f5/f5-openstack-agent.ini`).
+
+When a Neutron controller receives a request for a new loadbalancer, the F5® LBaaSv2 driver invokes the agent scheduler. The scheduler queries all active F5® agents and determines what, if any, existing loadbalancers are bound to each agent. If the driver locates an active agent that already has a bound loadbalancer for the same ``tenant_id`` as the newly-requested loadbalancer, the driver selects that agent. Otherwise, the driver selects an active agent at random. The request to create the loadbalancer service is sent to the selected agent's task queue. When the provisioning task is complete, the agent reports the outcome to the LBaaSv2 callback queue. The driver processes the agent's report and updates the Neutron database. The agent which handled the provisioning task is bound to the loadbalancer for the loadbalancer's lifetime (in other words, that agent will handle all tasks for that loadbalancer as long as the agent and/or loadbalancer are active). If a bound agent is inactive, the agent scheduler looks for other agents with the same ``environment_prefix`` as the bound agent. The scheduler assigns the task to the first active agent with a matching ``environment_prefix`` that it finds. The pool remains bound to the original (currently inactive) agent, with the expectation that the agent will eventually be brought back online.
+
+.. warning::
+
+     If you delete an agent, you should also delete all loadbalancers bound to that agent.
+
+     Run ``neutron lbaas-loadbalancer-list-on-agent <agent-id>`` to identify all pools associated with an agent.

--- a/docs/map_differentiated-services-scaleout.rst
+++ b/docs/map_differentiated-services-scaleout.rst
@@ -1,0 +1,50 @@
+.. _differentiated-services-scaleout:
+
+Differentiated Services and Scale Out
+-------------------------------------
+.. figure:: media/driver_multiple_environments.png
+    :alt: Installing the LBaaSv1 Driver in Multiple Environments
+
+    Figure 4. Installing the LBaaSv1 Driver in Multiple Environments
+
+.. figure:: media/agent_multiple_environments.png
+    :alt: F5® LBaaSv1 Agents in Multiple Environments
+
+    Figure 5. F5® LBaaSv1 Agents in Multiple Environments
+
+.. include:: includes/topic_differentiated-services-scaleout.rst
+    :start-line: 3
+
+.. _default-env-options:
+
+Default Environment Options
+```````````````````````````
+.. include:: includes/topic_default-env-options.rst
+    :start-line: 3
+
+.. _custom-envs:
+
+Custom Environments
+```````````````````
+.. include:: includes/topic_custom-env.rst
+    :start-line: 3
+
+.. _capacity-based-scaleout:
+
+Capacity-Based Scale Out
+````````````````````````
+
+.. figure:: media/env_group_scale_out.png
+    :alt: Environment Group Scale Out
+
+    Figure 6. Environment Group Scale Out
+
+.. include:: includes/topic_capacity-based-scaleout.rst
+    :start-line: 3
+
+.. _multiple-agents-same-host:
+
+Running Multiple F5® Agents on the Same Host
+````````````````````````````````````````````
+.. include:: includes/topic_multiple-agents-same-host.rst
+    :start-line: 3

--- a/docs/map_multi-controller-agent-redundancy.rst
+++ b/docs/map_multi-controller-agent-redundancy.rst
@@ -1,0 +1,11 @@
+.. _multi-controller-agent-redundancy:
+
+Multiple Controllers and Agent Redundancy
+-----------------------------------------
+.. figure:: media/basic_agent_scheduled_redundancy.png
+    :alt: Basic Agent Scheduled Redundancy
+
+    Figure 3. Basic Agent Scheduled Redundancy
+
+.. include:: includes/topic_multiple-controllers-agent-redundancy.rst
+    :start-line: 5


### PR DESCRIPTION
@jputrino @swormke 

#### What issues does this address?
This is a documentation update to reflect new/supported functionality.

#### What's this change do?
Add documentation for different multi agent configurations.

#### Where should the reviewer start?
docs/map_differentiated-services-scaleout.rst
docs/map_multi-controller-agent-redundancy.rst

#### Any background context?
Can be found in the LBaaSv1 docs:
http://f5-openstack-lbaasv1.readthedocs.io/en/latest/map_user-guide.html


