### PR TITLE
L7 rule and policy status updates to neutron fail

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -391,7 +391,8 @@ class LBaaSv2PluginCallbacksRPC(object):
             self,
             context,
             l7policy_id=None,
-            provisioning_status=plugin_constants.ERROR):
+            provisioning_status=plugin_constants.ERROR,
+            operating_status=None):
         """Agent confirmation hook to update l7 policy status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -406,7 +407,8 @@ class LBaaSv2PluginCallbacksRPC(object):
                     context,
                     models.L7Policy,
                     l7policy_id,
-                    provisioning_status
+                    provisioning_status,
+                    operating_status
                 )
             except Exception as e:
                 LOG.error('Exception: update_l7policy_status: %s',
@@ -414,6 +416,7 @@ class LBaaSv2PluginCallbacksRPC(object):
 
     @log_helpers.log_method_call
     def l7policy_destroyed(self, context, l7policy_id=None):
+        LOG.debug("l7policy_destroyed")
         """Agent confirmation hook that l7 policy has been destroyed."""
         self.driver.plugin.db.delete_l7policy(context, l7policy_id)
 
@@ -423,7 +426,8 @@ class LBaaSv2PluginCallbacksRPC(object):
             context,
             l7rule_id=None,
             l7policy_id=None,
-            provisioning_status=plugin_constants.ERROR):
+            provisioning_status=plugin_constants.ERROR,
+            operating_status=None):
         """Agent confirmation hook to update l7 policy status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -439,10 +443,11 @@ class LBaaSv2PluginCallbacksRPC(object):
                     context,
                     models.L7Rule,
                     l7rule_id,
-                    provisioning_status
+                    provisioning_status,
+                    operating_status
                 )
             except Exception as e:
-                LOG.error('Exception: update_l7policy_status: %s',
+                LOG.error('Exception: update_l7rule_status: %s',
                           e.message)
 
     @log_helpers.log_method_call

--- a/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
@@ -87,7 +87,7 @@ class FakeRule(FakeBaseObj):
     def __init__(self, id='test_obj_id', attached_to_lb=True):
         super(FakeRule, self).__init__(id=id, attached_to_lb=attached_to_lb)
         self.id = id
-        self.l7policy = FakePolicy()
+        self.policy = FakePolicy()
 
 
 @pytest.fixture


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #300 

#### What's this change do?
adds operating_status parameter to l7policy and rule update_status metjhods.

#### Where should the reviewer start?
plugin_rpc.py

#### Any background context?

Issues:
Fixes #300

Problem: calls to update_l7policy_status() and
update_l7rule_status() fail.

Analysis: Methods need to include operating_status parameters.
Added parameters.

Tests: Manual.