### PR TITLE
Branch-specific test infrastructure

### DIFF
--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -33,7 +33,7 @@ pip install ${TEMPEST_DIR}
 
 # We need to clone the OpenStack devtest repo for our TLC files
 rm -rf ${DEVTEST_DIR}
-git clone ${DEVTEST_REPO} ${DEVTEST_DIR}
+git clone -b ${TEST_OPENSTACK_DISTRO} ${DEVTEST_REPO} ${DEVTEST_DIR}
 
 pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
 # This should be listed in requirement.test.txt also, but will not succeed


### PR DESCRIPTION
Issues:
Fixes #506

Problem:
Automated regression infra currently uses one branch and tracks release-specific operations via filenames containing the OpenStack release. Migrate to using a branch per release to be consistent with product r    epos.

Analysis:
Add branch (OpenStack distro) when cloning test infra installation scripts.

Tests:
Manual confirmation that install_test_infra cloned the correct code/branch.

#### Any background context?
Test infra already has liberty and mitaka branches that are identical to master.  Nightly regression currently works from master branch.