### PR TITLE
Unable to create detached pool

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/test_service_builder.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_service_builder.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
-from pprint import PrettyPrinter
 from tempest import config
 from tempest.lib.common.utils import data_utils
 from tempest import test
@@ -32,11 +30,14 @@ class ServiceBuilderTestJSON(base.BaseTestCase):
         if not test.is_extension_enabled('lbaasv2', 'network'):
             msg = "lbaas extension not enabled."
             raise cls.skipException(msg)
+        cls.subnet = cls.get_tenant_network()
+
         cls.network_name = data_utils.rand_name('network')
         cls.network = cls.create_network(cls.network_name)
         cls.subnet = cls.create_subnet(cls.network)
         cls.create_lb_kwargs = {'tenant_id': cls.subnet['tenant_id'],
                                 'vip_subnet_id': cls.subnet['id']}
+
         cls.load_balancer = \
             cls._create_active_load_balancer(**cls.create_lb_kwargs)
         cls.load_balancer_id = cls.load_balancer['id']
@@ -58,23 +59,18 @@ class ServiceBuilderTestJSON(base.BaseTestCase):
             cls._create_pool(**cls.create_pool_kwargs))
         cls.pool_id = cls.pool['id']
 
-        # create second pool with no listener (detached)
-        cls.create_detached_pool_kwargs = {
-            'loadbalancer_id': cls.load_balancer_id,
-            'protocol': 'HTTPS',
-            'description': 'DETACHED pool',
-            'lb_algorithm': 'ROUND_ROBIN'}
-
-        cls.detached_pool = (
-            cls._create_pool(**cls.create_detached_pool_kwargs))
-        cls.detached_pool_id = cls.detached_pool['id']
-
         # create member
         cls.create_member_kwargs = {'address': '10.2.2.3',
                                     'protocol_port': 8080,
                                     'subnet_id': cls.subnet['id']}
         cls.member = (
             cls._create_member(cls.pool_id, **cls.create_member_kwargs))
+
+        cls.create_monitor_kwargs = {'pool_id': cls.pool_id,
+                                     'type': 'HTTP',
+                                     'delay': 1,
+                                     'timeout': 1,
+                                     'max_retries': 5}
 
         # get an RPC client for calling into driver
         cls.client = cls.plugin_rpc.get_client()
@@ -88,8 +84,6 @@ class ServiceBuilderTestJSON(base.BaseTestCase):
         # get service object from driver
         res = self.client.call(self.context, "get_service_by_loadbalancer_id",
                                loadbalancer_id=self.load_balancer_id)
-        pp = PrettyPrinter(indent=2)
-        pp.pprint(res)
 
         # loadbalancer
         self.assertEqual(self.load_balancer_id,
@@ -104,17 +98,12 @@ class ServiceBuilderTestJSON(base.BaseTestCase):
                                 self.create_listener_kwargs)
 
         # check attached pool
-        self.assertEqual(2,
+        self.assertEqual(1,
                          len(res['pools']),
-                         message="Expected 2 pools.")
+                         message="Expected 1 pool.")
         self.check_lbaas_object(
             self.find_object(self.pool_id, res['pools']),
             self.create_pool_kwargs)
