### PR TITLE
Add BIG-IP version and deployment matrix to nightly tests #375

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -13,12 +13,13 @@
 # limitations under the License.
 #
 
-.PHONY: all systest functest \
+.PHONY: all functest \
 tlc-install \
-tempest-setup \
-tempest_tests tempest_tests-setup \
-tempest_tests-install tempest_tests-run \
-tempest_tests-teardown
+tempest_tests-install tempest_tests-teardown \
+tempest_11.5.4_overcloud tempest_11.5.4_undercloud \
+tempest_11.6.0_overcloud tempest_11.6.0_undercloud \
+tempest_11.6.1_overcloud tempest_11.6.1_undercloud \
+tempest_12.1.1_overcloud tempest_12.1.1_undercloud
 
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -57,15 +58,12 @@ export PATH := /tools/bin:$(PATH)
 export PYTHONPATH := /tools/lib:/tools/bin:$(PYTHONPATH)
 export USER := buildbot
 export TEST_OPENSTACK_DISTRO := liberty
-export TEST_VE_IMAGE := os_ready-BIGIP-11.6.0.0.0.401.qcow2
 export TEST_CIRROS_IMAGE := cirros-0.3.4-x86_64-disk.qcow2
 export TEST_OPENSTACK_NODE_COUNT := 2
 export TEST_OPENSTACK_DEPLOY := multinode
-export TEST_OPENSTACK_CLOUD := overcloud
 export TEST_COMMON_LIB := $(DEVTEST_DIR)/common
 export GLANCE_COMPUTE_STORAGE := NFS
-export TLC_FILE := ${DEVTEST_DIR}/traffic/$(TEST_OPENSTACK_CLOUD)/ve_$(TEST_OPENSTACK_CLOUD).tlc
-export TEST_SESSION := $(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP)
+export TLC_FILE_DIR := $(DEVTEST_DIR)/traffic
 
 # Virtualenv & tempest requirements
 export VENVDIR := /home/buildbot/virtualenvs
@@ -74,38 +72,125 @@ export TEMPEST_CONFIG_DIR := $(TEMPEST_VENV_DIR)/etc/tempest
 export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 
 # Results Directories
-export RESULTS_DIR := $(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)
 export API_SESSION := api_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
+# Install the TLC application
 tlc-install:
 	cd scripts && sudo -EH ./install_tlc.sh
 
+# Run all tests, this is what buildbot calls: make functest
 functest:
-	$(MAKE) -j -C . functest_all
+	$(MAKE) -C . functest_all
 
-functest_all: tempest_tests 
+# These are all of the functests that we want to run as part of bbot job
+# We ignore the return value so that we run all of the tests
+functest_all: tlc-install tempest_tests-install
+	-$(MAKE) -C . tempest_11.5.4_overcloud
+	-$(MAKE) -C . tempest_11.6.0_overcloud
+	-$(MAKE) -C . tempest_11.6.1_overcloud
+	-$(MAKE) -C . tempest_12.1.1_overcloud
+	-$(MAKE) -C . tempest_11.5.4_undercloud
+	-$(MAKE) -C . tempest_11.6.0_undercloud
+	-$(MAKE) -C . tempest_11.6.1_undercloud
+	-$(MAKE) -C . tempest_12.1.1_undercloud
 
+# Not using the tempest TLC files for liberty because they install barbican
+# which causes the tests to lockup/hang
+
+# Tempest Tests for 11.5.x overcloud VE deployment
+tempest_11.5.4_overcloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=overcloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTCK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+# Tempest Tests for 11.6.x overcloud VE deployment
+tempest_11.6.0_overcloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=overcloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+tempest_11.6.1_overcloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=overcloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+# Tempest Tests for 12.1.x overcloud VE deployment
+tempest_12.1.1_overcloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=overcloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+# Tempest Tests for 11.5.x undercloud VE deployment
+tempest_11.5.4_undercloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+# Tempest Tests for 11.6.x undercloud VE deployment
+tempest_11.6.0_overcloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+tempest_11.6.1_undercloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+# Tempest Tests for 12.1.x undercloud VE deployment
+tempest_12.1.1_undercloud:
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	$(MAKE) -C . tempest_tests
+
+# Once we have the variables setup we can run the tempest tests on our env
 tempest_tests:
