### PR TITLE
 	Fixes needed for refactored driver_v2 module

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -301,7 +301,14 @@ class PoolManager(EntityManager):
     """PoolManager class handles Neutron LBaaS pool CRUD."""
 
     def _get_pool_dict(self, pool):
-        pool_dict = pool.to_api_dict()
+        pool_dict = pool.to_dict(
+            healthmonitor=False,
+            listener=False,
+            listeners=False,
+            loadbalancer=False,
+            l7_policies=False,
+            members=False,
+            session_persistence=False)
         pool_dict['provisioning_status'] = pool.provisioning_status
         pool_dict['operating_status'] = pool.operating_status
         return pool_dict


### PR DESCRIPTION
@richbrowne @jlongstaf 

#### What issues does this address?
Fixes #285 

#### What's this change do?
Addresses the bugs I introduced into the driver_v2 when I refactored that module. I have run the neutron-lbaas tempest tests and my unit tests against this code. The results are shown in a comment below.

#### Where should the reviewer start?
Start at the changes to the driver_v2 module, then move onto the unit tests.

#### Any background context?
Before the refactor broke things, it was supposed to commonize functions in the driver_v2 to prevent the repetitive code existing in that module. It now accomplishes that.