-
-        # check detached pool
-        self.check_lbaas_object(
-            self.find_object(self.detached_pool_id, res['pools']),
-            self.create_detached_pool_kwargs)
 
         # members
         self.assertEqual(1,
@@ -150,4 +139,6 @@ class ServiceBuilderTestJSON(base.BaseTestCase):
 
     @test.attr(type='smoke')
     def test_service_builder(self):
+
+        self._create_health_monitor(**self.create_monitor_kwargs)
         self.check_service_object()

--- a/f5lbaasdriver/test/tempest/tests/api/test_service_builder.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_service_builder.py
@@ -1,0 +1,153 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from pprint import PrettyPrinter
+from tempest import config
+from tempest.lib.common.utils import data_utils
+from tempest import test
+
+from f5lbaasdriver.test.tempest.tests.api import base
+
+
+CONF = config.CONF
+
+
+class ServiceBuilderTestJSON(base.BaseTestCase):
+    """F5 driver service builder tests."""
+
+    @classmethod
+    def resource_setup(cls):
+        super(ServiceBuilderTestJSON, cls).resource_setup()
+        if not test.is_extension_enabled('lbaasv2', 'network'):
+            msg = "lbaas extension not enabled."
+            raise cls.skipException(msg)
+        cls.network_name = data_utils.rand_name('network')
+        cls.network = cls.create_network(cls.network_name)
+        cls.subnet = cls.create_subnet(cls.network)
+        cls.create_lb_kwargs = {'tenant_id': cls.subnet['tenant_id'],
+                                'vip_subnet_id': cls.subnet['id']}
+        cls.load_balancer = \
+            cls._create_active_load_balancer(**cls.create_lb_kwargs)
+        cls.load_balancer_id = cls.load_balancer['id']
+
+        # create listener
+        cls.create_listener_kwargs = {'loadbalancer_id': cls.load_balancer_id,
+                                      'protocol': 'HTTP',
+                                      'protocol_port': 80}
+        cls.listener = (
+            cls._create_listener(**cls.create_listener_kwargs))
+        cls.listener_id = cls.listener['id']
+
+        # create pool for listener
+        cls.create_pool_kwargs = {'listener_id': cls.listener_id,
+                                  'protocol': 'HTTP',
+                                  'description': 'ATTACHED pool',
+                                  'lb_algorithm': 'ROUND_ROBIN'}
+        cls.pool = (
+            cls._create_pool(**cls.create_pool_kwargs))
+        cls.pool_id = cls.pool['id']
+
+        # create second pool with no listener (detached)
+        cls.create_detached_pool_kwargs = {
+            'loadbalancer_id': cls.load_balancer_id,
+            'protocol': 'HTTPS',
+            'description': 'DETACHED pool',
+            'lb_algorithm': 'ROUND_ROBIN'}
+
+        cls.detached_pool = (
+            cls._create_pool(**cls.create_detached_pool_kwargs))
+        cls.detached_pool_id = cls.detached_pool['id']
+
+        # create member
+        cls.create_member_kwargs = {'address': '10.2.2.3',
+                                    'protocol_port': 8080,
+                                    'subnet_id': cls.subnet['id']}
+        cls.member = (
+            cls._create_member(cls.pool_id, **cls.create_member_kwargs))
+
+        # get an RPC client for calling into driver
+        cls.client = cls.plugin_rpc.get_client()
+        cls.context = cls.plugin_rpc.get_context()
+
+    @classmethod
+    def resource_cleanup(cls):
+        super(ServiceBuilderTestJSON, cls).resource_cleanup()
+
+    def check_service_object(self):
+        # get service object from driver
+        res = self.client.call(self.context, "get_service_by_loadbalancer_id",
+                               loadbalancer_id=self.load_balancer_id)
+        pp = PrettyPrinter(indent=2)
+        pp.pprint(res)
+
+        # loadbalancer
+        self.assertEqual(self.load_balancer_id,
+                         res['loadbalancer']['id'],
+                         message="Invalid loadbalancer ID")
+
+        # listeners
+        self.assertEqual(1,
+                         len(res['listeners']),
+                         message="Expected 1 listener.")
+        self.check_lbaas_object(res['listeners'][0],
+                                self.create_listener_kwargs)
+
+        # check attached pool
+        self.assertEqual(2,
+                         len(res['pools']),
+                         message="Expected 2 pools.")
+        self.check_lbaas_object(
+            self.find_object(self.pool_id, res['pools']),
+            self.create_pool_kwargs)
+
+        # check detached pool
+        self.check_lbaas_object(
+            self.find_object(self.detached_pool_id, res['pools']),
+            self.create_detached_pool_kwargs)
+
+        # members
+        self.assertEqual(1,
+                         len(res['members']),
+                         message="Expected 1 member.")
+
+        # subnets
+        self.assertIsNotNone(res['subnets'],
+                             message="Expected subnets in service object.")
+
+        # networks
+        self.assertIsNotNone(res['networks'],
+                             message="Expected networks in service object.")
+
+    def check_lbaas_object(self, lbaas_obj, kwargs):
+        for key in kwargs:
+            # skip args like 'loadbalancer_id'
+            if "_id" not in key:
+                self.assertIn(key,
+                              lbaas_obj,
+                              message="Excpected key {0} in object.".format(
+                                  key))
+                self.assertEqual(kwargs[key],
+                                 lbaas_obj[key],
+                                 message="Expected value {0} for key {1}".
+                                 format(kwargs[key], key))
+
+    def find_object(self, id, list):
+        for obj in list:
+            if obj['id'] == id:
+                return obj
+        return None
+
+    @test.attr(type='smoke')
+    def test_service_builder(self):
+        self.check_service_object()

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""Service Module for F5® LBaaSv2."""
-# Copyright 2014 F5 Networks Inc.
+# Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -125,61 +125,13 @@ class LBaaSv2ServiceBuilder(object):
                     )
 
             # Get listeners and pools.
-            service['listeners'] = []
-            service['pools'] = []
-            listeners = self.plugin.db.get_listeners(
-                context,
-                filters={'loadbalancer_id': [loadbalancer.id]}
-            )
-            for listener in listeners:
-                listener_dict = listener.to_dict(
-                    loadbalancer=False,
-                    default_pool=False
-                )
-                if listener.default_pool:
-                    listener_dict['default_pool_id'] = listener.default_pool.id
+            service['listeners'] = self._get_listeners(context, loadbalancer)
 
-                service['listeners'].append(listener_dict)
+            service['pools'], service['healthmonitors'] = \
+                self._get_pools_and_healthmonitors(context, loadbalancer)
 
-                if listener.default_pool:
-                    pool = self.plugin.db.get_pool(
-                        context,
-                        listener.default_pool.id)
-                    pool_dict = pool.to_api_dict()
-                    pool_dict['provisioning_status'] = pool.provisioning_status
-                    pool_dict['operating_status'] = pool.operating_status
-                    service['pools'].append(pool_dict)
-
-            # Pools have multiple members and one healthmonitor.  Iterate
-            # over the list of pools, and popuate the service with members
-            # and healthmonitors.
-            service['members'] = []
-            service['healthmonitors'] = []
-            for pool in service['pools']:
-                pool_id = pool['id']
-                members = self.plugin.db.get_pool_members(
-                    context,
-                    filters={'pool_id': [pool_id]}
-                )
-                for member in members:
-                    # Get extended member attributes, network, and subnet.
-                    (member_dict, subnet, network) = (
-                        self._get_extended_member(context, member)
-                    )
-                    subnet_map[subnet['id']] = subnet
-                    network_map[network['id']] = network
-                    service['members'].append(member_dict)
-
-                healthmonitor_id = pool['healthmonitor_id']
-                if healthmonitor_id:
-                    healthmonitor = self.plugin.db.get_healthmonitor(
-                        context,
-                        healthmonitor_id)
-                    if healthmonitor:
-                        healthmonitor_dict = healthmonitor.to_dict(pool=False)
-                        healthmonitor_dict['pool_id'] = pool_id
-                        service['healthmonitors'].append(
-                            healthmonitor_dict)
+            service['members'] = self._get_members(
+                context, service['pools'], subnet_map, network_map)
 
             service['subnets'] = subnet_map
             service['networks'] = network_map
@@ -456,3 +408,92 @@ class LBaaSv2ServiceBuilder(object):
                 l7policy_rules[index]['policy_id'] = pol['id']
 
         return l7policy_rules
+
+    @log_helpers.log_method_call
+    def _get_listeners(self, context, loadbalancer):
+        listeners = []
+        db_listeners = self.plugin.db.get_listeners(
+            context,
+            filters={'loadbalancer_id': [loadbalancer.id]}
+        )
+
+        for listener in db_listeners:
+            listener_dict = listener.to_api_dict()
+            if listener.default_pool:
+                listener_dict['default_pool_id'] = listener.default_pool.id
+
+            listeners.append(listener_dict)
+
+        return listeners
+
+    @log_helpers.log_method_call
+    def _get_pools_and_healthmonitors(self, context, loadbalancer):
+        """Return list of pools and list of healthmonitors as dicts."""
+        healthmonitors = []
+        pools = []
+
+        if loadbalancer and loadbalancer.id:
+            db_pools = self.plugin.db.get_pools(
+                context,
+                filters={'loadbalancer_id': [loadbalancer.id]}
+            )
+
+            for pool in db_pools:
+                pools.append(self._pool_to_dict(pool))
+                pool_id = pool.id
+                healthmonitor_id = pool.healthmonitor_id
+                if healthmonitor_id:
+                    healthmonitor = self.plugin.db.get_healthmonitor(
+                        context,
+                        healthmonitor_id)
+                    if healthmonitor:
+                        healthmonitor_dict = healthmonitor.to_api_dict()
+                        healthmonitor_dict['pool_id'] = pool_id
+                        healthmonitors.append(healthmonitor_dict)
+
+        return pools, healthmonitors
+
+    @log_helpers.log_method_call
+    def _get_members(self, context, pools, subnet_map, network_map):
+        pool_members = []
+        if pools:
+            members = self.plugin.db.get_pool_members(
+                context,
+                filters={'pool_id': [p['id'] for p in pools]}
+            )
+
+            for member in members:
+                # Get extended member attributes, network, and subnet.
+                member_dict, subnet, network = (
+                    self._get_extended_member(context, member)
+                )
+
+                subnet_map[subnet['id']] = subnet
+                network_map[network['id']] = network
+                pool_members.append(member_dict)
+
+        return pool_members
+
+    @log_helpers.log_method_call
+    def _pool_to_dict(self, pool):
+        """Convert Pool data model to dict.
+
+        Provides an alternative to_api_dict() in order to get additional
+        object IDs without exploding object references.
+        """
+
+        pool_dict = pool.to_dict(healthmonitor=False,
+                                 listener=False,
+                                 listeners=False,
+                                 loadbalancer=False,
+                                 members=False)
+
+        pool_dict['members'] = [{'id': member.id} for member in pool.members]
+        pool_dict['listeners'] = [{'id': listener.id}
+                                  for listener in pool.listeners]
+        if pool.listener:
+            pool_dict['listener_id'] = pool.listener.id
+        else:
+            pool_dict['listener_id'] = None
+
+        return pool_dict


### PR DESCRIPTION
@richbrowne, @pjbreaux 
#### What issues does this address?
Fixes #155 

#### What's this change do?
Refactors service builder to create a list of pools independent of listeners. Previously, only pools attached to a listener were included in the service object.

#### Where should the reviewer start?
service_builder.py

#### Any background context?
No

Issues:
Fixes #155

Problem: Unable to create a pool not bound to a listener.

Analysis: Refactored service builder to create list of pools
independent of listeners.

Tests: unit test, tempest functional test