### PR TITLE
Merge feature.lb-stats into liberty

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
@@ -1,0 +1,160 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pprint
+import requests
+import time
+
+from neutron_lbaas.tests.tempest.v2.scenario import base
+from tempest import config
+from tempest.scenario import network_resources as net_resources
+
+config = config.CONF
+
+
+class F5StatsBaseTestCase(base.BaseTestCase):
+
+    def setUp(self):
+        super(F5StatsBaseTestCase, self).setUp()
+        self.members = {}
+        self._create_servers()
+        self._start_servers()
+        self._create_load_balancer()
+        self._create_member(
+            self.server_fixed_ips[self.servers['primary']],
+            'primary',
+            load_balancer_id=self.load_balancer.get('id'),
+            pool_id=self.pool.get('id'),
+            subnet_id=self.subnet.get('id'))
+        self._create_member(
+            self.server_fixed_ips[self.servers['secondary']],
+            'secondary',
+            load_balancer_id=self.load_balancer.get('id'),
+            pool_id=self.pool.get('id'),
+            subnet_id=self.subnet.get('id'))
+        self._wait_for_load_balancer_status(self.load_balancer.get('id'))
+
+    def _create_load_balancer(self, ip_version=4, persistence_type=None):
+        self.create_lb_kwargs = {'tenant_id': self.tenant_id,
+                                 'vip_subnet_id': self.subnet['id']}
+        self.load_balancer = self.load_balancers_client.create_load_balancer(
+            **self.create_lb_kwargs)
+        load_balancer_id = self.load_balancer['id']
+        self.addCleanup(self._cleanup_load_balancer, load_balancer_id)
+        self._wait_for_load_balancer_status(load_balancer_id)
+
+        listener = self._create_listener(load_balancer_id=load_balancer_id)
+        self._wait_for_load_balancer_status(load_balancer_id)
+        self.listener_id = listener.get('id')
+
+        self.pool = self._create_pool(listener_id=listener.get('id'),
+                                      persistence_type=persistence_type)
+        self._wait_for_load_balancer_status(load_balancer_id)
+
+        # self._create_members(load_balancer_id=load_balancer_id,
+        #                     pool_id=self.pool['id'],
+        #                     subnet_id=self.subnet['id'])
+
+        self.vip_ip = self.load_balancer.get('vip_address')
+
+        # if the ipv4 is used for lb, then fetch the right values from
+        # tempest.conf file
+        if ip_version == 4:
+            if (config.network.public_network_id and not
+                    config.network.project_networks_reachable):
+                load_balancer = net_resources.AttributeDict(self.load_balancer)
+                self._assign_floating_ip_to_lb_vip(load_balancer)
+                self.vip_ip = self.floating_ips[
+                    load_balancer.id][0]['floating_ip_address']
+
+        # Currently the ovs-agent is not enforcing security groups on the
+        # vip port - see https://bugs.launchpad.net/neutron/+bug/1163569
+        # However the linuxbridge-agent does, and it is necessary to add a
+        # security group with a rule that allows tcp port 80 to the vip port.
+        self.ports_client.update_port(
+            self.load_balancer.get('vip_port_id'),
+            security_groups=[self.security_group.id])
+
+    def _create_member(self, server_ip, server_position, load_balancer_id=None,
+                       pool_id=None, subnet_id=None):
+        """Create two members.
+
+        In case there is only one server, create both members with the same ip
+        but with different ports to listen on.
+        """
+
+        member = self.members_client.create_member(
+            pool_id=pool_id,
+            address=server_ip,
+            protocol_port=self.port1,
+            subnet_id=subnet_id)
+        self._wait_for_load_balancer_status(load_balancer_id)
+        self.members[server_position] = member
+        self.assertTrue(self.members[server_position])
+
+    def _run_traffic(
+            self, headers=None, cookies=None, uri_path=None,
+            expected_status=200, count=10):
+
+        for x in range(count):
+            try:
+                if not uri_path:
+                    uri_path = 'http://{}'.format(self.vip_ip)
+                print('making request to {}'.format(uri_path))
+                res = requests.get(uri_path, headers=headers, cookies=cookies)
+                assert res.status_code == expected_status
+            except Exception:
+                time.sleep(1)
+                continue
+
+    def _get_stats(self):
+        return self.load_balancers_client.get_load_balancer_stats(
+            self.load_balancer.get('id'))
+
+
+class TestLoadBalancerStats(F5StatsBaseTestCase):
+
+    def setUp(self):
+        super(TestLoadBalancerStats, self).setUp()
+
+    def test_stats(self):
+        request_count = 10  # number of requests to make
+
+        # get initial stats -- should be 0
+        before_stats = self._get_stats()
+        assert before_stats['active_connections'] == 0
+        assert before_stats['bytes_in'] == 0
+        assert before_stats['bytes_out'] == 0
+        assert before_stats['total_connections'] == 0
+
+        # send traffic through load balancer
+        self._run_traffic(count=request_count)
+
+        # Get stats -- may take some time for BIG-IP to update. Try
+        # until stats total_connections is equal to number of requests.
+        # Bail after 60 seconds.
+        for x in range(60):
+            after_stats = self._get_stats()
+            if after_stats['total_connections'] == request_count:
+                break
+            time.sleep(1)
+
+        # validate final stats
+        assert after_stats['active_connections'] == 0
+        assert after_stats['bytes_in'] > 0
+        assert after_stats['bytes_out'] > 0
+        assert after_stats['total_connections'] == request_count
+
+        print('===Success===')
+        print(pprint.pprint(after_stats))