-	@echo "automated functional tests..."
-	$(MAKE) -C . tlc-install
 	$(MAKE) -C . tempest_tests-setup
-	$(MAKE) -C . tempest_tests-install
+	$(MAKE) -C . tempest_tests-config
 	$(MAKE) -C . tempest_tests-run
-	$(MAKE) -C . tempest_tests-teardown
+	$(MAKE) -C . tempest_tests-cleanup
+
+tempest_tests-install:
+	@echo "installing and tempest tests..."
+	cd scripts && ./tempest_setup.sh || $(MAKE) -C ../ tempest_tests-cleanup
 
 tempest_tests-setup:
 	@echo "setting up tempest test TLC session..."
-	cd scripts && ./tlc_session_setup.sh || $(MAKE) -C ../ tempest_tests-teardown
+	cd scripts && ./tlc_session_setup.sh || $(MAKE) -C ../ tempest_tests-cleanup
 
-tempest_tests-install:
-	@echo "installing and configuring tempest tests..."
-	cd scripts && ./tempest_setup.sh || $(MAKE) -C ../ tempest_tests-teardown
+tempest_tests-config:
+	@echo "configuring tempest for the values in our TLC environment"
+	cd scripts && ./tempest_config.sh || $(MAKE) -C ../ tempest_tests-cleanup
 
 tempest_tests-run:
 	@echo "running the tempest test cases..."
-	cd scripts && ./tempest_tests.sh || $(MAKE) -C ../ tempest_tests-teardown
+	cd scripts && ./tempest_tests.sh || $(MAKE) -C ../ tempest_tests-cleanup
 
-tempest_tests-teardown:
-	@echo "tearing down the TLC session..."
+tempest_tests-cleanup:
+	@echo "cleaning up down the TLC session..."
 	-cd scripts && ./tlc_session_cleanup.sh

--- a/systest/scripts/conf/tempest.conf
+++ b/systest/scripts/conf/tempest.conf
@@ -7,7 +7,7 @@ api_version = 2.0
 project_network_cidr = 10.2.4.0/24 
 
 [DEFAULT]
-debug = True
+debug = False
 #log_file = tempest.log
 use_stderr = False
 use_syslog = False

--- a/systest/scripts/tempest_config.sh
+++ b/systest/scripts/tempest_config.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -ex
+
+# Copy over our default tempest files
+cp conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
+cp conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
+
+# Find the values for tempest.conf and substitute them
+OS_CONTROLLER_IP=`tlc --session ${TEST_SESSION} symbols \
+    | grep openstack_controller1ip_data_direct \
+    | awk '{print $3}'`
+
+ssh_cmd="ssh -o StrictHostKeyChecking=no testlab@${OS_CONTROLLER_IP}"
+
+OS_PUBLIC_ROUTER_ID=`${ssh_cmd} "source ~/keystonerc_testlab && neutron router-list -F id -f value"`
+OS_PUBLIC_NETWORK_ID=`${ssh_cmd} "source ~/keystonerc_testlab && neutron net-list -F name -F id -f value" \
+    | grep external_network \
+    | awk '{print $1}'`
+OS_CIRROS_IMAGE_ID=`${ssh_cmd} "source ~/keystonerc_testlab && glance image-list" \
+    | grep ${TEST_CIRROS_IMAGE} \
+    | awk '{print $2}'`
+
+cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig \
+  | sed "s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/" \
+  | sed "s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/" \
+  | sed "s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/" \
+  | sed "s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/" \
+  > ${TEMPEST_CONFIG_DIR}/tempest.conf

--- a/systest/scripts/tempest_setup.sh
+++ b/systest/scripts/tempest_setup.sh
@@ -27,34 +27,9 @@ pip install tox
 # Install tempest & its config files
 git clone ${TEMPEST_REPO} ${TEMPEST_DIR}
 pip install ${TEMPEST_DIR}
-cp conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
-cp conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
 
