### PR TITLE
Fix failed preamble

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -121,7 +121,7 @@ cleanup_tlc_session:
 	cd scripts && ./$@.sh
 
 cleanup_failed_tlc:
-	@echo "running tlc --session TEST_SESSION --debug cleanup && exit -1..."
+	@echo "running tlc --session TEST_SESSION --debug cleanup && exit 1..."
 	cd scripts && ./$@.sh
 
 # BRANCH MAKE TARGETS:

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -98,15 +98,15 @@ install_tlc:
 
 install_test_infra:
 	@echo "installing tempest openstack interfaces and neutron_lbaas tests..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh
 
 setup_tlc_session:
 	@echo "setting up TLC session..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:
 	@echo "injecting TLC symbol and openstack IDs into 'tempest' conf files..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 run_neutron_lbaas:
 	@echo "running tests extracted from 'neutron_lbaas' project..."
@@ -118,6 +118,10 @@ run_agent_transfers:
 
 cleanup_tlc_session:
 	@echo "running tlc --session TEST_SESSION --debug cleanup..."
+	cd scripts && ./$@.sh
+
+cleanup_failed_tlc:
+	@echo "running tlc --session TEST_SESSION --debug cleanup && exit -1..."
 	cd scripts && ./$@.sh
 
 # BRANCH MAKE TARGETS:

--- a/systest/scripts/cleanup_failed_tlc.sh
+++ b/systest/scripts/cleanup_failed_tlc.sh
@@ -18,4 +18,4 @@
 set -x
 
 # We only need to cleanup the session, we didn't use barbican-enabled TLC file
-tlc --session ${TEST_SESSION} --debug cleanup && exit -1
+tlc --session ${TEST_SESSION} --debug cleanup; exit 1

--- a/systest/scripts/cleanup_failed_tlc.sh
+++ b/systest/scripts/cleanup_failed_tlc.sh
@@ -18,4 +18,4 @@
 set -x
 
 # We only need to cleanup the session, we didn't use barbican-enabled TLC file
-tlc --session ${TEST_SESSION} --debug cleanup; exit 1
+tlc --session ${TEST_SESSION} --debug cleanup; exit 217

--- a/systest/scripts/cleanup_failed_tlc.sh
+++ b/systest/scripts/cleanup_failed_tlc.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -x
+
+# We only need to cleanup the session, we didn't use barbican-enabled TLC file
+tlc --session ${TEST_SESSION} --debug cleanup && exit -1


### PR DESCRIPTION
@pjbreaux 
    Ensure that a failure in preamble steps kills the

    rest of the test session.

    Issues:
    Fixes #421

    Problem: Steps prior to the test run in the automated test system were
    failing, but the subsequent test run step still attempted to execute
    its doomed task.

    Analysis: This was caused by using Step0 || Cleanup.  The failure
    in Step0 was concealed by the successful Cleanup.

    Tests: NONE
