### PR TITLE
Fix driver build failures for mitaka

### DIFF
--- a/systest/scripts/tempest_setup.sh
+++ b/systest/scripts/tempest_setup.sh
@@ -32,6 +32,9 @@ pip install ${TEMPEST_DIR}
 git clone ${DEVTEST_REPO} ${DEVTEST_DIR}
 
 # Add tempest configuration options for running tempest tests in f5lbaasv2driver
+OS_CONTROLLER_IP=`tlc --session ${TEST_SESSION} symbols \
+    | grep openstack_controller1ip_data_direct \
+    | awk '{print $3}'`
 BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
 echo "[f5_lbaasv2_driver]" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
 echo "icontrol_hostname = ${BIGIP_IP}" >> ${TEMPEST_CONFIG_DIR}/tempest.conf

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,6 @@ setenv =
   OS_TEST_PATH={toxinidir}/f5lbaasdriver/test/tempest/tests
 deps =
   -rrequirements.test.txt
+  git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
 changedir = f5lbaasdriver/test/tempest/tests/
 commands = py.test -vra {posargs}


### PR DESCRIPTION
@swormke @dflanigan 

#### What issues does this address?
Fixes #383 

#### What's this change do?
Added the autolog install in the tox.ini file. And added tlc command in tempest_setup to retrieve controller IP address.

#### Where should the reviewer start?

#### Any background context?
The mitaka jobs for the driver are failing due to an issue with the autolog not
being available in the build environment. It needs to be added.