### PR TITLE
Driver sets VIP port owner to 'network:f5lbaasv2'

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -171,7 +171,6 @@ class LoadBalancerManager(EntityManager):
                 'device_id': str(
                     uuid.uuid5(uuid.NAMESPACE_DNS, str(agent_host))
                 ),
-                'device_owner': 'network:f5lbaasv2',
                 'status': q_const.PORT_STATUS_ACTIVE
             }
             port_data[portbindings.HOST_ID] = agent_host


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Fixes #461 

#### What's this change do?
Removed the line to set the owner in driver_v2.py module.

Ran overcloud mitaka tests against this change the results look as it
does when not modified. This is as expected, since this issue can crop
up when the test tears down the VIP port at the exact time as the load
balancer deletion operation.

#### Where should the reviewer start?

#### Any background context?
The driver "takes ownership" of the VIP port (which is created by the
load balancer creation operation), and this is unnecessary. This appears
to directly affect the way the port is handled in neutron, especially
upon deletion. We are making this change in the mitaka branch to
troubleshoot nightly failures.