### PR TITLE
Pool member creation fails with network_type opflex

### DIFF
--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -41,31 +41,40 @@ class DisconnectedService(object):
 
     def get_network_segment(self, context, agent_configuration, network):
         data = None
+
         network_segment_physical_network = \
             agent_configuration.get('network_segment_physical_network', None)
-        if network_segment_physical_network:
-            supported_encapsulations = [
-                x.lower() for x in self.supported_encapsulations +
-                agent_configuration.get('tunnel_types', [])
-            ]
-            # look up segment details in the ml2_network_segments table
-            segments = db.get_network_segments(context.session, network['id'],
-                                               filter_dynamic=None)
-            for segment in segments:
-                if ((network_segment_physical_network ==
-                     segment['physical_network']) and
-                    (segment['network_type'].lower() in
-                     supported_encapsulations)):
-                    data = segment
-                    break
-            if not data:
-                LOG.error('network_id %s does not match physical_network %s' %
-                          (network['id'], network_segment_physical_network))
-        else:
+
+        supported_encapsulations = [
+            x.lower() for x in self.supported_encapsulations +
+            agent_configuration.get('tunnel_types', [])
+        ]
+        # look up segment details in the ml2_network_segments table
+        segments = db.get_network_segments(context.session, network['id'],
+                                           filter_dynamic=None)
+
+        for segment in segments:
+            if ((network_segment_physical_network ==
+                 segment['physical_network']) and
+                (segment['network_type'].lower() in
+                 supported_encapsulations)):
+                data = segment
+                break
+            elif (network['provider:network_type'] == 'opflex' and
+                  segment['network_type'] == 'vlan'):
+                data = segment
+                LOG.debug("Got OPFLEX segment: %s" % segment)
+                break
+
+        if not data:
+            LOG.debug('Using default segment for network %s' %
+                      (network['id']))
+
             # neutron is expected to provide this data immediately
             data = {
                 'segmentation_id': network['provider:segmentation_id']
             }
             if 'provider:network_type' in network:
                 data['network_type'] = network['provider:network_type']
+
         return data

--- a/f5lbaasdriver/v2/bigip/neutron_client.py
+++ b/f5lbaasdriver/v2/bigip/neutron_client.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+u"""Service Module for F5® LBaaSv2."""
+# Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from neutron.api.v2 import attributes
+from neutron.common import constants as neutron_const
+from neutron.extensions import portbindings
+
+from oslo_log import helpers as log_helpers
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class F5NetworksNeutronClient(object):
+
+    def __init__(self, plugin):
+        self.plugin = plugin
+
+    def create_port_for_member(self,
+                               context,
+                               ip_address,
+                               mac_address=None,
+                               network_id=None, subnet_id=None):
+        member_port = None
+
+        if not mac_address:
+            mac_address = attributes.ATTR_NOT_SPECIFIED
+
+        with context.session.begin(subtransactions=True):
+            member_port = self.create_port_on_subnet(
+                context, subnet_id, ip_address=ip_address)
+        return member_port
+
+    @log_helpers.log_method_call
+    def create_port_on_subnet(self, context, subnet_id=None,
+                              mac_address=None, ip_address=None,
+                              name="", fixed_address_count=1, host=""):
+        """Create port on subnet."""
+        port = None
+
+        if not mac_address:
+            mac_address = attributes.ATTR_NOT_SPECIFIED
+
+        with context.session.begin(subtransactions=True):
+            if subnet_id:
+                try:
+                    subnet = self.plugin.db._core_plugin.get_subnet(
+                        context,
+                        subnet_id
+                    )
+                    fixed_ip = {'subnet_id': subnet['id']}
+                    if ip_address:
+                        fixed_ip['ip_address'] = ip_address
+                    fixed_ips = [fixed_ip]
+
+                    port_data = {
+                        'tenant_id': subnet['tenant_id'],
+                        'name': name,
+                        'network_id': subnet['network_id'],
+                        'mac_address': mac_address,
+                        'admin_state_up': True,
+                        'device_id': "",
+                        'device_owner': 'network:f5lbaasv2',
+                        'status': neutron_const.PORT_STATUS_ACTIVE,
+                        'fixed_ips': fixed_ips
+                    }
+
+                    if ('binding:capabilities' in
+                            portbindings.EXTENDED_ATTRIBUTES_2_0['ports']):
+                        port_data['binding:capabilities'] = {
+                            'port_filter': False}
+                    port = self.plugin.db._core_plugin.create_port(
+                        context, {'port': port_data})
+
+                    # Because ML2 marks ports DOWN by default on creation
+                    update_data = {
+                        'status': neutron_const.PORT_STATUS_ACTIVE
+                    }
+                    self.plugin.db._core_plugin.update_port(
+                        context, port['id'], {'port': update_data})
+
+                except Exception as e:
+                    LOG.error("Exception: create_port_on_subnet: %s",
+                              e.message)
+            context.session.flush()
+            return port
+
+    @log_helpers.log_method_call
+    def delete_port(self, context, port_id=None, mac_address=None):
+        """Delete port."""
+        with context.session.begin(subtransactions=True):
+            if port_id:
+                self.plugin.db._core_plugin.delete_port(context, port_id)
+            elif mac_address:
+                filters = {'mac_address': [mac_address]}
+                ports = self.plugin.db._core_plugin.get_ports(
+                    context,
+                    filters=filters
+                )
+                for port in ports:
+                    self.plugin.db._core_plugin.delete_port(
+                        context,
+                        port['id']
+                    )

