### PR TITLE
HBP feature fails to move virtual server to correct network

### DIFF
--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -22,7 +22,7 @@ LOG = logging.getLogger(__name__)
 
 class DisconnectedService(object):
     def __init__(self):
-        pass
+        self.supported_encapsulations = ['vlan']
 
     # Retain this method for future use in case a particular ML2 implementation
     # decouples network_id from physical_network name.  The implementation in
@@ -44,11 +44,17 @@ class DisconnectedService(object):
         network_segment_physical_network = \
             agent_configuration.get('network_segment_physical_network', None)
         if network_segment_physical_network:
+            supported_encapsulations = [
+                x.lower() for x in self.supported_encapsulations +
+                agent_configuration.get('tunnel_types', [])
+            ]
             # look up segment details in the ml2_network_segments table
             segments = db.get_network_segments(context.session, network['id'])
             for segment in segments:
-                if (network_segment_physical_network ==
-                        segment['physical_network']):
+                if ((network_segment_physical_network ==
+                     segment['physical_network']) and
+                    (segment['network_type'].lower() in
+                     supported_encapsulations)):
                     data = segment
                     break
             if not data:


### PR DESCRIPTION
Issues:
Fixes #344

Problem:
HBP feature was written according to custom ML2 mechanism driver created for Cisco ACI deployment with BIG-IP attached via VLAN network type.  The discovered network in ml2 network segments table shows VLAN.  With the official Cisco ML2 driver, a parent physical network contains multipe child network segments, some of which show type opflex.

Analysis:
Iterate through the network segments list until finding one with a network type supported by the F5 agent, per the advertised tunnel types list + vlan (not a tunnel.  Caveat: this is a patch to unblock a customer, and Cisco asserts that only a single VLAN segment will ever be present in the current release.

Tests:
neutron-lbaas tempest