### PR TITLE
hardcode target of rm -rf in scripts

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -47,11 +47,9 @@ export DEVTEST_DIR := /home/buildbot/dev-test
 export DEVTEST_REPO := git@bldr-git.int.lineratesystems.com:openstack/dev-test.git
 
 # tempest (OpenStack tempest test library)
-export TEMPEST_DIR := /home/buildbot/tempest
 export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 
 # neutron-lbaas (OpenStack Neutron LBaaS repo for the test cases to run)
-export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
 

--- a/systest/scripts/configure_test_infra.sh
+++ b/systest/scripts/configure_test_infra.sh
@@ -18,8 +18,8 @@
 set -ex
 
 # Copy over our default tempest files
-cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
-cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
+cp -f conf/tempest.conf /home/buildbot/virtualenvs/tempest/etc/tempest/tempest.conf.orig
+cp -f conf/accounts.yaml /home/buildbot/virtualenvs/tempest/etc/tempest/accounts.yaml
 
 # Find the values for tempest.conf and substitute them
 OS_CONTROLLER_IP=`/tools/bin/tlc --sid ${TEST_SESSION} symbols \

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -18,22 +18,22 @@
 set -ex
 
 # Create a virtualenv
-rm -rf ${TEMPEST_VENV_DIR}
-virtualenv ${TEMPEST_VENV_DIR}
+rm -rf /home/buildbot/virtualenvs/tempest
+virtualenv /home/buildbot/virtualenvs/tempest
 source ${TEMPEST_VENV_ACTIVATE}
 
 # Install tox
 pip install tox
 
 # Install tempest & its config files
-rm -rf ${TEMPEST_DIR}
-git clone ${TEMPEST_REPO} ${TEMPEST_DIR}
-pip install ${TEMPEST_DIR}
+rm -rf /home/buildbot/tempest
+git clone ${TEMPEST_REPO} /home/buildbot/tempest
+pip install /home/buildbot/tempest
 
 
 # We need to clone the OpenStack devtest repo for our TLC files
-rm -rf ${DEVTEST_DIR}
-git clone ${DEVTEST_REPO} ${DEVTEST_DIR}
+rm -rf /home/buildbot/dev-test
+git clone ${DEVTEST_REPO} /home/buildbot/dev-test
 
 pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
 # This should be listed in requirement.test.txt also, but will not succeed
@@ -53,12 +53,12 @@ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent.git@${BRAN
 #
 # TODO: Make a decision about not using the neutron-lbaas install script
 #       and just installing from requirements files on newest versions
-rm -rf ${NEUTRON_LBAAS_DIR}
+rm -rf /home/buildbot/neutron-lbaas
 git clone\
   -b ${NEUTRON_LBAAS_BRANCH} \
   --single-branch \
   ${NEUTRON_LBAAS_REPO} \
-  ${NEUTRON_LBAAS_DIR}
+  /home/buildbot/neutron-lbaas
 
 # Copy our tox.ini file to neutron so we can run py.test instead of testr
-cp -f conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
+cp -f conf/neutron-lbaas.tox.ini /home/buildbot/neutron-lbaas/f5.tox.ini

--- a/systest/scripts/install_tlc.sh
+++ b/systest/scripts/install_tlc.sh
@@ -42,16 +42,16 @@ pip install --upgrade pip
 pip install argcomplete blessings configargparse prettytable
 
 # Clone the toolsbase directory and setup the file system structure
-rm -rf ${TOOLSBASE_DIR}
-git clone ${TOOLSBASE_REPO} ${TOOLSBASE_DIR}
-mkdir ${TOOLSBASE_DIR}/independent/share
-mkdir ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/share
-rm -rf ${TOOLSBASE_DIR}/independent/bin/*.pyc
-rm -rf ${TOOLSBASE_DIR}/independent/bin/tlc_pb2.py
-rm -rf ${TOOLSBASE_DIR}/independent/lib/*.pyc
-rm -rf ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/bin/*.pyc
-rm -rf ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/lib/*.pyc
-ln -sf ${TOOLSBASE_DIR}/Ubuntu-10-x86_64 /tools
+rm -rf /toolsbase
+git clone ${TOOLSBASE_REPO} /toolsbase
+mkdir /toolsbase/independent/share
+mkdir /toolsbase/Ubuntu-10-x86_64/share
+rm -rf /toolsbase/independent/bin/*.pyc
+rm -rf /toolsbase/independent/bin/tlc_pb2.py
+rm -rf /toolsbase/independent/lib/*.pyc
+rm -rf /toolsbase/Ubuntu-10-x86_64/bin/*.pyc
+rm -rf /toolsbase/Ubuntu-10-x86_64/lib/*.pyc
+ln -sf /toolsbase/Ubuntu-10-x86_64 /tools
 
 # Remove all of the stale libs that are for some reason is toolsbase/bin
 libs="file_access.py
@@ -68,27 +68,27 @@ tlc_autocomplete.py
 utils.py
 "
 for lib in $libs; do
-  rm -f ${TOOLSBASE_DIR}/independent/bin/$lib
-  rm -f ${TOOLSBASE_DIR}/Ubuntu-10-x86_64/bin/$lib
+  rm -f /toolsbase/independent/bin/$lib
+  rm -f /toolsbase/Ubuntu-10-x86_64/bin/$lib
 done
 
 # Install TLC packages and binaries
-rm -rf ${TLC_DIR}
+rm -rf /home/buildbot/tlc
 git clone \
   -b ${TLC_BRANCH} \
   --single-branch \
   ${TLC_REPO} \
-  ${TLC_DIR}
+  /home/buildbot/tlc
 
 # Apply patches found for local changes to TLC on build server
 # Should these patches be applied in the repo for real?
 cp -f patches/* /tmp/
-patch ${TLC_DIR}/tlc/install.sh /tmp/tlc_install.sh.patch
-patch ${TOOLSBASE_DIR}/independent/create_softlinks /tmp/create_softlinks.patch
-patch ${TLC_DIR}/vmware/install.sh /tmp/vmware_install.patch
+patch /home/buildbot/tlc/tlc/install.sh /tmp/tlc_install.sh.patch
+patch /toolsbase/independent/create_softlinks /tmp/create_softlinks.patch
+patch /home/buildbot/tlc/vmware/install.sh /tmp/vmware_install.patch
 
 # Install all of the TLC sub-components
-cd ${TLC_DIR}
+cd /home/buildbot/tlc
 cd tlc && ./install.sh
 cd ../tl3 && ./install.sh
 cd ../vmware && ./install.sh

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -19,7 +19,7 @@ set -x
 
 # Activate our tempest virtualenv
 source ${TEMPEST_VENV_ACTIVATE}
-cd ${NEUTRON_LBAAS_DIR}
+cd /home/buildbot/neutron-lbaas
 
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini -- \


### PR DESCRIPTION
Issues:
Fixes #434

Problem: In order to make scripts rerunnable it's desirable to
remove directories, prior to running commands that populate them.
If the targets have variable names it's possible that an error
in variable assignment/creation could cause an incorrect directory
to be removed.

Analysis: This change makes the targets "hard-coded" to prevent
the possibility of a "variable injection" style error.

Tests: The changes were manually tested by running the make targets
in a buildbot sandbox environment.