### PR TITLE
Service builder not using the segment physical_network field

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -241,7 +241,7 @@ class LBaaSv2PluginCallbacksRPC(object):
     @log_helpers.log_method_call
     def update_loadbalancer_status(self, context,
                                    loadbalancer_id=None,
-                                   status=plugin_constants.ERROR,
+                                   status=None,
                                    operating_status=None):
         """Agent confirmation hook to update loadbalancer status."""
         with context.session.begin(subtransactions=True):
@@ -340,7 +340,7 @@ class LBaaSv2PluginCallbacksRPC(object):
             self,
             context,
             member_id=None,
-            provisioning_status=plugin_constants.ERROR,
+            provisioning_status=None,
             operating_status=None):
         """Agent confirmations hook to update member status."""
         with context.session.begin(subtransactions=True):

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -98,9 +98,10 @@ class LBaaSv2ServiceBuilder(object):
             if segment_data:
                 network['provider:segmentation_id'] = \
                     segment_data.get('segmentation_id', None)
-                if 'provider:network_type' in network:
-                    network['provider:network_type'] = \
-                        segment_data.get('network_type', None)
+                network['provider:network_type'] = \
+                    segment_data.get('network_type', None)
+                network['provider:physical_network'] = \
+                    segment_data.get('physical_network', None)
             network_map[network_id] = network
 
             # Check if the tenant can create a loadbalancer on the network.


### PR DESCRIPTION
Issues:
Fixes #452

Problem:
Service builder is not completely populating the network dictionary
with all the values from the segments table. The error is that the
phyiscal_network_name is assumed to be defined in the top-level segment,
but this is not always the case.

Analysis:
Add the segment's physical_network field to the network definition
in the service object.

Tests:
Manual testing consisted of:
Create loadbalancer service with all objects: listener, pool, members
Create member with and without existing port.
Create member on opflex, add vlan child segment manually and verify
that the member is connected.
Create loadbalancer on opflex network, add vlan child segment
manual and verify that the virtual get's created.
Create loadbalancer on opflex network, don't add segment and check
that the loadbalacner goes to 'ERROR' state and that it can be deleted.
Create a member on the opflex network, don't add segment and check
that the member goes to 'ERROR' state after timeout period and verify
it can be deleted.
