### PR TITLE
Autolog output directory is driving the suite name in trtl results

### DIFF
--- a/systest/scripts/tempest_tests.sh
+++ b/systest/scripts/tempest_tests.sh
@@ -20,6 +20,12 @@ set -x
 # Activate our tempest virtualenv
 source ${TEMPEST_VENV_ACTIVATE}
 
+# Create .pytest.rootdir files at the root of the driver and neutron-lbaas
+# respositories to make the results suite names be rooted at the top-level
+# of the respective test repository
+touch ${MAKEFILE_DIR}/../f5lbaasdriver/test/tempest/tests/.pytest.rootdir
+touch ${NEUTRON_LBAAS_DIR}/neutron-lbaas/tests/tempest/v2/.pytest.rootdir
+
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${MAKEFILE_DIR}/../
 tox -e tempest -c tox.ini -- \


### PR DESCRIPTION
@dflanigan @jlongstaf 

Note: These changes are only committed to mitaka, because there we see duplicate test results we would like to rectify that, as well as use this as an opportunity to

#### What issues does this address?
Fixes #398 

#### What's this change do?
Did not commit these files to the repo, but had the .pytest.rootdir files added via the tempest_tests.sh script in systest/scripts. This will prevent the inevitable questions about why these files exist in the public repo.

#### Where should the reviewer start?

#### Any background context?
When tox is run in nightly, the --autolog-outputdir provided to the tox command causes the suite name to be rooted (and thus named) from the / directory on the worker. We need to provide a .pytest.rootdir file near the tests, so suite name is made relative to the location of the tests, and thus is not filled with redundancies.
