### PR TITLE
Agent RPC module (agent_rpc.py) needs to have interfaces added for po…

### DIFF
--- a/f5lbaasdriver/v2/bigip/agent_rpc.py
+++ b/f5lbaasdriver/v2/bigip/agent_rpc.py
@@ -272,3 +272,77 @@ class LBaaSv2AgentRPC(object):
                 service=service
             ),
             topic=topic)
+
+    @log_helpers.log_method_call
+    def create_l7policy(self, context, l7policy, service, host):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'create_l7policy',
+                l7policy=l7policy,
+                service=service
+            ),
+            topic=topic)
+
+    @log_helpers.log_method_call
+    def update_l7policy(self, context, old_l7policy, l7policy, service, host):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'update_l7policy',
+                old_l7policy=old_l7policy,
+                l7policy=l7policy,
+                service=service
+            ),
+            topic=topic)
+
+    @log_helpers.log_method_call
+    def delete_l7policy(self, context, l7policy, service, host):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'delete_l7policy',
+                l7policy=l7policy,
+                service=service
+            ),
+            topic=topic)
+
+    @log_helpers.log_method_call
+    def create_l7rule(self, context, l7rule, service, host):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'create_l7rule',
+                l7rule=l7rule,
+                service=service
+            ),
+            topic=topic)
+
+    @log_helpers.log_method_call
+    def update_l7rule(self, context, old_l7rule, l7rule, service, host):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'update_l7rule',
+                old_l7rule=old_l7rule,
+                l7rule=l7rule,
+                service=service
+            ),
+            topic=topic)
+
+    @log_helpers.log_method_call
+    def delete_l7rule(self, context, l7rule, service, host):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'delete_l7rule',
+                l7rule=l7rule,
+                service=service
+            ),
+            topic=topic)

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -22,7 +22,7 @@ from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 from oslo_utils import importutils
 
-from neutron.common import constants as q_const
+from neutron_lib import constants as q_const
 from neutron.extensions import portbindings
 from neutron.plugins.common import constants as plugin_constants
 

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -22,9 +22,9 @@ from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 from oslo_utils import importutils
 
-from neutron_lib import constants as q_const
 from neutron.extensions import portbindings
 from neutron.plugins.common import constants as plugin_constants
+from neutron_lib import constants as q_const
 
 from neutron_lbaas.db.loadbalancer import models
 from neutron_lbaas.extensions import lbaas_agentschedulerv2

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -439,12 +439,23 @@ class L7PolicyManager(EntityManager):
         self._call_rpc(context, policy, 'create_l7policy')
 
     @log_helpers.log_method_call
-    def update(self, context, policy):
+    def update(self, context, old_policy, policy):
         """Update a policy."""
 
+        driver = self.driver
         self.loadbalancer = policy.listener.loadbalancer
-        self.api_dict = policy.to_dict(listener=False)
-        self._call_rpc(context, policy, 'update_l7policy')
+        try:
+            agent_host, service = self._setup_crud(context, policy)
+            driver.agent_rpc.update_l7policy(
+                context,
+                old_policy.to_dict(listener=False),
+                policy.to_dict(listener=False),
+                service,
+                agent_host
+            )
+        except Exception as e:
+            LOG.error("Exception: l7policy update: %s" % e.message)
+            raise e
 
     @log_helpers.log_method_call
     def delete(self, context, policy):
@@ -467,12 +478,23 @@ class L7RuleManager(EntityManager):
         self._call_rpc(context, rule, 'create_l7rule')
 
     @log_helpers.log_method_call
-    def update(self, context, rule):
+    def update(self, context, old_rule, rule):
         """Update a rule."""
 
+        driver = self.driver
         self.loadbalancer = rule.l7policy.listener.loadbalancer
-        self.api_dict = rule.to_dict(policy=False)
-        self._call_rpc(context, rule, 'update_l7rule')
+        try:
+            agent_host, service = self._setup_crud(context, rule)
+            driver.agent_rpc.update_l7rule(
+                context,
+                old_rule.to_dict(policy=False),
+                rule.to_dict(policy=False),
+                service,
+                agent_host
+            )
+        except Exception as e:
+            LOG.error("Exception: l7rule update: %s" % e.message)
+            raise e
 
     @log_helpers.log_method_call
     def delete(self, context, rule):

--- a/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
@@ -461,10 +461,16 @@ def test_l7policymgr_create(happy_path_driver):
 def test_l7policymgr_update(happy_path_driver):
     mock_driver, mock_ctx = happy_path_driver
     l7policy_mgr = dv2.L7PolicyManager(mock_driver)
-    fake_l7policy = FakePolicy()
-    l7policy_mgr.update(mock_ctx, fake_l7policy)
+    fake_old_l7policy = FakePolicy(id='old_policy')
+    fake_new_l7policy = FakePolicy(id='new_policy')
+    l7policy_mgr.update(mock_ctx, fake_old_l7policy, fake_new_l7policy)
     assert mock_driver.agent_rpc.update_l7policy.call_args == \
-        mock.call(mock_ctx, fake_l7policy.to_dict(), {}, 'test_agent')
+        mock.call(
+            mock_ctx,
+            fake_old_l7policy.to_dict(),
+            fake_new_l7policy.to_dict(),
+            {},
+            'test_agent')
 
 
 def test_l7policymgr_delete(happy_path_driver):
@@ -488,10 +494,16 @@ def test_l7rulemgr_create(happy_path_driver):
 def test_l7rulemgr_update(happy_path_driver):
     mock_driver, mock_ctx = happy_path_driver
     l7rule_mgr = dv2.L7RuleManager(mock_driver)
-    fake_l7rule = FakeRule()
-    l7rule_mgr.update(mock_ctx, fake_l7rule)
+    fake_old_l7rule = FakeRule(id='old_rule')
+    fake_new_l7rule = FakeRule(id='new_rule')
+    l7rule_mgr.update(mock_ctx, fake_old_l7rule, fake_new_l7rule)
     assert mock_driver.agent_rpc.update_l7rule.call_args == \
-        mock.call(mock_ctx, fake_l7rule.to_dict(), {}, 'test_agent')
+        mock.call(
+            mock_ctx,
+            fake_old_l7rule.to_dict(),
+            fake_new_l7rule.to_dict(),
+            {},
+            'test_agent')
 
 
 def test_l7rulemgr_delete(happy_path_driver):


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #291

#### What's this change do?

Problem: Need to add interfaces to agent_rpc.py for L7 policy and rule commands.

Analysis: added methods to support create/update/delete of L7 policy and
L7 rules.

Tests: