### PR TITLE
Merge Liberty to Mitaka

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
 - git config --global user.name "Travis F5 Openstack"
 install:
 - pip install hacking pytest coverage
-- pip install -r requirements.txt
 - pip install -r requirements.test.txt
 - pip install -r requirements.docs.txt
 script:

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,6 +1,6 @@
 Sphinx>=1.4.5
 six>=1.10.0
 sphinx-rtd-theme
--e git+https://github.com/openstack/neutron#egg=neutron
--e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
-pytest
+git+https://github.com/openstack/neutron.git@liberty-eol
+git+https://github.com/openstack/neutron-lbaas.git@liberty-eol
+pytest==2.9.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,12 +1,13 @@
+-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
 -e .
-git+https://github.com/F5Networks/pytest-symbols.git
-git+https://github.com/F5Networks/f5-openstack-test.git
 git+https://github.com/openstack/neutron.git@stable/mitaka
-git+https://github.com/openstack/neutron-lbaas.git@8.3.0
+git+https://github.com/openstack/neutron-lbaas.git@stable/mitaka
+git+https://github.com/F5Networks/pytest-symbols.git
+git+https://github.com/F5Networks/f5-openstack-test.git@mitaka
 git+https://github.com/openstack/tempest.git@12.0.0
 
 mock==1.3.0
 pytest==2.9.1
-pytest-cov
+pytest-cov==2.2.1
 decorator==4.0.9
 paramiko==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-# app
--e git+https://github.com/openstack/neutron#egg=neutron
--e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
-
-# Test Requirements
-mock==1.3.0
-pytest==2.9.1
-decorator==4.0.9
-paramiko==1.16.0

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -18,9 +18,13 @@
 install_tlc \
 install_test_infra \
 tempest_11.5.4_overcloud tempest_11.5.4_undercloud \
+tempest_11.5.4_undercloud_gre tempest_11.5.4_undercloud_vlan \
 tempest_11.6.0_overcloud tempest_11.6.0_undercloud \
+tempest_11.6.0_undercloud_gre tempest_11.6.0_undercloud_vlan \
 tempest_11.6.1_overcloud tempest_11.6.1_undercloud \
-tempest_12.1.1_overcloud tempest_12.1.1_undercloud
+tempest_11.6.1_undercloud_gre tempest_11.6.1_undercloud_vlan \
+tempest_12.1.1_overcloud tempest_12.1.1_undercloud \
+tempest_12.1.1_undercloud_gre tempest_12.1.1_undercloud_vlan
 
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
 export BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -140,9 +144,17 @@ functest: install_tlc install_test_infra
 	-$(MAKE) -C . tempest_11.6.1_overcloud
 	-$(MAKE) -C . tempest_12.1.1_overcloud
 	-$(MAKE) -C . tempest_11.5.4_undercloud
+	-$(MAKE) -C . tempest_11.5.4_undercloud_gre
+	-$(MAKE) -C . tempest_11.5.4_undercloud_vlan
 	-$(MAKE) -C . tempest_11.6.0_undercloud
+	-$(MAKE) -C . tempest_11.6.0_undercloud_gre
+	-$(MAKE) -C . tempest_11.6.0_undercloud_vlan
 	-$(MAKE) -C . tempest_11.6.1_undercloud
+	-$(MAKE) -C . tempest_11.6.1_undercloud_gre
+	-$(MAKE) -C . tempest_11.6.1_undercloud_vlan
 	-$(MAKE) -C . tempest_12.1.1_undercloud
+	-$(MAKE) -C . tempest_12.1.1_undercloud_gre
+	-$(MAKE) -C . tempest_12.1.1_undercloud_vlan
 
 # Not using the tempest TLC files for liberty because they install barbican
 # which causes the tests to lockup/hang
@@ -194,6 +206,27 @@ tempest_11.5.4_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.5.4_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.5.4_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.x undercloud VE deployment
@@ -204,6 +237,27 @@ tempest_11.6.0_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.0_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.0_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
 	$(MAKE) -C . run_tests
 
 tempest_11.6.1_undercloud:
@@ -213,6 +267,27 @@ tempest_11.6.1_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.1_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_11.6.1_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x undercloud VE deployment
@@ -223,7 +298,29 @@ tempest_12.1.1_undercloud:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	$(MAKE) -C . run_tests
+
+tempest_12.1.1_undercloud_gre:
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	$(MAKE) -C . run_tests
+
+tempest_12.1.1_undercloud_vlan:
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
+	$(MAKE) -C . run_tests
+
 
 run_tests:
 	$(MAKE) -C . setup_tlc_session


### PR DESCRIPTION
Issues:
Fixes #501

Problem:
Unit test run on a PR in Travis fails due to an object attribute no longer being present. Requirements files do to not correctly pin package versions, and external packages have drifted forward and removed expected functionality.
dd

Analysis:
Pin versions to openstack upper-contraints for the appropriate branch.

Tests:
Travis builds pass again and able to execute unit tests within local virtualenv.

Note:
Also merges recent changes in liberty (VLAN and GRE network deployments)