### PR TITLE
Gumballs incapable of parsing DRIVER_TEMPEST_SESSION var in Makefile

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -74,7 +74,7 @@ export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 # Results Directories
 export API_SESSION := api_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
-export DRIVER_TEMPEST_SESSION := driver_tempest_$(SUBJECTCODE_ID)_$(TIMESTAMP)
+export DRIVER_TEMPEST_SESSION := driver.tempest_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 # Install the TLC application
 tlc-install:


### PR DESCRIPTION
@zancas 

**Please wait for Kevin to give his thumbs up on this change as well, as this was suggested by him.**

#### What issues does this address?
Fixes #423

#### What's this change do?
Fixed the issue by changing the first underscore to a dot character.

#### Where should the reviewer start?

#### Any background context?
This fix is currently only applicable to the mitaka branch. We need to
modify the value of the variable above to not contain two underscore
characters, as this isn't acceptable by the gumballs parser.