### PR TITLE
Add support for GRE and VLAN network deployments

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -18,9 +18,13 @@
 install_tlc \
 install_test_infra \
 tempest_11.5.4_overcloud tempest_11.5.4_undercloud \
+tempest_11.5.4_undercloud_gre tempest_11.5.4_undercloud_vlan \
 tempest_11.6.0_overcloud tempest_11.6.0_undercloud \
+tempest_11.6.0_undercloud_gre tempest_11.6.0_undercloud_vlan \
 tempest_11.6.1_overcloud tempest_11.6.1_undercloud \
-tempest_12.1.1_overcloud tempest_12.1.1_undercloud
+tempest_11.6.1_undercloud_gre tempest_11.6.1_undercloud_vlan \
+tempest_12.1.1_overcloud tempest_12.1.1_undercloud \
+tempest_12.1.1_undercloud_gre tempest_12.1.1_undercloud_vlan
 
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
 export BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -139,9 +143,17 @@ functest: install_tlc install_test_infra
 	-$(MAKE) -C . tempest_11.6.1_overcloud
 	-$(MAKE) -C . tempest_12.1.1_overcloud
 	-$(MAKE) -C . tempest_11.5.4_undercloud
+	-$(MAKE) -C . tempest_11.5.4_undercloud_gre
+	-$(MAKE) -C . tempest_11.5.4_undercloud_vlan
 	-$(MAKE) -C . tempest_11.6.0_undercloud
+	-$(MAKE) -C . tempest_11.6.0_undercloud_gre
+	-$(MAKE) -C . tempest_11.6.0_undercloud_vlan
 	-$(MAKE) -C . tempest_11.6.1_undercloud
+	-$(MAKE) -C . tempest_11.6.1_undercloud_gre
+	-$(MAKE) -C . tempest_11.6.1_undercloud_vlan
 	-$(MAKE) -C . tempest_12.1.1_undercloud
+	-$(MAKE) -C . tempest_12.1.1_undercloud_gre
+	-$(MAKE) -C . tempest_12.1.1_undercloud_vlan
 
 # Not using the tempest TLC files for liberty because they install barbican
 # which causes the tests to lockup/hang
@@ -193,6 +205,27 @@ tempest_11.5.4_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.5.4_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.5.4_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.x undercloud VE deployment
@@ -203,6 +236,27 @@ tempest_11.6.0_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.0_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.0_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
 	$(MAKE) -C . run_tests
 
 tempest_11.6.1_undercloud:
@@ -212,6 +266,27 @@ tempest_11.6.1_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.1_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.1_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x undercloud VE deployment
@@ -222,7 +297,29 @@ tempest_12.1.1_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	$(MAKE) -C . run_tests
+
+tempest_12.1.1_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_12.1.1_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
+	$(MAKE) -C . run_tests
+
 
 run_tests:
 	$(MAKE) -C . setup_tlc_session


### PR DESCRIPTION
@pjbreaux 

**NOTE: Merge request 42 against the internal testlab tools repo MUST be accepted prior to this request, but it's useful to review them simultaneously.**

Issues:
Fixes #489

Problem:
Internal testlab OpenStack deployments only support global routed mode and VXLAN L2Adjacent mode. Need to support GRE and VLAN to round out 'encapsulated' network deployments for dev and nightly regression purposes.

Analysis:
Add make targets for gre and vlan that leverage new variable in OpenStack deployment tools to set tenant network type.

Tests:
Executed scenario tests via make on bbot-worker sandbox for vxlan, gre and vlan deployments. Session persistence fails, consistent with vxlan nightly results.

```
test_healthmonitor_basic.py::TestHealthMonitorBasic::test_health_monitor_basic <- .tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
test_listener_basic.py::TestListenerBasic::test_listener_basic <- .tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
test_load_balancer_basic.py::TestLoadBalancerBasic::test_load_balancer_basic <- .tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
test_load_balancer_tls.py::TestLoadBalancerTLS::test_load_balancer_tls <- .tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
test_loadbalancer_tls.py::TestLoadBalancerTLS::test_load_balancer_tls <- .tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
test_session_persistence.py::TestSessionPersistence::test_session_persistence <- .tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py FAILED
```