-# We need to deactivate the virtualenv to run TLC commands
-deactivate
-
-# Find the values for tempest.conf and substitute them
-
-OS_CONTROLLER_IP=`tlc --session ${TEST_SESSION} symbols \
-    | grep openstack_controller1ip_data_direct \
-    | awk '{print $3}'`
-
-ssh_cmd="ssh -o StrictHostKeyChecking=no testlab@${OS_CONTROLLER_IP}"
-
-OS_PUBLIC_ROUTER_ID=`${ssh_cmd} "source ~/keystonerc_testlab && neutron router-list -F id -f value"`
-OS_PUBLIC_NETWORK_ID=`${ssh_cmd} "source ~/keystonerc_testlab && neutron net-list -F name -F id -f value" \
-    | grep external_network \
-    | awk '{print $1}'`
-OS_CIRROS_IMAGE_ID=`${ssh_cmd} "source ~/keystonerc_testlab && glance image-list" \
-    | grep ${TEST_CIRROS_IMAGE} \
-    | awk '{print $2}'`
-
-cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig \
-  | sed "s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/" \
-  | sed "s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/" \
-  | sed "s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/" \
-  | sed "s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/" \
-  > ${TEMPEST_CONFIG_DIR}/tempest.conf
+# We need to clone the OpenStack devtest repo for our TLC files
+git clone ${DEVTEST_REPO} ${DEVTEST_DIR}
 
 # Install neutron at stable/mitaka because stable/liberty tests will not work
 # because they use an upper contraints file in the installation script that
@@ -78,4 +53,3 @@ git clone\
 
 # Copy our tox.ini file to neutron so we can run py.test instead of testr
 cp conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
-

--- a/systest/scripts/tempest_tests.sh
+++ b/systest/scripts/tempest_tests.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-set -ex
+set -x
 
 # Activate our tempest virtualenv
 source ${TEMPEST_VENV_ACTIVATE}
@@ -23,12 +23,15 @@ cd ${NEUTRON_LBAAS_DIR}
 
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini -- \
-  -lvv --tb=line \
+  -lvv --tb=short \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${API_SESSION}
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
 tox -e scenariov2 -c f5.tox.ini -- \
-  -lvv --tb=line \
+  -lvv --tb=short \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${SCENARIO_SESSION}
+
+# Returning pass so that all tests run
+exit 0

--- a/systest/scripts/tlc_session_cleanup.sh
+++ b/systest/scripts/tlc_session_cleanup.sh
@@ -15,5 +15,7 @@
 # limitations under the License.
 #
 
-# Cleanup the session. Should we be killing the barbican in Mesos too?
+set -x
+
+# We only need to cleanup the session, we didn't use barbican-enabled TLC file
 tlc --session ${TEST_SESSION} --debug cleanup

--- a/systest/scripts/tlc_session_setup.sh
+++ b/systest/scripts/tlc_session_setup.sh
@@ -17,9 +17,6 @@
 
 set -ex
 
-# We need to clone the OpenStack devtest repo for our TLC files
-git clone ${DEVTEST_REPO} ${DEVTEST_DIR}
-
 # Run the setup & commands for the session
 tlc --session ${TEST_SESSION} --config ${TLC_FILE} --debug setup
 tlc --session ${TEST_SESSION} --debug cmd ready


### PR DESCRIPTION
@pjbreaux @dflanigan 

#### Issues
Fixes #375

#### Problem
The nightly test only included one combination of BIG-IP:deployment (11.6.1 overcloud). We need to test all the combinations we support on a nightly basis.

#### Analysis
* Create separate targets for each of the cells in our supported matrix
* Run all tests even if the previous ones fail
* Ignore failures on functest_all tests so we run all tests
* Removing -j option for make because we do not want these to run in parallel due to resource constraints.
* Moved clone of devtest repo to a script that only runs once to avoid checking out twice is same location each time we execute a new target.
* Fixed TLC file dir path
* Added a bit longer traceback for debugging failures
* Make unique TLC session names to workaround session dirs not deleting because of NFS changes for nova storage
* Removed some commented out code