--- a/f5lbaasdriver/v2/bigip/neutron_client.py
+++ b/f5lbaasdriver/v2/bigip/neutron_client.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""Service Module for F5® LBaaSv2."""
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright 2017 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -22,6 +22,7 @@ from oslo_log import log as logging
 
 from f5lbaasdriver.v2.bigip import constants_v2
 from f5lbaasdriver.v2.bigip.disconnected_service import DisconnectedService
+from f5lbaasdriver.v2.bigip import neutron_client as q_client
 
 LOG = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ class LBaaSv2ServiceBuilder(object):
         self.last_cache_update = datetime.datetime.fromtimestamp(0)
         self.plugin = self.driver.plugin
         self.disconnected_service = DisconnectedService()
+        self.q_client = q_client.F5NetworksNeutronClient(self.plugin)
 
     def build(self, context, loadbalancer, agent):
         """Get full service definition from loadbalancer ID."""
@@ -212,15 +214,17 @@ class LBaaSv2ServiceBuilder(object):
         # There should be only one.
         if len(ports) == 1:
             member_dict['port'] = ports[0]
-            self._populate_member_network(context, member_dict, network)
         else:
-            # FIXME(RJB: raise an exception here and let the driver handle
-            # the port that is not on the network.
-            LOG.error("Unexpected number of ports returned for member: ")
             if not ports:
-                LOG.error("No port found")
+                LOG.debug("Create port for member")
+                member_dict['port'] = \
+                    self.q_client.create_port_for_member(
+                        context, member.address,
+                        subnet_id=subnet_id)
             else:
                 LOG.error("Multiple ports found: %s" % ports)
+
+        self._populate_member_network(context, member_dict, network)
 
         return (member_dict, subnet, network)
 
@@ -277,20 +281,26 @@ class LBaaSv2ServiceBuilder(object):
         member['vxlan_vteps'] = []
         member['gre_vteps'] = []
 
-        if 'provider:network_type' in network:
-            net_type = network['provider:network_type']
-            if net_type == 'vxlan':
-                if 'binding:host_id' in member['port']:
-                    host = member['port']['binding:host_id']
-                    member['vxlan_vteps'] = self._get_endpoints(
-                        context, 'vxlan', host)
-            if net_type == 'gre':
-                if 'binding:host_id' in member['port']:
-                    host = member['port']['binding:host_id']
-                    member['gre_vteps'] = self._get_endpoints(
-                        context, 'gre', host)
-        if 'provider:network_type' not in network:
-            network['provider:network_type'] = 'undefined'
+        agent_config = {}
+        segment_data = self.disconnected_service.get_network_segment(
+            context, agent_config, network)
+        if segment_data:
+            network['provider:segmentation_id'] = \
+                segment_data.get('segmentation_id', None)
+            network['provider:network_type'] = \
+                segment_data.get('network_type', None)
+
+        net_type = network.get('provider:network_type', "undefined")
+        if net_type == 'vxlan':
+            if 'binding:host_id' in member['port']:
+                host = member['port']['binding:host_id']
+                member['vxlan_vteps'] = self._get_endpoints(
+                    context, 'vxlan', host)
+        if net_type == 'gre':
+            if 'binding:host_id' in member['port']:
+                host = member['port']['binding:host_id']
+                member['gre_vteps'] = self._get_endpoints(
+                    context, 'gre', host)
         if 'provider:segmentation_id' not in network:
             network['provider:segmentation_id'] = 0
 

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -16,6 +16,7 @@ u"""Service Module for F5® LBaaSv2."""
 #
 import datetime
 import json
+from netaddr import IPNetwork
 
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
@@ -214,17 +215,25 @@ class LBaaSv2ServiceBuilder(object):
         # There should be only one.
         if len(ports) == 1:
             member_dict['port'] = ports[0]
+            self._populate_member_network(context, member_dict, network)
         else:
             if not ports:
-                LOG.debug("Create port for member")
-                member_dict['port'] = \
-                    self.q_client.create_port_for_member(
-                        context, member.address,
-                        subnet_id=subnet_id)
+                cidr = IPNetwork(subnet['cidr'])
+                member_ip = IPNetwork("%s/%d" %
+                                      (member.address, cidr.prefixlen))
+                if cidr == member_ip:
+                    LOG.debug("Create port for member")
+                    member_dict['port'] = \
+                        self.q_client.create_port_for_member(
+                            context, member.address,
+                            subnet_id=subnet_id)
+                    self._populate_member_network(
+                        context, member_dict, network)
+                else:
+                    LOG.error("Member IP %s is not in subnet %s" %
+                              (member.address, subnet['cidr']))
             else:
                 LOG.error("Multiple ports found: %s" % ports)
-
-        self._populate_member_network(context, member_dict, network)
 
         return (member_dict, subnet, network)
 
@@ -301,6 +310,8 @@ class LBaaSv2ServiceBuilder(object):
                 host = member['port']['binding:host_id']
                 member['gre_vteps'] = self._get_endpoints(
                     context, 'gre', host)
+        if 'provider:network_type' not in network:
+            network['provider:network_type'] = 'undefined'
         if 'provider:segmentation_id' not in network:
             network['provider:segmentation_id'] = 0
 


### PR DESCRIPTION
Issues:
Fixes #443

Problem:
The fix for F5Networks/f5-openstack-lbaasv2-driver#353 enabled the
F5 driver/agent to detect and bind a virtual server to a dynamic VLAN
segment, created by Cisco ACI. Now pool member creation fails because
the agent cannot find the VLAN segment for the pool network.

Need to allow member creation with missing seg ID or network segment.
Community code already knows how to do the right thing to create a VLAN
network segment under the opflex parent. Follow that for member creation.
The current agent code expects the VLAN to be present prior to member
creation. For type opflex, need to move this earlier in the workflow.

Analysis:
- If the port for the service does not exist, we create one with the
f5lbaas device owner.
- Add logic to delete ports on member delete
if the owner is f5lbaas.
- Add logic to detect opflex network_type in disconnected service.
- Add segment data to pool member network definition.

Tests:
Manual:
Create loadbalancer service with all objects: listener, pool, members
Create member with and without existing port.
Create member on opflex network, add vlan child segment manually and
verify that the member is connected.
Create listener on opflex network, add vlan child segment manually
and verify that the virtual is created.
Create listener on opflex network, don't add segment and check that
the loadbalancer is put in 'ERROR' state after timeout.

TODO:
Automate above tests.
Run neutron-lbaas scenario tests.

