### PR TITLE
Makefile script in liberty does not teardown barbican containers

### DIFF
--- a/systest/scripts/cleanup_tlc_session.sh
+++ b/systest/scripts/cleanup_tlc_session.sh
@@ -17,6 +17,6 @@
 
 set -x
 
-# We only need to cleanup the session, we didn't use barbican-enabled TLC file
+# Teardown the barbican worker and cleanup the TLC session
 tlc --session ${TEST_SESSION} --debug cmd uninstall_barbican
 tlc --session ${TEST_SESSION} --debug cleanup

--- a/systest/scripts/cleanup_tlc_session.sh
+++ b/systest/scripts/cleanup_tlc_session.sh
@@ -18,4 +18,5 @@
 set -x
 
 # We only need to cleanup the session, we didn't use barbican-enabled TLC file
+tlc --session ${TEST_SESSION} --debug cmd uninstall_barbican
 tlc --session ${TEST_SESSION} --debug cleanup


### PR DESCRIPTION
@mattgreene @dflanigan 

#### What issues does this address?
Fixes #507

#### What's this change do?
Added the barbican container cleanup to the cleanup_tlc_session.sh
script.

#### Where should the reviewer start?

#### Any background context?
The makefile script cleanup_tlc_session.sh does not cleanup the barbican
container with the uninstall_barbican tlc command. This is because
previously, we were not using barbican in the liberty branch.