### PR TITLE
Add imports to __init__.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 - git config --global user.email "OpenStack_TravisCI@f5.com"
 - git config --global user.name "Travis F5 Openstack"
 install:
-- sudo pip install hacking pytest pytest-cov .
 - sudo pip install -r requirements.txt
+- sudo pip install hacking pytest pytest-cov .
 - sudo pip install -r requirements.docs.txt
 script:
 - flake8 ./f5lbaasdriver

--- a/f5lbaasdriver/__init__.py
+++ b/f5lbaasdriver/__init__.py
@@ -1,2 +1,3 @@
 import v2
 __version__ = "8.0.7"
+__all__ = ['v2']

--- a/f5lbaasdriver/__init__.py
+++ b/f5lbaasdriver/__init__.py
@@ -1,1 +1,2 @@
+import v2
 __version__ = "8.0.7"

--- a/f5lbaasdriver/v2/__init__.py
+++ b/f5lbaasdriver/v2/__init__.py
@@ -1,0 +1,1 @@
+import bigip

--- a/f5lbaasdriver/v2/__init__.py
+++ b/f5lbaasdriver/v2/__init__.py
@@ -1,1 +1,2 @@
 import bigip
+__all__ = ['bigip']

--- a/f5lbaasdriver/v2/bigip/__init__.py
+++ b/f5lbaasdriver/v2/bigip/__init__.py
@@ -1,0 +1,1 @@
+import driver_v2

--- a/f5lbaasdriver/v2/bigip/__init__.py
+++ b/f5lbaasdriver/v2/bigip/__init__.py
@@ -1,1 +1,2 @@
 import driver_v2
+__all__ = ['driver_v2']

--- a/test/test_driver_init.py
+++ b/test/test_driver_init.py
@@ -1,0 +1,22 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import f5lbaasdriver
+
+
+def test_driver_import():
+    """Test that users can init driver by importing f5lbaasdriver only."""
+    f5 = f5lbaasdriver.v2.bigip.driver_v2.F5DriverV2
+    assert f5 is not None


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #225 

#### What's this change do?
Adds import statements to __init__ modules so that users only have to import
f5lbaasdriver to load f5DriverV2, instead of import f5lbaasdriver.v2.bigip.

#### Where should the reviewer start?
__init__.py

#### Any background context?
The need for this is caused by driver shim that was upstreamed to neutron-lbaas OpenStack project. This code only imports f5lbaasdrvier. This change is necessary to keep this code from failing.

Issues:
Fixes #225

Problem: Users need to fully specify import path to F5DriverV2.
Need to allow users to only import f5lbaasdriver.

Analysis: Added imports to __init__ modules.

Tests: Unit test test_driver_init.py