### PR TITLE
adding image_ref for scenario tests

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -57,5 +57,6 @@ tempest_tests-run:
 	docker push `cat registry_fullname`_test_results
 
 tempest_tests-teardown:
-	. ./tlc_session && ssh -oStrictHostKeyChecking=no -A builder@$(BAHAMAS) \
-    "/tools/bin/tlc --sid $${TLC_SESSION} cleanup"
+	. ./tlc_session && ssh -oStrictHostKeyChecking=no -A builder@$(BAHAMAS)  "/tools/bin/tlc --sid \
+        $${TLC_SESSION} cmd uninstall_barbican && /tools/bin/tlc --sid $${TLC_SESSION} cleanup"
+

--- a/systest/scripts/tempest_v2driver_install.sh
+++ b/systest/scripts/tempest_v2driver_install.sh
@@ -24,8 +24,8 @@ PUBLIC_NETWORK_ID=`${SSH_WITH_KEYSTONE} "neutron net-list -F id -F name "\
     "| grep external_network | cut -d '|' -f 2  | tr -d '[:space:]' 2>/dev/null"`
 OS_TENANT_ID=`${SSH_WITH_KEYSTONE} "keystone tenant-list "\
     "| grep testlab | cut -d '|' -f 2  | tr -d '[:space:]' 2>/dev/null"`
-IMAGE_REF=`${SSH_WITH_KEYSTONE} "glance image-list"\ 
-    "| grep cirros-0.3.4-x86_64-disk.qcow2 | cut -d '|' -f 2 | tr -d '[:space:]' 2>/dev/null`
+IMAGE_REF=`${SSH_WITH_KEYSTONE} "glance image-list"\
+    "| grep cirros-0.3.4-x86_64-disk.qcow2 | cut -d '|' -f 2 | tr -d '[:space:]' 2>/dev/null"`
 
 # post processing ('prepend export=') NOTE: OS_AUTH_URL needs no modification
 CONTROLLER_IPADDR="export CONTROLLER_IPADDR="${CONTROLLER_IPADDR}

--- a/systest/scripts/tempest_v2driver_install.sh
+++ b/systest/scripts/tempest_v2driver_install.sh
@@ -24,7 +24,8 @@ PUBLIC_NETWORK_ID=`${SSH_WITH_KEYSTONE} "neutron net-list -F id -F name "\
     "| grep external_network | cut -d '|' -f 2  | tr -d '[:space:]' 2>/dev/null"`
 OS_TENANT_ID=`${SSH_WITH_KEYSTONE} "keystone tenant-list "\
     "| grep testlab | cut -d '|' -f 2  | tr -d '[:space:]' 2>/dev/null"`
-
+IMAGE_REF=`${SSH_WITH_KEYSTONE} "glance image-list"\ 
+    "| grep cirros-0.3.4-x86_64-disk.qcow2 | cut -d '|' -f 2 | tr -d '[:space:]' 2>/dev/null`
 
 # post processing ('prepend export=') NOTE: OS_AUTH_URL needs no modification
 CONTROLLER_IPADDR="export CONTROLLER_IPADDR="${CONTROLLER_IPADDR}
@@ -34,6 +35,7 @@ OS_AUTH_URL_V3="export OS_AUTH_URL_V3"${OS_AUTH_URL_V3#export OS_AUTH_URL}
 PUBLIC_ROUTER_ID="export PUBLIC_ROUTER_ID="${PUBLIC_ROUTER_ID}
 PUBLIC_NETWORK_ID="export PUBLIC_NETWORK_ID="${PUBLIC_NETWORK_ID}
 OS_TENANT_ID="export OS_TENANT_ID="${OS_TENANT_ID}
+IMAGE_REF="export IMAGE_REF="${IMAGE_REF}
 
 echo ${CONTROLLER_IPADDR} > tempest_variables
 echo ${ICONTROL_IPADDR} >> tempest_variables
@@ -42,6 +44,7 @@ echo ${OS_AUTH_URL_V3} >> tempest_variables
 echo ${PUBLIC_ROUTER_ID} >> tempest_variables
 echo ${PUBLIC_NETWORK_ID} >> tempest_variables
 echo ${OS_TENANT_ID} >> tempest_variables
+echo ${IMAGE_REF} >> tempest_variables
 
 . ./tempest_variables &&
 


### PR DESCRIPTION
@zancas 
#### What issues does this address?
Fixes #296 #320 


#### What's this change do?
This change will find the ID of Cirros image and save it as tempest_variables and then it will pass it to the docker container.
Also it will cleanup Barbican sessions as part of Stack cleanup step.

