### PR TITLE
Policy object with rules becomes too large for message queue

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -457,7 +457,7 @@ class L7PolicyManager(EntityManager):
         """Create an L7 policy."""
 
         self.loadbalancer = policy.listener.loadbalancer
-        self.api_dict = policy.to_dict(listener=False)
+        self.api_dict = policy.to_dict(listener=False, rules=False)
         self._call_rpc(context, policy, 'create_l7policy')
 
     @log_helpers.log_method_call
@@ -484,7 +484,7 @@ class L7PolicyManager(EntityManager):
         """Delete a policy."""
 
         self.loadbalancer = policy.listener.loadbalancer
-        self.api_dict = policy.to_dict(listener=False)
+        self.api_dict = policy.to_dict(listener=False, rules=False)
         self._call_rpc(context, policy, 'delete_l7policy')
 
 


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #449 

#### What's this change do?
I fixed this in the to_dict calls in driver_v2, I added a filter on rules. These will not be recursively evaluated.

#### Where should the reviewer start?

#### Any background context?
When we retrieve the policy object in the driver_v2.py module with to_dict, if a rule exists for the policy, the rule will be retrieved recursively. This has the potential to create a very large policy object, especially if more than one rule exists.