### PR TITLE
Adding tempest tests for deployment and update of multiple policies and rules

### DIFF
--- a/f5lbaasdriver/test/tempest/services/clients/bigip_client.py
+++ b/f5lbaasdriver/test/tempest/services/clients/bigip_client.py
@@ -76,53 +76,61 @@ class BigIpClient(object):
             rule = policy.rules_s.rules.load(name=rule_name)
 
             return rule.conditions_s.get_collection()
+        return []
 
-    def rule_has_condition(self, policy_name, rule_name, cond_name, partition):
+    def rule_has_condition(
+            self, policy_name, rule_name, cond_name, value, partition):
         conditions = self.rule_conditions(policy_name, rule_name, partition)
         for cond in conditions:
-            if getattr(cond, cond_name, None):
+            cond_val = getattr(cond, cond_name, None)
+            assert len(cond.values) == 1
+            value_str = cond.values[0]
+            # Condition value should be set to True if condition type is
+            # httpHost or condition comparison type is startsWith etc...
+            # The values attribute should only contain one value and it
+            # should be set to some string, even if it's empty
+            if cond_val and value_str == value:
                 return True
-
         return False
 
-    def rule_has_starts_with(self, policy_name, rule_name, partition):
+    def rule_has_starts_with(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'startsWith', partition)
+            policy_name, rule_name, 'startsWith', value, partition)
 
-    def rule_has_ends_with(self, policy_name, rule_name, partition):
+    def rule_has_ends_with(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'endsWith', partition)
+            policy_name, rule_name, 'endsWith', value, partition)
 
-    def rule_has_contains(self, policy_name, rule_name, partition):
+    def rule_has_contains(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'contains', partition)
+            policy_name, rule_name, 'contains', value, partition)
 
-    def rule_has_equals(self, policy_name, rule_name, partition):
+    def rule_has_equals(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'equals', partition)
+            policy_name, rule_name, 'equals', value, partition)
 
-    def rule_has_host_name(self, policy_name, rule_name, partition):
+    def rule_has_host_name(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'httpHost', partition)
+            policy_name, rule_name, 'httpHost', value, partition)
 
-    def rule_has_path(self, policy_name, rule_name, partition):
+    def rule_has_path(self, policy_name, rule_name, value, partition):
         has_httpUri = self.rule_has_condition(
-            policy_name, rule_name, 'httpUri', partition)
+            policy_name, rule_name, 'httpUri', value, partition)
         has_path = self.rule_has_condition(
-            policy_name, rule_name, 'path', partition)
+            policy_name, rule_name, 'path', value, partition)
         return has_httpUri and has_path
 
-    def rule_has_file_type(self, policy_name, rule_name, partition):
+    def rule_has_file_type(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'httpUri', partition)
+            policy_name, rule_name, 'httpUri', value, partition)
 
-    def rule_has_header(self, policy_name, rule_name, partition):
+    def rule_has_header(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'httpHeader', partition)
+            policy_name, rule_name, 'httpHeader', value, partition)
 
-    def rule_has_cookie(self, policy_name, rule_name, partition):
+    def rule_has_cookie(self, policy_name, rule_name, value, partition):
         return self.rule_has_condition(
-            policy_name, rule_name, 'httpCookie', partition)
+            policy_name, rule_name, 'httpCookie', value, partition)
 
     def virtual_server_exists(self, name, partition):
         return self.bigip.tm.ltm.virtuals.virtual.exists(

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -381,9 +381,10 @@ class BaseTestCase(base.BaseNetworkTest):
             cls._wait_for_load_balancer_status(cls.load_balancer.get('id'))
 
     @classmethod
-    def _update_l7rule(cls, l7rule_id, wait=True, **l7rule_kwargs):
+    def _update_l7rule(
+            cls, l7policy_id, l7rule_id, wait=True, **l7rule_kwargs):
         l7rule = cls.l7rule_client.update_l7rule(
-            l7rule_id, **l7rule_kwargs)
+            l7policy_id, l7rule_id, **l7rule_kwargs)
         if wait:
             cls._wait_for_load_balancer_status(
                 cls.load_balancer.get('id'))

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -66,30 +66,36 @@ class L7PolicyTestJSONBasic(base.BaseTestCase):
             cls._create_pool(**cls.create_pool_kwargs))
         cls.pool_id = cls.pool['id']
 
