### PR TITLE
Update version strings to 8.2.0.b1 for beta release.

### DIFF
--- a/docs/includes/topic_install-f5-lbaasv2-driver.rst
+++ b/docs/includes/topic_install-f5-lbaasv2-driver.rst
@@ -10,7 +10,7 @@ Quick Start
 
 .. code-block:: text
 
-    $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v8.1.0
+    $ sudo pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v8.2.0.b1
 
 
 .. tip::
@@ -37,13 +37,13 @@ The ``f5-openstack-lbaasv2-driver`` package can be installed using ``dpkg``.
 
 .. code-block:: bash
 
-    $ curl –L –O https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v8.1.0/python-f5-openstack-lbaasv2-driver_8.1.0-1_1404_all.deb
+    $ curl –L –O https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v8.2.0.b1/python-f5-openstack-lbaasv2-driver_8.2.0.b1-1_1404_all.deb
 
 2. Install the package on the Neutron controller:
 
 .. code-block:: bash
 
-    $ sudo dpkg –i python-f5-openstack-lbaasv2-driver_8.1.0-1_1404_all.deb
+    $ sudo dpkg –i python-f5-openstack-lbaasv2-driver_8.2.0.b1-1_1404_all.deb
 
 RPM Package
 ```````````
@@ -54,12 +54,12 @@ The ``f5-openstack-lbaasv2-driver`` package can be installed using ``rpm``.
 
 .. code-block:: bash
 
-    $ curl –L –O https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v8.1.0/f5-openstack-lbaasv2-driver-8.1.0-1.el7.noarch.rpm
+    $ curl –L –O https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v8.2.0.b1/f5-openstack-lbaasv2-driver-8.2.0.b1-1.el7.noarch.rpm
 
 2. Install the package on the Neutron controller:
 
 .. code-block:: bash
 
-    $ sudo rpm –ivh f5-openstack-lbaasv2-driver-8.1.0-1.el7.noarch.rpm
+    $ sudo rpm –ivh f5-openstack-lbaasv2-driver-8.2.0.b1-1.el7.noarch.rpm
 
 

--- a/docs/map_before-you-begin.rst
+++ b/docs/map_before-you-begin.rst
@@ -59,7 +59,7 @@ Install the F5 Agent
 
     .. code-block:: text
 
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@v8.1.0
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@v8.2.0.b1
 
     .. tip::
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,19 +13,13 @@ Release Highlights
 
 This release introduces the following:
 
-- Agent redundancy and capacity-based scale out
-- Differentiated Service Environments
-- BIG-IP® vCMP® compatibility
+- load balancer statistics (e.g., ``neutron lbaas-loadbalancer-stats``)
 - Bug fixes
 
-See the `changelog <https://github.com/F5Networks/f5-openstack-lbaasv2-driver/compare/v8.0.8...v8.1.0>`_ for the full list of changes in this release.
+See the `changelog <https://github.com/F5Networks/f5-openstack-lbaasv2-driver/compare/v8.1.0...v8.2.0.b1>`_ for the full list of changes in this release.
 
 Caveats
 -------
-
-The following are not supported in this release:
-
-* load balancer statistics (e.g., ``neutron lbaas-loadbalancer-stats``)
 
 Open Issues
 -----------


### PR DESCRIPTION
Issues:
Fixes #347

Problem:
Documentation needs to reflect latest version.

Analysis:
Search and replace 8.1.0 with 8.2.0.b1

Tests:
Review docs in fork prior to submitting PR to F5Networks.