### PR TITLE
Travis builds fail in unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ before_install:
 - git config --global user.email "OpenStack_TravisCI@f5.com"
 - git config --global user.name "Travis F5 Openstack"
 install:
-- sudo pip install hacking pytest pytest-cov .
-- sudo pip install -r requirements.txt
-- sudo pip install -r requirements.docs.txt
+- pip install hacking pytest coverage
+- pip install -r requirements.test.txt
+- pip install -r requirements.docs.txt
 script:
 - flake8 ./f5lbaasdriver
+- coverage run --source f5lbaasdriver -m py.test f5lbaasdriver/v2/bigip/
+- coverage report
 - f5-openstack-lbaasv2-driver-dist/scripts/package.sh "redhat" "7"
 - f5-openstack-lbaasv2-driver-dist/scripts/package.sh "ubuntu" "14.04"
 - sudo chown -R travis:travis ${DIST_REPO}/rpms

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,6 +1,6 @@
 Sphinx>=1.4.5
 six>=1.10.0
 sphinx-rtd-theme
--e git+https://github.com/openstack/neutron#egg=neutron
--e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
-pytest
+git+https://github.com/openstack/neutron.git@liberty-eol
+git+https://github.com/openstack/neutron-lbaas.git@liberty-eol
+pytest==2.9.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,8 +1,13 @@
+-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/liberty
 -e .
+git+https://github.com/openstack/neutron.git@liberty-eol
+git+https://github.com/openstack/neutron-lbaas.git@liberty-eol
 git+https://github.com/F5Networks/pytest-symbols.git
-git+https://github.com/F5Networks/f5-openstack-test.git
+git+https://github.com/F5Networks/f5-openstack-test.git@liberty
+git+https://github.com/openstack/tempest.git@12.0.0
 
 mock==1.3.0
 pytest==2.9.1
-decorator==4.0.9
+pytest-cov==2.2.1
+decorator==4.0.6
 paramiko==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-# app
--e git+https://github.com/openstack/neutron#egg=neutron
--e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
-
-# Test Requirements
-mock==1.3.0
-pytest==2.9.1
-decorator==4.0.9
-paramiko==1.16.0


### PR DESCRIPTION
Issues:
Fixes #501

Problem:
Unit test run on a PR in Travis fails due to an object attribute no longer being present.  Requirements files do to not correctly pin package versions, and external packages have drifted forward and removed expected functionality.
dd

Analysis:
Pin versions to openstack upper-contraints for the appropriate branch.

Tests:
Travis builds pass again and able to execute unit tests within local virtualenv.
