### PR TITLE
Nightly tempest

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,7 +2,6 @@
 git+https://github.com/F5Networks/f5-common-python.git@v2.1.0
 git+https://github.com/F5Networks/pytest-symbols.git
 git+https://github.com/F5Networks/f5-openstack-test.git
-# TODO(paul): Must change this before it collapses into mitaka
 git+https://github.com/openstack/neutron.git@stable/mitaka
 git+https://github.com/openstack/neutron-lbaas.git@8.3.0
 git+https://github.com/openstack/tempest.git@12.0.0

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -27,7 +27,7 @@ TIMESTAMP ?= $(shell date +"%Y%m%d-%H%M%S")
 export TIMESTAMP   # Only eval TIMESTAMP in the top make.
 PROJECT := f5-openstack-lbaasv2-driver
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
+export MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
 
 # Repos that are used for the tests and environment
 # TLC
@@ -77,6 +77,7 @@ export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 export RESULTS_DIR := $(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)
 export API_SESSION := api_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
+export DRIVER_TEMPEST_SESSION := driver_tempest_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 tlc-install:
 	cd scripts && sudo -EH ./install_tlc.sh

--- a/systest/scripts/tempest_setup.sh
+++ b/systest/scripts/tempest_setup.sh
@@ -56,6 +56,12 @@ cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig \
   | sed "s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/" \
   > ${TEMPEST_CONFIG_DIR}/tempest.conf
 
+# Add tempest configuration options for running tempest tests in f5lbaasv2driver
+BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
+echo "[f5_lbaasv2_driver]" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
+echo "icontrol_hostname = ${BIGIP_IP}" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
+echo "transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
+
 # Clone neutron-lbaas so we have the tests
 git clone\
   -b ${NEUTRON_LBAAS_BRANCH} \

--- a/systest/scripts/tempest_tests.sh
+++ b/systest/scripts/tempest_tests.sh
@@ -19,8 +19,21 @@ set -ex
 
 # Activate our tempest virtualenv
 source ${TEMPEST_VENV_ACTIVATE}
-cd ${NEUTRON_LBAAS_DIR}
 
+# Navigate to the root of the repo, where the tox.ini file is found
+cd ${MAKEFILE_DIR}/../
+tox -e tempest -c tox.ini -- \
+  -lvv --tb=line \
+  --autolog-outputdir ${RESULTS_DIR} \
+  --autolog-session ${DRIVER_TEMPEST_SESSION}
+
+cd ${NEUTRON_LBAAS_DIR}
+tox -e tempest -c tox.ini -- \
+  -lvv --tb=line \
+  --autolog-outputdir ${RESULTS_DIR} \
+  --autolog-session ${API_SESSION}
+
+cd ${NEUTRON_LBAAS_DIR}
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini -- \
   -lvv --tb=line \

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+basepython = python2.7
+
+[testenv:tempest]
+passenv = TEMPEST_CONFIG_DIR
+setenv =
+  OS_TEST_PATH={toxinidir}/f5lbaasdriver/test/tempest/tests
+deps =
+  -rrequirements.test.txt
+changedir = f5lbaasdriver/test/tempest/tests/
+commands = py.test -vra {posargs}


### PR DESCRIPTION
@swormke @dflanigan 

#### What issues does this address?
Fixes #373 

#### What's this change do?
Added the tox.ini file at root level of the repo. Added a target for these L7 tests. Also modified the Makefile and script to run these tests from the proper location.

#### Where should the reviewer start?
Start at the tox file, then move to the makefile and then the script.

#### Any background context?
We need to get the tempest tests we wrote running in our nightly build in Boulder. This will require some changes to the makefile in systest. We will likely start with these tests being lumped in with the neutron-lbaas tests, then we can break them out later if we desire.
