### PR TITLE
From_agent_session name in Makefile need to be renamed

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -76,7 +76,7 @@ export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 # Results Directories
 export API_SESSION := api_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
-export FROM_AGENT_SESSION := from_agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
+export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 # LEAF MAKE TARGETS:
 #


### PR DESCRIPTION
@zancas 

Don't merge until you get your changes in.

#### What issues does this address?
Fixes #435 

#### What's this change do?
Changed the from_agent_session to replace the first underscore with a
dot.

#### Where should the reviewer start?

#### Any background context?
This change is applicable in liberty and mitaka and is required to make
gumballs report correctly in nightly. The parser which reports results
in gumballs doesn't handle the multiple underscores correctly when
reporting. We need to change one of the underscores to something else,
so those tests will fall in line with others.