### PR TITLE
edit teardown command target to load correct TLC_SESSION

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -54,5 +54,5 @@ tempest_tests-run:
 	docker push `cat registry_fullname`_test_results
 
 tempest_tests-teardown:
-	. tlc_session && ssh -oStrictHostKeyChecking=no -A builder@$(BAHAMAS)  "/tools/bin/tlc --sid \
+	. ./tlc_session && ssh -oStrictHostKeyChecking=no -A builder@$(BAHAMAS)  "/tools/bin/tlc --sid \
         $${TLC_SESSION} cleanup"

--- a/systest/scripts/tempest_v2driver_install.sh
+++ b/systest/scripts/tempest_v2driver_install.sh
@@ -7,7 +7,7 @@ BRANCH=$3
 SUBJECTCODE_ID=$4
 USER=$5
 
-CONTROLLER_IPADDR=`ssh -A builder@${BAHAMAS}\
+CONTROLLER_IPADDR=`ssh -oStrictHostKeyChecking=no -A builder@${BAHAMAS}\
               "/tools/bin/tlc --sid ${TESTSESSION} symbols "\
               "| grep -e'openstack_controller.*_data_direct' "\
               "| cut -d':' -f2 | tr -d '[:space:]'"`


### PR DESCRIPTION
@mattgreene 

Turning off StrictHostKeyChecking is just for convenience it can be turned back on when we add bahamas ssh key to the buildbot worker.
