### PR TITLE
Unable to create loadbalancer on VLAN network

### DIFF
--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -76,5 +76,7 @@ class DisconnectedService(object):
             }
             if 'provider:network_type' in network:
                 data['network_type'] = network['provider:network_type']
+            if 'provider:physical_network' in network:
+                data['physical_network'] = network['provider:physical_network']
 
         return data

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -299,6 +299,8 @@ class LBaaSv2ServiceBuilder(object):
                 segment_data.get('segmentation_id', None)
             network['provider:network_type'] = \
                 segment_data.get('network_type', None)
+            network['provider:physical_network'] = \
+                segment_data.get('physical_network', None)
 
         net_type = network.get('provider:network_type', "undefined")
         if net_type == 'vxlan':


### PR DESCRIPTION
@richbrowne 

Issues:
Fixes #485

Problem:
Attempts to create loadbalancer fail. Loadbalancer object is in FAILED state and F5 agent emits a traceback.

Analysis:
The driver passes through provider:physical_network = None.  The agent attempts to construct a string using this value, which raises a TypeEror.  The driver needs to populate this field in the service definition, along with network_type and segmentation_id.

Tests:
*Note* This bug was reproduced on a manual VLAN deployment.  Work is in process to automate a VLAN deployment and add to nightly regression.
Create loadbalancer and listener, confirm objects reach ONLINE state and VLAN interface is created on BIG-IP.