### PR TITLE
Add tempest tests for CRUD operations for l7policies and rules

### DIFF
--- a/f5lbaasdriver/test/tempest/config.py
+++ b/f5lbaasdriver/test/tempest/config.py
@@ -35,7 +35,7 @@ f5_lbaasv2_driver_opts = [
     ),
     cfg.StrOpt(
         'transport_url',
-        default="rabbit://stackrabbit:nova@10.1.0.147:5672/",
+        default="rabbit://guest:guest@10.190.4.156:5672/",
         help='The transport_url to use for messaging, see neutron.conf'
     ),
 ]

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -23,6 +23,8 @@ from tempest.lib import exceptions
 from f5lbaasdriver.test.tempest.services.clients import \
     l7policy_client
 from f5lbaasdriver.test.tempest.services.clients import \
+    l7rule_client
+from f5lbaasdriver.test.tempest.services.clients import \
     plugin_rpc_client
 from neutron_lbaas.tests.tempest.v2.clients import \
     health_monitors_client
@@ -83,6 +85,8 @@ class BaseTestCase(base.BaseNetworkTest):
             health_monitors_client.HealthMonitorsClientJSON(*client_args))
         cls.l7policy_client = (
             l7policy_client.L7PolicyClientJSON(*client_args))
+        cls.l7rule_client = (
+            l7rule_client.L7RuleClientJSON(*client_args))
         cls.plugin_rpc = (
             plugin_rpc_client.F5PluginRPCClient()
         )
@@ -117,7 +121,7 @@ class BaseTestCase(base.BaseNetworkTest):
                     for rule in l7policy.get('rules'):
                         cls._try_delete_resource(
                             cls.l7rule_client.delete_l7rule,
-                            rule.get('id'))
+                            l7policy.get('id'), rule.get('id'))
                     cls._try_delete_resource(
                         cls.l7policy_client.delete_l7policy,
                         l7policy.get('id'))
@@ -360,15 +364,15 @@ class BaseTestCase(base.BaseNetworkTest):
         return l7policy
 
     @classmethod
-    def _create_l7rule(cls, wait=True, **l7policy_kwargs):
-        l7rule = cls.l7rule_client.create_l7policy(**l7policy_kwargs)
+    def _create_l7rule(cls, policy_id, wait=True, **l7rule_kwargs):
+        l7rule = cls.l7rule_client.create_l7rule(policy_id, **l7rule_kwargs)
         if wait:
             cls._wait_for_load_balancer_status(cls.load_balancer.get('id'))
         return l7rule
 
     @classmethod
-    def _delete_l7rule(cls, l7rule_id, wait=True):
-        cls.l7rule_client.delete_l7rule(l7rule_id)
+    def _delete_l7rule(cls, policy_id, l7rule_id, wait=True):
+        cls.l7rule_client.delete_l7rule(policy_id, l7rule_id)
         if wait:
             cls._wait_for_load_balancer_status(cls.load_balancer.get('id'))
 

--- a/f5lbaasdriver/v2/bigip/exceptions.py
+++ b/f5lbaasdriver/v2/bigip/exceptions.py
@@ -22,6 +22,10 @@ class F5LBaaSv2DriverException(q_exc.NeutronException):
 
     message = "F5LBaaSv2DriverException"
 
+    def __init__(self, message=None):
+        if message:
+            self.message = message
+
 
 class F5MismatchedTenants(F5LBaaSv2DriverException):
     """The loadbalancer tenant is not the same as the network tenant."""
@@ -34,3 +38,15 @@ class F5DeleteListenerWithAttachedPool(F5LBaaSv2DriverException):
 
     message = "Cannot delete listener with an attached pool. " \
               "Delete pool first."
+
+
+class PolicyHasMoreThanOneListener(F5LBaaSv2DriverException):
+    """A policy should have only one listener."""
+
+    def __str__(self):
+        return self.message
+
+
+class RuleHasMoreThanOnePolicy(F5LBaaSv2DriverException):
+    """A rule should have only one policy."""
+    pass

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -421,8 +421,8 @@ class LBaaSv2PluginCallbacksRPC(object):
     def update_l7rule_status(
             self,
             context,
-            l7rule_id,
-            l7policy_id,
+            l7rule_id=None,
+            l7policy_id=None,
             provisioning_status=plugin_constants.ERROR):
         """Agent confirmation hook to update l7 policy status."""
         with context.session.begin(subtransactions=True):


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Fixes #276 and #277 

#### What's this change do?
Add tempest tests for CRUD operations for l7policies and rules.

#### Where should the reviewer start?
Start at the changes in service_builder.py then move on to unit tests. Lastly, look at the tempest tests.

#### Any background context?
Found a couple of bugs during tempest testing and fixed those. Also found a few issues with tempest setup and teardown that have been fixed for the l7policy tests, but the l7rule tests are still failing. This is because we will not adequately mock out agent behavior to get the tests pass. Instead, we'll wait until the agent behavior is there.