### PR TITLE
Fix plugin_rpc to use get_agents_in_env()

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -157,11 +157,13 @@ class LBaaSv2PluginCallbacksRPC(object):
         plugin = self.driver.plugin
 
         with context.session.begin(subtransactions=True):
-            agents = self.driver.scheduler.get_active_agents_in_env(
+            agents = self.driver.scheduler.get_agents_in_env(
                 context,
                 self.driver.plugin,
                 env,
-                group)
+                group=group,
+                active=True
+            )
 
             for agent in agents:
                 agent_lbs = plugin.db.list_loadbalancers_on_lbaas_agent(


### PR DESCRIPTION
@pjbreaux 


#### What's this change do?
The function get_active_agents_in_env is going away, so the
plugin rpc call that uses this fails, this causes problems with
the agent sync_state() when it calls get_all_loadbalancers()

#### Where should the reviewer start?

#### Any background context?

The function get_active_agents_in_env is going away, so the
plugin rpc call that uses this fails, this causes problems with
the agent sync_state()