### PR TITLE
map tlc --> /tools/bin/tlc

### DIFF
--- a/systest/scripts/tlc_session_setup.sh
+++ b/systest/scripts/tlc_session_setup.sh
@@ -18,7 +18,7 @@
 set -ex
 
 # Run the setup & commands for the session
-tlc --session ${TEST_SESSION} --config ${TLC_FILE} --debug setup
-tlc --session ${TEST_SESSION} --debug cmd ready
-tlc --session ${TEST_SESSION} --debug cmd test_env
-tlc --session ${TEST_SESSION} --debug cmd lbaasv2
+/tools/bin/tlc --session ${TEST_SESSION} --config ${TLC_FILE} --debug setup
+/tools/bin/tlc --session ${TEST_SESSION} --debug cmd ready
+/tools/bin/tlc --session ${TEST_SESSION} --debug cmd test_env
+/tools/bin/tlc --session ${TEST_SESSION} --debug cmd lbaasv2


### PR DESCRIPTION
@pjbreaux
Issues:
Fixes #371

Problem: tlc is used as part of the in-house test
procedure, but it's install procedure does not
place it in a standard location.

Analysis: This commit makes invocations of tlc explicitly
call /tools/bin/tlc the location it is installed to.
