### PR TITLE
[Docs] Issue 482 Fix; Removed duplicate entry for Global Routed Mode

### DIFF
--- a/docs/map_lbaasv2-features.rst
+++ b/docs/map_lbaasv2-features.rst
@@ -13,7 +13,6 @@ Supported Features
     High Availability <includes/topic_ha-modes>
     Device Clusters <includes/topic_clustering>
     Multi-Tenancy <includes/topic_multi-tenancy>
-    includes/topic_global-routed-mode
     includes/topic_cert-manager
     includes/topic_hierarchical-port-binding
     includes/topic_agent-redundancy-scaleout


### PR DESCRIPTION
#### What issues does this address?
Fixes #482

#### What's this change do?
Removed the duplicate GRM link in "Supported Features" section of the docs

#### Where should the reviewer start?
Review the only change made. 

#### Any background context?
Nope.