### PR TITLE
Driver make targets duplicated and typo in 11.5.4 undercloud target

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -102,7 +102,7 @@ functest_all: tlc-install tempest_tests-install
 tempest_11.5.4_overcloud:
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=overcloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTCK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$(PROJECT)_$(BRANCH)-$@ ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	$(MAKE) -C . tempest_tests
@@ -143,7 +143,7 @@ tempest_11.5.4_undercloud:
 	$(MAKE) -C . tempest_tests
 
 # Tempest Tests for 11.6.x undercloud VE deployment
-tempest_11.6.0_overcloud:
+tempest_11.6.0_undercloud:
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\
 	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\


### PR DESCRIPTION
@zancas @swormke 

#### What issues does this address?
Fixes #386 

#### What's this change do?
Changed the duplicated target to the proper undercloud target and fixed the typo.

#### Where should the reviewer start?

#### Any background context?
In the nightly builds, the tempest_11.6.0_overcloud make target is duplicated. It should be changed to tempest_11.6.0_undercloud. Also, a typo exists in the tempest_11.5.4_overcloud build, where the TEST_OPENSTACK_CLOUD variable is wrong.