### PR TITLE
Tempest api tests attempt to delete VIP port, which is managed by

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -127,6 +127,19 @@ class BaseTestCase(base.BaseNetworkTest):
                                          listener.get('id'))
                 cls._wait_for_load_balancer_status(lb_id)
             cls._try_delete_resource(cls._delete_load_balancer, lb_id)
+        # Wait for VIP port to be deleted
+        for vip_port in cls.vip_ports:
+            port_deleted = False
+            for i in range(20):
+                if cls.ports_client.is_resource_deleted(vip_port['id']):
+                    port_deleted = True
+                    break
+                time.sleep(1)
+            if port_deleted is False:
+                raise AssertionError(
+                    'VIP port {} not deleted by loadbalancer'.format(
+                        vip_port['id']))
+
         # Loadbalancer is gone, so folder on device should be gone too
         assert not cls.bigip_client.folder_exists(
             'Project_' + cls.subnet['tenant_id'])
@@ -155,6 +168,7 @@ class BaseTestCase(base.BaseNetworkTest):
     @classmethod
     def setUpClass(cls):
         cls.LOG = logging.getLogger(cls._get_full_case_name())
+        cls.vip_ports = []
         super(BaseTestCase, cls).setUpClass()
 
     def setUp(cls):
@@ -174,8 +188,10 @@ class BaseTestCase(base.BaseNetworkTest):
             cls._wait_for_load_balancer_status(lb.get('id'))
 
         cls._lbs_to_delete.append(lb.get('id'))
+        # Due to a possible race betwen the test port teardown and the lb
+        # delete in neutron-lbaas, the test should not tear down the VIP port.
         port = cls.ports_client.show_port(lb['vip_port_id'])
-        cls.ports.append(port['port'])
+        cls.vip_ports.append(port['port'])
         return lb
 
     @classmethod


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Fixes #456 

#### What's this change do?
Fixed the api base.py module to prevent the port deletion outright, and
properly wait for the loadbalancer delete to subsequently remove the VIP
port.

#### Where should the reviewer start?

#### Any background context?
The tempest tests often create a loadbalancer in test setup. Once that
lb is created, tempest searches for the VIP port that was also created
by the loadbalancer and puts it in a list to be deleted later.

The test should not need to cleanup that port, as it will be done once
the loadbalancer is deleted. We should have the test poll for the port,
to ensure it was deleted properly. Otherwise, for now, the test will
fail.

Ran this test against a stack where I modified a sleep on the
loadbalancer delete operation. The sleep was implemented before the VIP
port delete. By varying the time of sleep, we can see what happens when
the loadbalancer deletes the port implicitly and when it doesn't. We
raise if it doesn't.