### PR TITLE
Tenant folder remains after deleting last loadbalancer

### DIFF
--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -81,7 +81,7 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
             return lbaas_agent
 
     def get_agents_in_env(
-            self, context, plugin, env, group=None, active=False):
+            self, context, plugin, env, group=None, active=None):
         """Get an active agents in the specified environment."""
         return_agents = []
 


### PR DESCRIPTION
@pjbreaux 

#### What issues does this address?
Fixes #329 


Issues:
Fixes #329

Problem:
When When creating and destroying a loadbalancer on Mitaka release,
the virtual address is removed, but the tenant folder, disconnected
network, and route domain remain.

Analysis:
The agent calls the driver to get a list of loadbalancers in the
tenant.  If this list has one remaining loadbalancer, then the
folder should be removed but this list is empty.

This error was in the call to get_agents_in_env which calls the
get_lbaas_agents() plugin method with active set to False.  This
should be None to get all loadbalancers regardless of admin_status.

Tests:
Create/delete loadbalancer -- test to ensure that the loadbalancer
tenant is removed.