### PR TITLE
Integrate neutron-lbaas v2 tempest test into F5 internal regression s…

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -74,11 +74,9 @@ export TEMPEST_CONFIG_DIR := $(TEMPEST_VENV_DIR)/etc/tempest
 export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 
 # Results Directories
-export RESULTS_DIR := $(MAKEFILE_DIR)/test_results/$(PROJECT)
+export RESULTS_DIR := $(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)
 export API_SESSION := api_$(SUBJECTCODE_ID)_$(TIMESTAMP)
-export API_RESULTS_DIR := $(RESULTS_DIR)/api
 export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
-export SCENARIO_RESULTS_DIR := $(RESULTS_DIR)/scenario
 
 tlc-install:
 	cd scripts && sudo -EH ./install_tlc.sh

--- a/systest/scripts/tempest_tests.sh
+++ b/systest/scripts/tempest_tests.sh
@@ -24,11 +24,11 @@ cd ${NEUTRON_LBAAS_DIR}
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini -- \
   -lvv --tb=line \
-  --autolog-outputdir ${API_RESULTS_DIR} \
+  --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${API_SESSION}
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
 tox -e scenariov2 -c f5.tox.ini -- \
   -lvv --tb=line \
-  --autolog-outputdir ${SCENARIO_RESULTS_DIR} \
+  --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${SCENARIO_SESSION}


### PR DESCRIPTION
@mattgreene 
Integrate neutron-lbaas v2 tempest test into F5 internal regression system #355

#### Issues
Fixes #355

#### Problem
After final testing the results files did not appear in the reporting system correctly becaue the directories were not formatted properly.

#### Analysis
* Make sure that the results are shown in trtl as a project called f5-openstack-lbaasv2-driver_liberty
* All branch results are bbot jobs so we want to organize them by project
* Ensure session names are unique with timestamp