-        # Create basic args for policy creation
-        cls.create_l7policy_kwargs = {'listener_id': cls.listener_id,
-                                      'admin_state_up': "true"}
-
-        # Get a client to emulate the agent's behavior.
-        cls.client = cls.plugin_rpc.get_client()
-        cls.context = cls.plugin_rpc.get_context()
-
-
-class TestL7PolicyTestJSONReject(L7PolicyTestJSONBasic):
-    @test.attr(type='smoke')
-    def test_create_l7_reject_policy(self):
-        """Test the creationg of a L7 reject policy."""
-        create_l7policy_kwargs = self.create_l7policy_kwargs
-        create_l7policy_kwargs['action'] = "REJECT"
-
-        new_policy = self._create_l7policy(
-            **create_l7policy_kwargs)
-        self._wait_for_load_balancer_status(self.load_balancer_id)
-        self.addCleanup(self._delete_l7policy, new_policy['id'])
-        assert (new_policy['action'] == "REJECT")
+    def _create_detached_pool(self):
+        pool = {
+            'loadbalancer_id': self.load_balancer.get('id'),
+            'lb_algorithm': 'ROUND_ROBIN',
+            'protocol': 'HTTP'
+        }
+        self.detached_pool = self.pools_client.create_pool(**pool)
+        self._wait_for_load_balancer_status(self.load_balancer.get('id'))
+        self.assertTrue(self.detached_pool)
+        self.addCleanup(self._delete_pool, self.detached_pool.get('id'))
 
     def setUp(self):
-        super(TestL7PolicyTestJSONReject, self).setUp()
+        self.policies = []
+        self._create_detached_pool()
+        super(L7PolicyTestJSONBasic, self).setUp()
+
+    def tearDown(self):
+        for policy in self.policies:
+            try:
+                self._delete_l7policy(policy.get('id'))
+            except Exception as ex:
+                if 'could not be found' in str(ex):
+                    continue
+                raise
+        super(L7PolicyTestJSONBasic, self).tearDown()
+
+
+class L7PolicyJSONReject(L7PolicyTestJSONBasic):
+    def setUp(self):
+        super(L7PolicyJSONReject, self).setUp()
         self._reject_args()
 
     def _reject_args(self):
@@ -97,14 +103,27 @@ class TestL7PolicyTestJSONReject(L7PolicyTestJSONBasic):
             'listener_id': self.listener.get('id'),
             'admin_state_up': 'true', 'action': 'REJECT'}
 
