### PR TITLE
Feature.l7switching requirements file need to have tempest setup

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,8 +2,9 @@
 git+https://github.com/F5Networks/pytest-symbols.git
 git+https://github.com/F5Networks/f5-openstack-test.git
 # TODO(paul): Must change this before it collapses into mitaka
-git+https://github.com/openstack/neutron-lbaas.git@stable/mitaka
 git+https://github.com/openstack/neutron.git@stable/mitaka
+git+https://github.com/openstack/neutron-lbaas.git@8.3.0
+git+https://github.com/openstack/tempest.git@12.0.0
 
 mock==1.3.0
 pytest==2.9.1


### PR DESCRIPTION
@jlongstaf and @richbrowne 

#### What issues does this address?
Fixes #318 

#### What's this change do?
Changed the requirements.test.txt file to have a tagged version of
tempest and neutron-lbaas

#### Where should the reviewer start?
Only one change.

#### Any background context?
The tempest tests need to have a specific version of neutron-lbaas and
tempest to run properly. This is due to the nature of tempest being a
moving target with respect to OpenStack releases. We have found a match
of these two projects at a point in time and we are running tests with
that infrastructure.