### PR TITLE
Loadbalancer stuck in 'PENDING_UPDATE' when listener created after te…

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/test_load_balancers_admin.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_load_balancers_admin.py
@@ -1,0 +1,104 @@
+# Copyright 2015 Hewlett-Packard Development Company, L.P.
+# Copyright 2016 Rackspace Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from tempest import config
+from tempest.lib.common.utils import data_utils
+from tempest import test
+
+from f5lbaasdriver.test.tempest.tests.api import base
+
+CONF = config.CONF
+
+
+class LoadBalancersTestJSON(base.BaseAdminTestCase):
+    """Loadbalancer Tempest tests.
+
+    Tests the following operations in the Neutron-LBaaS API using the
+    REST client for Load Balancers with default credentials:
+
+        list load balancers
+        create load balancer
+        get load balancer
+        update load balancer
+        delete load balancer
+    """
+
+    @classmethod
+    def resource_setup(cls):
+        """Setup client fixtures for test suite."""
+        super(LoadBalancersTestJSON, cls).resource_setup()
+        if not test.is_extension_enabled('lbaas', 'network'):
+            msg = "lbaas extension not enabled."
+            raise cls.skipException(msg)
+        network_name = data_utils.rand_name('network')
+        cls.network = cls.create_network(network_name)
+        cls.subnet = cls.create_subnet(cls.network)
+        cls.create_lb_kwargs = {'tenant_id': cls.subnet['tenant_id'],
+                                'vip_subnet_id': cls.subnet['id']}
+        cls.load_balancer = \
+            cls._create_active_load_balancer(**cls.create_lb_kwargs)
+        cls.load_balancer_id = cls.load_balancer['id']
+
+    @test.attr(type='smoke')
+    def test_create_load_balancer_with_tenant_id_field_for_admin(self):
+        """Test create loadbalancer.
+
+        Test create load balancer with tenant id field from subnet.
+        Verify tenant_id matches when creating loadbalancer vs.
+        load balancer(admin tenant)
+        """
+        load_balancer = self.load_balancers_client.create_load_balancer(
+            tenant_id=self.subnet['tenant_id'],
+            vip_subnet_id=self.subnet['id'])
+        self.addCleanup(self._delete_load_balancer, load_balancer['id'])
+        admin_lb = self.load_balancers_client.get_load_balancer(
+            load_balancer.get('id'))
+        self.assertEqual(load_balancer.get('tenant_id'),
+                         admin_lb.get('tenant_id'))
+
+        self._wait_for_load_balancer_status(load_balancer['id'])
+
+    @test.attr(type='smoke')
+    def test_create_load_balancer_without_tenant_id(self):
+        """Test create loadbalancer.
+
+        Test create load balancer with tenant id field from subnet.
+        Verify tenant_id matches when creating loadbalancer vs.
+        load balancer(admin tenant)
+        """
+        load_balancer = self.load_balancers_client.create_load_balancer(
+            vip_subnet_id=self.subnet['id'])
+        self.addCleanup(self._delete_load_balancer, load_balancer['id'])
+
+        self._wait_for_load_balancer_status(load_balancer['id'],
+                                            provisioning_status='ERROR',
+                                            operating_status='OFFLINE')
+
+        # Create listener for test
+        create_listener_kwargs = {'loadbalancer_id': load_balancer['id'],
+                                  'protocol': "HTTP",
+                                  'protocol_port': "80"}
+        listener = self._create_listener(**create_listener_kwargs)
+
+        self._wait_for_load_balancer_status(load_balancer['id'],
+                                            provisioning_status='ERROR',
+                                            operating_status='OFFLINE')
+
+        self._delete_listener(listener['id'], wait=True)
+
+        self._wait_for_load_balancer_status(load_balancer['id'],
+                                            provisioning_status='ERROR',
+                                            operating_status='OFFLINE')

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -143,9 +143,8 @@ class LoadBalancerManager(object):
             )
 
         except (lbaas_agentschedulerv2.NoEligibleLbaasAgent,
-                lbaas_agentschedulerv2.NoActiveLbaasAgent,
-                f5_exc.F5MismatchedTenants) as e:
-            LOG.error("Exception: loadbalancer create: %s" % e.message)
+                lbaas_agentschedulerv2.NoActiveLbaasAgent) as e:
+            LOG.error("Exception: loadbalancer create: %s" % e)
             driver.plugin.db.update_status(
                 context,
                 models.LoadBalancer,
@@ -209,9 +208,8 @@ class LoadBalancerManager(object):
             )
 
         except (lbaas_agentschedulerv2.NoEligibleLbaasAgent,
-                lbaas_agentschedulerv2.NoActiveLbaasAgent,
-                f5_exc.F5MismatchedTenants) as e:
-            LOG.error("Exception: loadbalancer delete: %s" % e.message)
+                lbaas_agentschedulerv2.NoActiveLbaasAgent) as e:
+            LOG.error("Exception: loadbalancer delete: %s" % e)
             driver.plugin.db.delete_loadbalancer(context, loadbalancer.id)
         except Exception as e:
             LOG.error("Exception: loadbalancer delete: %s" % e.message)

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -22,7 +22,6 @@ from oslo_log import log as logging
 
 from f5lbaasdriver.v2.bigip import constants_v2
 from f5lbaasdriver.v2.bigip.disconnected_service import DisconnectedService
-from f5lbaasdriver.v2.bigip import exceptions as f5_exc
 
 LOG = logging.getLogger(__name__)
 
@@ -111,7 +110,6 @@ class LBaaSv2ServiceBuilder(object):
                               loadbalancer.tenant_id,
                               network['id'],
                               network['tenant_id']))
-                raise f5_exc.F5MismatchedTenants()
 
             # Get the network VTEPs if the network provider type is
             # either gre or vxlan.


### PR DESCRIPTION
…nant mismatch.

Issues:
Fixes #402

Problem:
When a loadbalancer is created on a network that is not shared, nor
owned by the administrator, there is a configuration problem on the
BigIP because the network constructs will be in a different partition
from the LTM objects.  Network RBAC will solve this problem.

In the near term an exception was thrown that would be thrown from
service builder and handled in the driver.  While the loadbalancer would
be put in ERROR state, this does not prevent a user from creating a
listener/pool this loadbalancer.  The result is that the loadbalancer
get's put in a 'PENDING_UPDATE' state that cannot be cleared
because the MismatchedTenants exception prevents the agent from
clearing up this condition.

Analysis:
The change is to remove the mismatched tenants exception all
together and log the error in the server log.  The result will
be the attempt by the agent to deploy the service will fail
because the LTM objects are in the loadbalancer partition and the
network objects are in the network partition.  These cannot be
shared and will result in a loadbalancer in ERROR state.  However,
subsequent objects created on the loadbalancer will not cause
the lb to stick in PENDING_UPDATE.  The request will be sent to the
agent and it will properly put the lb in ERROR state.

Tests:
Create an admin network and a demo network (owned by demo user)
As admin create a loadbalancer on the demo-network -- verify lb in ERROR
As admin, create a listener on the previous lb. -- verify lb in ERROR
not in PENDING_UPDATE.
As admin, remove listener -- verify removed.
As admin, remove loadbalancer --verify removed.

Conflicts:
	f5lbaasdriver/v2/bigip/driver_v2.py

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
