### PR TITLE
L7 policy update test failures due to bad test teardowns

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -174,11 +174,9 @@ class BaseTestCase(base.BaseNetworkTest):
     def setUp(cls):
         cls.LOG.info(('Starting: {0}').format(cls._testMethodName))
         super(BaseTestCase, cls).setUp()
-        cls.bigip_client.snapshot_device()
 
     def tearDown(cls):
         super(BaseTestCase, cls).tearDown()
-        cls.bigip_client.reset_device_to_pretest_snapshot()
         cls.LOG.info(('Finished: {0}\n').format(cls._testMethodName))
 
     @classmethod


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #500 

#### What's this change do?
Removed the calls to snapshot the bigip device and to reset the device
to snapshot. I left the plumbing in the bigip client, in case we want to
reimplement this in a more intelligent way, but right now, it's causing
more trouble than it's worth. And we already have an intelligent
teardown in resource_cleanup in base.py for the api tests. We'll leave
it at that for now.

#### Where should the reviewer start?

#### Any background context?
A certain set of the update tests are failing due to a new cleanup I
implemented to wipe the BIG-IP in case a test failed. The BIG-IP cleanup
looks like it is actually occurring before teardown of other neutron
objects created during the test, so we should move it to one of the last
functions of the test teardown, to ensure the test has had a chance to
properly teardown as much as possible. Then we teardown any leftover
things on the BIG-IP.