### PR TITLE
Fix broken unit tests

### DIFF
--- a/f5lbaasdriver/v2/bigip/test/test_service_builder.py
+++ b/f5lbaasdriver/v2/bigip/test/test_service_builder.py
@@ -29,9 +29,15 @@ class FakeDict(dict):
 
     def __getattr__(self, item):
         """Needed for using as a model object"""
-        return self[item]
+        if item in self:
+            return self[item]
+        else:
+            return None
 
     def to_api_dict(self):
+        return self
+
+    def to_dict(self, **kwargs):
         return self
 
 
@@ -42,8 +48,10 @@ def _uuid():
 
 @pytest.fixture
 def listeners():
-    return [FakeDict(default_pool=FakeDict()),
-            FakeDict(default_pool=FakeDict())]
+    return [FakeDict(default_pool=FakeDict(),
+                     l7_policies=[]),
+            FakeDict(default_pool=FakeDict(),
+                     l7_policies=[])]
 
 
 @pytest.fixture


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #287 

#### What's this change do?
Fix broken unit tests by modifying FactDict class definition, and adding missing attributes for listeners.

#### Where should the reviewer start?
test_service_builder.py

#### Any background context?
No

Issues:
Fixes #287

Problem: test_service_builder.py broken by changes to
service_builder.py

Analysis: Modified FakeDict definitions.

Tests: test_service_builder.py