### PR TITLE
during dev its useful to repeat tlc-install

### DIFF
--- a/systest/scripts/install_tlc.sh
+++ b/systest/scripts/install_tlc.sh
@@ -18,12 +18,12 @@
 set -ex
 
 # Copy the testlab key and make sure it has right owner/permissions
-cp /home/buildbot/.ssh/id_rsa /home/buildbot/.ssh/id_rsa_testlab
+cp -f /home/buildbot/.ssh/id_rsa /home/buildbot/.ssh/id_rsa_testlab
 chmod 600 /home/buildbot/.ssh/id_rsa_testlab
 chown buildbot:buildbot /home/buildbot/.ssh/id_rsa_testlab
 
 # Update the system and install required debian packages
-ln -s /bin/bash /usr/local/bin/bash
+ln -fs /bin/bash /usr/local/bin/bash
 apt-get update
 apt-get -y install \
     vim \
@@ -36,14 +36,13 @@ apt-get -y install \
     python-protobuf \
     protobuf-compiler \
     gosu
-apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Pip install TLC requirements
 pip install --upgrade pip
 pip install argcomplete blessings configargparse prettytable
 
 # Clone the toolsbase directory and setup the file system structure
+rm -rf ${TOOLSBASE_DIR}
 git clone ${TOOLSBASE_REPO} ${TOOLSBASE_DIR}
 mkdir ${TOOLSBASE_DIR}/independent/share
 mkdir ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/share
@@ -52,7 +51,7 @@ rm -rf ${TOOLSBASE_DIR}/independent/bin/tlc_pb2.py
 rm -rf ${TOOLSBASE_DIR}/independent/lib/*.pyc
 rm -rf ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/bin/*.pyc
 rm -rf ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/lib/*.pyc
-ln -s ${TOOLSBASE_DIR}/Ubuntu-10-x86_64 /tools
+ln -sf ${TOOLSBASE_DIR}/Ubuntu-10-x86_64 /tools
 
 # Remove all of the stale libs that are for some reason is toolsbase/bin
 libs="file_access.py
@@ -74,6 +73,7 @@ for lib in $libs; do
 done
 
 # Install TLC packages and binaries
+rm -rf ${TLC_DIR}
 git clone \
   -b ${TLC_BRANCH} \
   --single-branch \
@@ -82,7 +82,7 @@ git clone \
 
 # Apply patches found for local changes to TLC on build server
 # Should these patches be applied in the repo for real?
-cp patches/* /tmp/
+cp -f patches/* /tmp/
 patch ${TLC_DIR}/tlc/install.sh /tmp/tlc_install.sh.patch
 patch ${TOOLSBASE_DIR}/independent/create_softlinks /tmp/create_softlinks.patch
 patch ${TLC_DIR}/vmware/install.sh /tmp/vmware_install.patch


### PR DESCRIPTION
Issues:
Fixes #378

Problem: development is significantly slowed by non-rerunnable
test infrastructure setup steps.

Analysis:  This change makes the tlc-install command ~ idempotent

