### PR TITLE
prep post_configure target to have more subtargets

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -107,7 +107,7 @@ tempest_11.5.4_overcloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.x overcloud VE deployment
 tempest_11.6.0_overcloud:
@@ -117,7 +117,7 @@ tempest_11.6.0_overcloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 tempest_11.6.1_overcloud:
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
@@ -126,7 +126,7 @@ tempest_11.6.1_overcloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x overcloud VE deployment
 tempest_12.1.1_overcloud:
@@ -136,7 +136,7 @@ tempest_12.1.1_overcloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.5.x undercloud VE deployment
 tempest_11.5.4_undercloud:
@@ -146,7 +146,7 @@ tempest_11.5.4_undercloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.x undercloud VE deployment
 tempest_11.6.0_undercloud:
@@ -156,7 +156,7 @@ tempest_11.6.0_undercloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 tempest_11.6.1_undercloud:
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
@@ -165,7 +165,7 @@ tempest_11.6.1_undercloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x undercloud VE deployment
 tempest_12.1.1_undercloud:
@@ -175,9 +175,12 @@ tempest_12.1.1_undercloud:
 	export GUMBALLS_PROJECT=$(PROJECT)_$(BRANCH)_$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(PROJECT)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	$(MAKE) -C . tempest_tests
+	$(MAKE) -C . run_tests
 
 # Once we have the variables setup we can run the tempest tests on our env
+run_tests:
+	$(MAKE) -C . tempest_tests
+
 tempest_tests:
 	$(MAKE) -C . tempest_tests-setup
 	$(MAKE) -C . tempest_tests-config

--- a/systest/scripts/tempest_config.sh
+++ b/systest/scripts/tempest_config.sh
@@ -18,11 +18,11 @@
 set -ex
 
 # Copy over our default tempest files
-cp conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
-cp conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
+cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
+cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
 
 # Find the values for tempest.conf and substitute them
-OS_CONTROLLER_IP=`tlc --session ${TEST_SESSION} symbols \
+OS_CONTROLLER_IP=`/tools/bin/tlc --session ${TEST_SESSION} symbols \
     | grep openstack_controller1ip_data_direct \
     | awk '{print $3}'`
 


### PR DESCRIPTION
@pjbreaux 
Issues:
Fixes #408

Problem: tempest_tests is too specific (as a general test-target name)

Analysis: In order to add new (functional) tests we needed to add
a make target underneath the device/cloud multiplex that could
itself take different test types as sub targets.

Tests: Run