+    def test_create_l7_reject_policy(self):
+        """Test the creationg of a L7 reject policy."""
+        create_l7policy_kwargs = self.reject_args
+        l7policy = self._create_l7policy(
+            **create_l7policy_kwargs)
+        self.policies.append(l7policy)
+        self._wait_for_load_balancer_status(self.load_balancer_id)
+        assert (l7policy.get('action') == "REJECT")
+        assert not self.bigip_client.policy_exists("wrapper_policy",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+
     def test_policy_reject_header_ends_with(self):
         '''Reject traffic when header value ends with value.'''
 
-        self.l7policy = self._create_l7policy(**self.reject_args)
+        l7policy = self._create_l7policy(**self.reject_args)
+        self.policies.append(l7policy)
         rule_args = {'type': 'HEADER', 'compare_type': 'ENDS_WITH',
                      'key': 'X-HEADER', 'value': 'real'}
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        self._create_l7rule(self.l7policy.get('id'), **rule_args)
+        self._create_l7rule(l7policy.get('id'), **rule_args)
 
         assert self.bigip_client.policy_exists("wrapper_policy",
                                                "Project_" +
@@ -113,33 +132,22 @@ class TestL7PolicyTestJSONReject(L7PolicyTestJSONBasic):
                                              "reject_1",
                                              "Project_" +
                                              self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "endsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
 
     def test_policy_reject_header_contains(self):
         '''Reject traffic when header value ends with value.'''
 
-        self.l7policy = self._create_l7policy(**self.reject_args)
+        l7policy = self._create_l7policy(**self.reject_args)
+        self.policies.append(l7policy)
         rule_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
                      'key': 'X-HEADER', 'value': 'es'}
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        self._create_l7rule(self.l7policy.get('id'), **rule_args)
-
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-
-    def test_policy_reject_two_rules(self):
-        self.l7policy = self._create_l7policy(**self.reject_args)
-        rule1_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
-                      'key': 'X-HEADER', 'value': 'es'}
-        rule2_args = {'type': 'HEADER', 'compare_type': 'STARTS_WITH',
-                      'key': 'X-HEADER', 'value': 'real'}
-        self._wait_for_load_balancer_status(self.load_balancer_id)
-        self.rule1 = self._create_l7rule(self.l7policy.get('id'), **rule1_args)
-        self.rule2 = self._create_l7rule(self.l7policy.get('id'), **rule2_args)
+        self._create_l7rule(l7policy.get('id'), **rule_args)
 
         assert self.bigip_client.policy_exists("wrapper_policy",
                                                "Project_" +
@@ -151,33 +159,256 @@ class TestL7PolicyTestJSONReject(L7PolicyTestJSONBasic):
         assert self.bigip_client.rule_has_condition("wrapper_policy",
                                                     "reject_1",
                                                     "contains",
+                                                    "es",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+
+    def test_policy_reject_three_rules(self):
+        l7policy = self._create_l7policy(**self.reject_args)
+        self.policies.append(l7policy)
+        rule1_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
+                      'key': 'X-HEADER', 'value': 'es'}
+        rule2_args = {'type': 'COOKIE', 'compare_type': 'STARTS_WITH',
+                      'key': 'cook', 'value': 'real'}
+        rule3_args = {'type': 'HOST_NAME', 'compare_type': 'ENDS_WITH',
+                      'value': 'test'}
+        self._wait_for_load_balancer_status(self.load_balancer_id)
+        self.rule1 = self._create_l7rule(l7policy.get('id'), **rule1_args)
+        self.rule2 = self._create_l7rule(l7policy.get('id'), **rule2_args)
+        self.rule3 = self._create_l7rule(l7policy.get('id'), **rule3_args)
+
+        assert self.bigip_client.policy_exists("wrapper_policy",
+                                               "Project_" +
+                                               self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "reject_1",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "contains",
+                                                    "es",
                                                     "Project_" +
                                                     self.project_tenant_id)
         assert self.bigip_client.rule_has_condition("wrapper_policy",
                                                     "reject_1",
                                                     "startsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "endsWith",
+                                                    "test",
                                                     "Project_" +
                                                     self.project_tenant_id)
 
-        self._delete_l7rule(self.l7policy.get('id'), self.rule1.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule1.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
         assert self.bigip_client.policy_exists("wrapper_policy",
                                                "Project_" +
                                                self.project_tenant_id)
         assert not \
-            (self.bigip_client.rule_has_condition("wrapper_policy",
-                                                  "reject_1",
-                                                  "contains",
-                                                  "Project_" +
-                                                  self.project_tenant_id))
+            self.bigip_client.rule_has_condition("wrapper_policy",
+                                                 "reject_1",
+                                                 "contains",
+                                                 "es",
+                                                 "Project_" +
+                                                 self.project_tenant_id)
         assert \
             self.bigip_client.rule_has_condition("wrapper_policy",
                                                  "reject_1",
                                                  "startsWith",
+                                                 "real",
+                                                 "Project_" +
+                                                 self.project_tenant_id)
+        assert \
+            self.bigip_client.rule_has_condition("wrapper_policy",
+                                                 "reject_1",
+                                                 "endsWith",
+                                                 "test",
                                                  "Project_" +
                                                  self.project_tenant_id)
 
-        self._delete_l7rule(self.l7policy.get('id'), self.rule2.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
+        self._wait_for_load_balancer_status(self.load_balancer_id)
+        assert not \
+            self.bigip_client.policy_exists("wrapper_policy",
+                                            "Project_" +
+                                            self.project_tenant_id)
+
+    def test_policy_reject_multi_policy_multi_rules(self):
+        l7policy1 = self._create_l7policy(**self.reject_args)
+        self.policies.append(l7policy1)
+        rule1_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
+                      'key': 'X-HEADER', 'value': 'es'}
+        rule2_args = {'type': 'COOKIE', 'compare_type': 'STARTS_WITH',
+                      'key': 'cook', 'value': 'real'}
+        self._wait_for_load_balancer_status(self.load_balancer_id)
+        self.rule1 = self._create_l7rule(l7policy1.get('id'), **rule1_args)
+        self.rule2 = self._create_l7rule(l7policy1.get('id'), **rule2_args)
+
+        l7policy2 = self._create_l7policy(**self.reject_args)
+        self.policies.append(l7policy2)
+        self.rule3 = self._create_l7rule(l7policy2.get('id'), **rule1_args)
+        self.rule4 = self._create_l7rule(l7policy2.get('id'), **rule2_args)
+
+        self._delete_l7rule(l7policy1.get('id'), self.rule1.get('id'))
+        assert self.bigip_client.policy_exists("wrapper_policy",
+                                               "Project_" +
+                                               self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "reject_1",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "reject_2",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert not self.bigip_client.rule_has_condition("wrapper_policy",
+                                                        "reject_1",
+                                                        "contains",
+                                                        "es",
+                                                        "Project_" +
+                                                        self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "startsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_2",
+                                                    "startsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_2",
+                                                    "contains",
+                                                    "es",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+
+        self._delete_l7policy(l7policy1.get('id'))
+        assert not self.bigip_client.rule_exists("wrapper_policy",
+                                                 "reject_1",
+                                                 "Project_" +
+                                                 self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "reject_2",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert self.bigip_client.policy_exists("wrapper_policy",
+                                               "Project_" +
+                                               self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_2",
+                                                    "contains",
+                                                    "es",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_2",
+                                                    "startsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        self._delete_l7policy(l7policy2.get('id'))
+        assert not \
+            self.bigip_client.policy_exists("wrapper_policy",
+                                            "Project_" +
+                                            self.project_tenant_id)
+
+    def test_policy_reject_many_rules(self):
+        l7policy = self._create_l7policy(**self.reject_args)
+        self.policies.append(l7policy)
+        rule1_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
+                      'key': 'X-HEADER', 'value': 'es'}
+        rule2_args = {'type': 'HOST_NAME', 'compare_type': 'STARTS_WITH',
+                      'value': 'real'}
+        rule3_args = {'type': 'PATH', 'compare_type': 'ENDS_WITH',
+                      'value': 'real'}
+        rule4_args = {'type': 'PATH', 'compare_type': 'STARTS_WITH',
+                      'value': 're'}
+        rule5_args = {'type': 'PATH', 'compare_type': 'CONTAINS',
+                      'value': 'al'}
+        rule6_args = {'type': 'PATH', 'compare_type': 'CONTAINS',
+                      'value': 'l'}
+        rule7_args = {'type': 'PATH', 'compare_type': 'ENDS_WITH',
+                      'value': 'ireal'}
+        self._wait_for_load_balancer_status(self.load_balancer_id)
+        self.rule1 = self._create_l7rule(l7policy.get('id'), **rule1_args)
+        self.rule2 = self._create_l7rule(l7policy.get('id'), **rule2_args)
+        self.rule3 = self._create_l7rule(l7policy.get('id'), **rule3_args)
+        self.rule4 = self._create_l7rule(l7policy.get('id'), **rule4_args)
+        self.rule5 = self._create_l7rule(l7policy.get('id'), **rule5_args)
+        self.rule6 = self._create_l7rule(l7policy.get('id'), **rule6_args)
+        self.rule7 = self._create_l7rule(l7policy.get('id'), **rule7_args)
+
+        assert self.bigip_client.policy_exists("wrapper_policy",
+                                               "Project_" +
+                                               self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "reject_1",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "contains",
+                                                    "es",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "startsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "endsWith",
+                                                    "real",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "startsWith",
+                                                    "re",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "contains",
+                                                    "al",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "contains",
+                                                    "l",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "reject_1",
+                                                    "endsWith",
+                                                    "ireal",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        self._delete_l7rule(l7policy.get('id'), self.rule1.get('id'))
+        assert not self.bigip_client.rule_has_condition("wrapper_policy",
+                                                        "reject_1",
+                                                        "contains",
+                                                        "es",
+                                                        "Project_" +
+                                                        self.project_tenant_id)
+        self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule4.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule5.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule6.get('id'))
+        self._delete_l7rule(l7policy.get('id'), self.rule7.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
         assert not \
             (self.bigip_client.policy_exists("wrapper_policy",
@@ -186,36 +417,29 @@ class TestL7PolicyTestJSONReject(L7PolicyTestJSONBasic):
 
 
 class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
-    @test.attr(type='smoke')
-    def test_create_l7_redirect_to_url_policy(self):
-        """Test the creationg of a L7 URL redirect policy."""
-        redirect_url = "http://www.mysite.com/my-widget-app"
-        create_l7policy_kwargs = self.create_l7policy_kwargs
-        create_l7policy_kwargs['action'] = "REDIRECT_TO_URL"
-        create_l7policy_kwargs['redirect_url'] = redirect_url
-        new_policy = self._create_l7policy(
-            **create_l7policy_kwargs)
-        self._wait_for_load_balancer_status(self.load_balancer_id)
-        self.addCleanup(self._delete_l7policy, new_policy['id'])
-        assert (new_policy['action'] == "REDIRECT_TO_URL")
-        assert (new_policy['redirect_url'] == redirect_url)
-
     def setUp(self):
         super(TestL7PolicyTestJSONRedirectToUrl, self).setUp()
         self._redirect_url_args()
 
     def _redirect_url_args(self):
         self.redirect_url_args = {
-            'listener_id': self.listener.get('id'),
-            'admin_state_up': 'true', 'action': 'REDIRECT_TO_URL',
-            'redirect_url': 'http://10.190.0.20'}
+            'listener_id': self.listener.get('id'), 'admin_state_up': 'true',
+            'action': 'REDIRECT_TO_URL', 'redirect_url': 'http://www.cdc.gov'}
+
+    def test_create_l7_redirect_to_url_policy(self):
+        """Test the creationg of a L7 URL redirect policy."""
+        l7policy = self._create_l7policy(
+            **self.redirect_url_args)
+        self.policies.append(l7policy)
+        self._wait_for_load_balancer_status(self.load_balancer_id)
 
     def test_policy_redirect_url_contains(self):
-        self.l7policy = self._create_l7policy(**self.redirect_url_args)
+        l7policy = self._create_l7policy(**self.redirect_url_args)
+        self.policies.append(l7policy)
         rule_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
                      'key': 'X-HEADER', 'value': 'es'}
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        self._create_l7rule(self.l7policy.get('id'), **rule_args)
+        self._create_l7rule(l7policy.get('id'), **rule_args)
         self._wait_for_load_balancer_status(self.load_balancer_id)
         assert self.bigip_client.policy_exists("wrapper_policy",
                                                "Project_" +
@@ -227,21 +451,81 @@ class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
         assert self.bigip_client.rule_has_condition("wrapper_policy",
                                                     "redirect_to_url_1",
                                                     "httpHeader",
+                                                    "es",
                                                     "Project_" +
                                                     self.project_tenant_id)
 
 
-class TestL7PolicyTestJSONRedirectToPool(L7PolicyTestJSONBasic):
-    @test.attr(type='smoke')
-    def test_create_l7_redirect_to_pool_policy(self):
-        """Test the creationg of a L7 pool redirect policy."""
-        create_l7policy_kwargs = self.create_l7policy_kwargs
-        create_l7policy_kwargs['action'] = "REDIRECT_TO_POOL"
-        create_l7policy_kwargs['redirect_pool_id'] = self.pool_id
+class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
+    def setUp(self):
+        super(L7PolicyJSONRedirectToPool, self).setUp()
+        self._redirect_pool_args()
 
-        new_policy = self._create_l7policy(
-            **create_l7policy_kwargs)
+    def _redirect_pool_args(self):
+        self.redirect_pool_args = {
+            'listener_id': self.listener.get('id'), 'admin_state_up': 'true',
+            'action': 'REDIRECT_TO_POOL',
+            'redirect_pool_id': self.detached_pool.get('id')}
+
+    def test_create_l7_redirect_to_pool_policy_file_type_contains(self):
+        """Test the creationg of a L7 pool redirect policy."""
+        l7policy = self._create_l7policy(
+            **self.redirect_pool_args)
+        self.policies.append(l7policy)
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        self.addCleanup(self._delete_l7policy, new_policy['id'])
-        assert (new_policy['action'] == "REDIRECT_TO_POOL")
-        assert (new_policy['redirect_pool_id'] == self.pool_id)
+        # File type rule cannot have contains as compare type
+        rule_args = {'type': 'FILE_TYPE', 'compare_type': 'EQUAL_TO',
+                     'value': 'jpg'}
+        self._create_l7rule(l7policy.get('id'), **rule_args)
+        assert self.bigip_client.policy_exists("wrapper_policy",
+                                               "Project_" +
+                                               self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "redirect_to_pool_1",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "redirect_to_pool_1",
+                                                    "extension",
+                                                    "jpg",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+
+    def test_create_l7_redirect_to_pool_policy_not_file_type(self):
+        """Test the creationg of a L7 pool redirect policy."""
+        l7policy = self._create_l7policy(
+            **self.redirect_pool_args)
+        self.policies.append(l7policy)
+        self._wait_for_load_balancer_status(self.load_balancer_id)
+        rule_args = {'type': 'FILE_TYPE', 'compare_type': 'EQUAL_TO',
+                     'value': 'qcow2', 'invert': True}
+        rule1 = self._create_l7rule(l7policy.get('id'), **rule_args)
+        assert self.bigip_client.policy_exists("wrapper_policy",
+                                               "Project_" +
+                                               self.project_tenant_id)
+        assert self.bigip_client.rule_exists("wrapper_policy",
+                                             "redirect_to_pool_1",
+                                             "Project_" +
+                                             self.project_tenant_id)
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "redirect_to_pool_1",
+                                                    "extension",
+                                                    "qcow2",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        # Verify same rule exists, but invert is set to True
+        assert self.bigip_client.rule_has_condition("wrapper_policy",
+                                                    "redirect_to_pool_1",
+                                                    "not_",
+                                                    "qcow2",
+                                                    "Project_" +
+                                                    self.project_tenant_id)
+        rule_args['invert'] = False
+        # Change invert to False and check if it sticks
+        self._update_l7rule(l7policy.get('id'), rule1.get('id'), **rule_args)
+        assert not self.bigip_client.rule_has_condition("wrapper_policy",
+                                                        "redirect_to_pool_1",
+                                                        "not_",
+                                                        "qcow2",
+                                                        "Project_" +
+                                                        self.project_tenant_id)

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_update.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_update.py
@@ -76,7 +76,7 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         assert self.bigip.policy_exists(policy, partition=self.partition)
 
     def check_rule(self, rule='', policy='wrapper_policy',
-                   action=None, condition=None):
+                   action=None, condition=None, value=None):
         # Validate BIG-IP has rule
         assert self.bigip.rule_exists(
             policy, rule, partition=self.partition)
@@ -87,7 +87,7 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
 
         if condition:
             assert self.bigip.rule_has_condition(
-                policy, rule, condition, partition=self.partition)
+                policy, rule, condition, value, partition=self.partition)
 
     def check_virtual_server(self):
         # Validate virtual server has policy
@@ -131,7 +131,7 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         self.check_rule(
             'reject_1',
             action=create_l7policy_rule_kwargs['action'],
-            condition='startsWith')
+            condition='startsWith', value='/api')
         self.check_virtual_server()
 
     @test.attr(type='smoke')
@@ -157,7 +157,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         self.addCleanup(self._delete_l7rule, policy1_id, rule1['id'])
 
         self.check_policy()
-        self.check_rule('reject_1')
+        self.check_rule(rule='reject_1', action='REJECT',
+                        condition='startsWith', value='/api')
         self.check_virtual_server()
 
         policy2 = self._create_l7policy(
@@ -172,7 +173,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         self.addCleanup(self._delete_l7rule, policy2_id, rule2['id'])
 
         self.check_policy()
-        self.check_rule('redirect_to_url_2')
+        self.check_rule('redirect_to_url_2', action='REDIRECT_TO_URL',
+                        condition='endsWith', value='.org')
         self.check_virtual_server()
 
     @test.attr(type='smoke')
@@ -198,7 +200,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         self.addCleanup(self._delete_l7rule, policy1_id, rule1['id'])
 
         self.check_policy()
-        self.check_rule('reject_1')
+        self.check_rule('reject_1', action='REJECT', condition='startsWith',
+                        value='/api')
         self.check_virtual_server()
 
         policy2 = self._create_l7policy(
@@ -211,7 +214,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         self.addCleanup(self._delete_l7rule, policy2_id, rule2['id'])
 
         self.check_policy()
-        self.check_rule('redirect_to_url_2')
+        self.check_rule('redirect_to_url_2', action='REDIRECT_TO_URL',
+                        condition='endsWith', value='.jpg')
         self.check_virtual_server()
 
         update_rule_kwargs = {'position': 2}
@@ -219,8 +223,10 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
 
         # redirect should now be first
         self.check_policy()
-        self.check_rule('redirect_to_url_1')
-        self.check_rule('reject_2')
+        self.check_rule('redirect_to_url_1', action='REDIRECT_TO_URL',
+                        condition='endsWith', value='.jpg')
+        self.check_rule('reject_2', action='REJECT', condition='startsWith',
+                        value='/api')
         self.check_virtual_server()
 
     @test.attr(type='smoke')
@@ -238,7 +244,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         rule_id = rule['id']
 
         self.check_policy()
-        self.check_rule('reject_1')
+        self.check_rule('reject_1', action='REJECT', condition='startsWith',
+                        value='/api')
         self.check_virtual_server()
 
         # remove both rule and policy and expect policy removed from BIG-IP
@@ -265,7 +272,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         rule_id = rule['id']
 
         self.check_policy()
-        self.check_rule('reject_1')
+        self.check_rule('reject_1', action='REJECT', condition='startsWith',
+                        value='/api')
         self.check_virtual_server()
 
         # remove rule and expect policy removed from BIG-IP
@@ -291,7 +299,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         rule1_id = rule1['id']
 
         self.check_policy()
-        self.check_rule('reject_1')
+        self.check_rule('reject_1', action='REJECT', condition='startsWith',
+                        value='/api')
         self.check_virtual_server()
 
         rule2 = self._create_l7rule(
@@ -299,7 +308,8 @@ class L7PolicyRulesTestJSON(base.BaseTestCase):
         rule2_id = rule2['id']
         self.addCleanup(self._delete_l7rule, policy_id, rule2_id)
         self.check_policy()
-        self.check_rule('reject_1')
+        self.check_rule('reject_1', action='REJECT', condition='endsWith',
+                        value='/api')
         self.check_virtual_server()
 
         # remove first rule leaving second and expect new policy on BIG-IP


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #324 

#### What's this change do?
Added a couple of new tests and changed the validation of all api tests to check the value of a condition in addition to the comparison type.  This means checking that header is equal to 'test', instead of just checking whether a condition exists that checks a header. This allows us to distinguish between different header conditions in the same rule

#### Where should the reviewer start?
Start at the changes to the bigip client first.

#### Any background context?
New tests are needed to validate whether the agent does the correct thing when policies with multiple rules are deleted or when rules are deleted in varying orders. Also need to added validation that the proper conditions exist on the device when a rule is deployed. This is just test effort