### PR TITLE
check 'path' variables against expected values

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -94,35 +94,35 @@ export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 install_tlc:
 	@echo "installing the tlc client on the worker..."
-	cd scripts && sudo -EH ./$@.sh
+	cd scripts && ./disallow_dangerous_vars.sh && sudo -EH ./$@.sh
 
 install_test_infra:
 	@echo "installing tempest openstack interfaces and neutron_lbaas tests..."
-	cd scripts && ./$@.sh
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh
 
 setup_tlc_session:
 	@echo "setting up TLC session..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:
 	@echo "injecting TLC symbol and openstack IDs into 'tempest' conf files..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 run_neutron_lbaas:
 	@echo "running tests extracted from 'neutron_lbaas' project..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
 
 run_agent_transfers:
 	@echo "running tests extracted from 'f5-openstack-agent' project..."
-	cd scripts && ./$@.sh
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh
 
 cleanup_tlc_session:
 	@echo "running tlc --session TEST_SESSION --debug cleanup..."
-	cd scripts && ./$@.sh
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh
 
 cleanup_failed_tlc:
 	@echo "running tlc --session TEST_SESSION --debug cleanup && exit 1..."
-	cd scripts && ./$@.sh
+	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh
 
 # BRANCH MAKE TARGETS:
 #

--- a/systest/scripts/disallow_dangerous_vars.sh
+++ b/systest/scripts/disallow_dangerous_vars.sh
@@ -1,0 +1,46 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# The buildbot worker has access to the lab NFS.
+# It's possible that filesystem operations could have
+# unintended consequences if "PATH" variables are
+# incorrect.  This script restricts the "dangerous" path variables
+# to predefined values.
+# A developer must amend this list to insert new top-level path
+# variables.
+if [ "${TLC_DIR}" != "/home/buildbot/tlc" ];then
+    echo TLC_DIR "${TLC_DIR}" not allowed!
+    exit 31
+fi
+if [ "${TOOLSBASE_DIR}" != "/toolsbase" ];then
+    echo TOOLSBASE_DIR "${TOOLSBASE_DIR}" not allowed!
+    exit 31
+fi
+if [ "${DEVTEST_DIR}" != "/home/buildbot/dev-test" ];then
+    echo DEVTEST_DIR "${DEVTEST_DIR}" not allowed!
+    exit 31
+fi
+if [ "${TEMPEST_DIR}" != "/home/buildbot/tempest" ];then
+    echo TEMPEST_DIR "${TEMPEST_DIR}" not allowed!
+    exit 31
+fi
+if [ "${NEUTRON_LBAAS_DIR}" != "/home/buildbot/neutron-lbaas" ];then
+    echo NEUTRON_LBAAS_DIR "${NEUTRON_LBAAS_DIR}" not allowed!
+    exit 31
+fi
+if [ "${VENVDIR}" != "/home/buildbot/virtualenvs" ];then
+    echo VENVDIR "${VENVDIR}" not allowed!
+    exit 31
+fi


### PR DESCRIPTION
Issues:
Fixes #440

Problem: It's possible that filesystem operations on variables
with unexpected values could cause data loss on the lab NFS.
For example:  sudo rm -rf ${FOO}/${SPAM}
could be catastrophic if FOO == SPAM == ''

Analysis: As a better than nothing step, we validate known
"path" variables against their expected values.

Tests:  These changes were tested by running:

`make tempest_11.6.0_overcloud`

in a custom "buildbot sandbox" environment.