--- a/f5lbaasdriver/v2/bigip/agent_rpc.py
+++ b/f5lbaasdriver/v2/bigip/agent_rpc.py
@@ -119,6 +119,24 @@ class LBaaSv2AgentRPC(object):
             topic=topic)
 
     @log_helpers.log_method_call
+    def update_loadbalancer_stats(
+            self,
+            context,
+            loadbalancer,
+            service,
+            host
+    ):
+        topic = '%s.%s' % (self.topic, host)
+        return self.cast(
+            context,
+            self.make_msg(
+                'update_loadbalancer_stats',
+                loadbalancer=loadbalancer,
+                service=service
+            ),
+            topic=topic)
+
+    @log_helpers.log_method_call
     def create_listener(self, context, listener, service, host):
         topic = '%s.%s' % (self.topic, host)
         return self.cast(

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -224,8 +224,33 @@ class LoadBalancerManager(object):
 
     @log_helpers.log_method_call
     def stats(self, context, loadbalancer):
-        """Get loadbalancer statistics."""
-        pass
+        driver = self.driver
+        try:
+            agent = driver.scheduler.schedule(
+                driver.plugin,
+                context,
+                loadbalancer.id,
+                driver.env
+            )
+            service = driver.service_builder.build(context,
+                                                   loadbalancer,
+                                                   agent)
+            driver.agent_rpc.update_loadbalancer_stats(
+                context,
+                loadbalancer.to_api_dict(),
+                service,
+                agent['host']
+            )
+        except (lbaas_agentschedulerv2.NoEligibleLbaasAgent,
+                lbaas_agentschedulerv2.NoActiveLbaasAgent) as e:
+            LOG.error("Exception: update_loadbalancer_stats: %s" % e.message)
+            driver._handle_driver_error(context,
+                                        models.LoadBalancer,
+                                        loadbalancer.id,
+                                        plugin_constants.ERROR)
+        except Exception as e:
+            LOG.error("Exception: update_loadbalancer_stats: %s" % e.message)
+            raise e
 
 
 class ListenerManager(object):

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -222,10 +222,19 @@ class LBaaSv2PluginCallbacksRPC(object):
             return loadbalancers
 
     @log_helpers.log_method_call
-    def update_service_stats(self, context, service_id=None,
-                             stats=None, host=None):
+    def update_loadbalancer_stats(self, context, loadbalancer_id=None,
+                             stats=None):
         """Update service stats."""
-        pass
+        with context.session.begin(subtransactions=True):
+            try:
+                self.driver.plugin.db.update_loadbalancer_stats(
+                    context,
+                    loadbalancer_id,
+                    stats
+                )
+            except Exception as e:
+                LOG.error('Exception: update_loadbalancer_stats: %s',
+                          e.message)
 
     @log_helpers.log_method_call
     def update_loadbalancer_status(self, context,

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -222,8 +222,10 @@ class LBaaSv2PluginCallbacksRPC(object):
             return loadbalancers
 
     @log_helpers.log_method_call
-    def update_loadbalancer_stats(self, context, loadbalancer_id=None,
-                             stats=None):
+    def update_loadbalancer_stats(self,
+                                  context,
+                                  loadbalancer_id=None,
+                                  stats=None):
         """Update service stats."""
         with context.session.begin(subtransactions=True):
             try:


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #29 

#### What's this change do?
Implements update_loadbalancer_stats method in plugin_rpc.

#### Where should the reviewer start?
Start with plugin_rpc.py, then look at test_stats.py (a Tempest scenario test). Ignore test_solution.py modifications, as this test is being phased out.

#### Any background context?
This change is needed in the driver to support agent changes to implement lb-stats. See also companion agent PR: https://github.com/F5Networks/f5-openstack-agent/pull/404
