### PR TITLE
TLC config failing due to nonexistent TEST_SESSION variable

### DIFF
--- a/systest/scripts/tempest_config.sh
+++ b/systest/scripts/tempest_config.sh
@@ -42,3 +42,9 @@ cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig \
   | sed "s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/" \
   | sed "s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/" \
   > ${TEMPEST_CONFIG_DIR}/tempest.conf
+
+# Add tempest configuration options for running tempest tests in f5lbaasv2driver
+BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
+echo "[f5_lbaasv2_driver]" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
+echo "icontrol_hostname = ${BIGIP_IP}" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
+echo "transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/" >> ${TEMPEST_CONFIG_DIR}/tempest.conf

--- a/systest/scripts/tempest_setup.sh
+++ b/systest/scripts/tempest_setup.sh
@@ -31,15 +31,6 @@ pip install ${TEMPEST_DIR}
 # We need to clone the OpenStack devtest repo for our TLC files
 git clone ${DEVTEST_REPO} ${DEVTEST_DIR}
 
-# Add tempest configuration options for running tempest tests in f5lbaasv2driver
-OS_CONTROLLER_IP=`tlc --session ${TEST_SESSION} symbols \
-    | grep openstack_controller1ip_data_direct \
-    | awk '{print $3}'`
-BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
-echo "[f5_lbaasv2_driver]" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
-echo "icontrol_hostname = ${BIGIP_IP}" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
-echo "transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
-
 # Clone neutron-lbaas so we have the tests
 git clone\
   -b ${NEUTRON_LBAAS_BRANCH} \


### PR DESCRIPTION
@swormke @dflanigan 
#### What issues does this address?
Fixes #383 

#### What's this change do?
Moved the retrieval of the BIG-IP IP address to the tempest_config file instead of the tempest_setup script.

#### Where should the reviewer start?

#### Any background context?
The mitaka jobs for the driver are failing due to the fact that some tempest setup is in the wrong place now that make commands exist which are targeting specific test runs. This variable was global, but now it's not.