### PR TITLE
Typo in path to write .pytest.rootdir for neutron-lbaas

### DIFF
--- a/systest/scripts/tempest_tests.sh
+++ b/systest/scripts/tempest_tests.sh
@@ -24,7 +24,7 @@ source ${TEMPEST_VENV_ACTIVATE}
 # respositories to make the results suite names be rooted at the top-level
 # of the respective test repository
 touch ${MAKEFILE_DIR}/../f5lbaasdriver/test/tempest/tests/.pytest.rootdir
-touch ${NEUTRON_LBAAS_DIR}/neutron-lbaas/tests/tempest/v2/.pytest.rootdir
+touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${MAKEFILE_DIR}/../


### PR DESCRIPTION
@dflanigan @jlongstaf 

#### What issues does this address?
Fixes #398 

#### What's this change do?
Typo in path to write .pytest.rootdir for neutron-lbaas

#### Where should the reviewer start?

#### Any background context?
There was a typo in the path to reference the neutron-lbaas repository for creating the .pytest.rootdir file.