### PR TITLE
Generate md5 checksums for release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 env:
   global:
   - DIST_REPO="f5-openstack-lbaasv2-driver-dist"
+  - PKG_VERSION=$(python -c "import f5lbaasdriver; print f5lbaasdriver.__version__")
+  - PKG_RELEASE=$(python ${DIST_REPO}/scripts/get-version-release.py --release)
+  - PKG_RELEASE_EL7=${DIST_REPO}/rpms/f5-openstack-lbaasv2-driver-${PKG_VERSION}-1.el7.noarch.rpm
+  - PKG_RELEASE_1404=${DIST_REPO}/deb_dist/python-f5-openstack-lbaasv2-driver_${PKG_VERSION}-${PKG_RELEASE}_1404_all.deb
 services:
 - docker
 language: python
@@ -21,6 +25,8 @@ script:
 - sudo chown -R travis:travis ${DIST_REPO}/rpms
 - sudo chown -R travis:travis ${DIST_REPO}/deb_dist/*.deb
 after_success:
+  - md5sum ${PKG_RELEASE_EL7} > ${PKG_RELEASE_EL7}.md5 && md5sum --check ${PKG_RELEASE_EL7}.md5
+  - md5sum ${PKG_RELEASE_1404} > ${PKG_RELEASE_1404}.md5 && md5sum --check ${PKG_RELEASE_1404}.md5
   - f5-openstack-lbaasv2-driver-dist/scripts/test_install.sh "redhat" "7"
   - f5-openstack-lbaasv2-driver-dist/scripts/test_install.sh "ubuntu" "14.04"
 notifications:
@@ -30,15 +36,15 @@ notifications:
     - secure: R9I38fqG1n1dXSd97e7eKrNt8XtWPpcF7J1cZ8cc+vB3+LcHjruMTVfRZHPWsBHMlWxvgrl7zD3t+38cIW2hJ7YrWjo4Izl60k8OM6HteFwHfDGsLM6eZNUaTZFORbeTSJCo6jryAI7qsu5xjU2uUi08nJTmuXU9jxsC+7mRzh1EL680TaPtCfoniVqI+3xRWt1ApVs8u61yU44x83KlBcSHdg9F/7X3o/I9vG+CiKxm+RWi0i6g1RebLzAEnYYMTGEctTaQCmyt4Y8+I9K/WBVKEQyT6o1z2Ac00qmbsk0sbSuEt9q30nJwlqGR1/WTn4FvDxGC1BE82rOmyppFjV0giXlJGINQre6LuGnMkeW8Cmg2P4vsHVwmxDR8B4G2cwdSgiho758wtP3ABVVA10GgnoatxeUAAC1rc6QAcQ9HdYObKmGzpRjp+6AWp1YghSCjszdRUvwtfWIZ9fmvTZBhB2qDJxAsyjw0DU+hxIfGs1v6TV6hcN4Vh9C34fKvP19tn7BS5vbZTPorq67uTxDj9EOfLOzuZNKbzRLqNQu+ZXniiV7P5sqT+mEryGJ04rrEC7/KuuWg0zPhevitY1oZNo4fjSSiSN2m42c+9cOtw0eZVACQFwI2vlU5pdRhPkfU6QqKPNIIfjsp+uWehN5sRPvL+GKh5siiQzhvyJ4=
     on_success: change
     on_failure: always
-before_deploy:
-  PKG_VERSION=$(python -c "import f5lbaasdriver; print(f5lbaasdriver.__version__)")
 deploy:
   - provider: releases
     api_key:
       secure: tFUvbzPVEpk0Tfqq4EWcvFnVJG5N4Zk1/OTZslnGXNz/M915HAucXFTkygqWkOHeEgTn/TETGAavQg8lTaOV7/But9sX6/BfXB4UH0yW0Nv6wOM7O0K3BU6CkeHnkDZAuM/j8yDwWu8RrMsA5CrJXHrgRgEltN+yNrCsXlly0FYIkEZrYX/lrhUbAPsb6Y71MGRSW6XyhaoYh4CvNRgx2KE8Ctk5BOCIpysSkVTZ9lnORHZruML149FCqY0+9gYUwN1Uy6Ym8+uPDsGwpyGWPdOPEbBES8KMwBAM+IzUN3wO53ypy8bqxBLhUhKbGiiUQ4BISNJ9vjZmDLAdxcFEgpM/lPOyjEOEKBWDgCgSIzCRkoLa8PxPcTVRW8NSgQIaSq2qumGKEDUruzubg4PAt9PkeW4z69FfH/qhr+Alhhoq2bAAGb2fDPyYzXPIfq3AY+IV33WVN/b1Ww0DiRKAPpXlvOoVpyrCSYmfDBNEtpPpHWfldXLZLCjaZUuXvuKN23J9OYMmludkEEbIsRjhpHLN3E/quzw1vVVXLhQPLBkJc4/v0ONX3G751/PeHCWX5/IDhCRuBeaA8eZ6Jq/o1PgzzqcenXrCCAxeMY1HhcVMwHCorBzYB1FQe6VI5jR/+oPhU0GQe3EttebeNIb6PjlZEYYS0j2VM6vz5foS/z0=
     file:
-      - ${DIST_REPO}/rpms/f5-openstack-lbaasv2-driver-${PKG_VERSION}-1.el7.noarch.rpm
-      - ${DIST_REPO}/deb_dist/python-f5-openstack-lbaasv2-driver_${PKG_VERSION}-1_1404_all.deb
+      - ${PKG_RELEASE_EL7}
+      - ${PKG_RELEASE_EL7}.md5
+      - ${PKG_RELEASE_1404}
+      - ${PKG_RELEASE_1404}.md5
     skip_cleanup: true
     overwrite: true
     on:


### PR DESCRIPTION
@jlongstaf 

Issues:
Fixes #255

Problem: Need to add md5 checksum to binary files for consistency with F5 downloads.

Analysis: Update travis scheme to generate md5sum files and attach to the github release page adjacent to the rpm and deb binary files.

Tests: Confirmed generation of md5 files via test build in fork.