### PR TITLE
HBP fails to detect dynamic segments when scanning disconnected services

### DIFF
--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -49,7 +49,8 @@ class DisconnectedService(object):
                 agent_configuration.get('tunnel_types', [])
             ]
             # look up segment details in the ml2_network_segments table
-            segments = db.get_network_segments(context.session, network['id'])
+            segments = db.get_network_segments(context.session, network['id'],
+                                               filter_dynamic=None)
             for segment in segments:
                 if ((network_segment_physical_network ==
                      segment['physical_network']) and


### PR DESCRIPTION
Issues:
Fixes #353

Problem:
Cisco ACI creates a dynamic segment under the parent network to provide a VLAN for tenant separation.  The agent times out in scanning for disconnected networks unable to find the network segment matching the configured name in the .ini file.

Analysis:
The get_network_segments API provided in neutron.plugins.ml2.db has 'filter_dynamic=False' as a default conditional.  The code checks if filter_dynamic is not None, then apply a filter.  Presume that this implementation preserves backwards compatibility but by default excludes dynamic segments.  Add filter_dynamic=None to the call from disconnected in order to fetch the entire list of segments for the network.

Tests:
Created a unit test in neutron to prove functional behavior.  Provided patch to vendor to confirm issue is resolved.
