### PR TITLE
Liberty nightly test runs needs to set a .pytest.rootdir

### DIFF
--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -24,6 +24,8 @@ cd ${NEUTRON_LBAAS_DIR}
 # The following tox commands will fail, if the ${EXCLUDE_FILE}
 # doesn't exist in the ${EXCLUDE_DIR}.
 
+# Create .pytest.rootdir file at root of the neutron-lbaas repository directory
+touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
 
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini --sitepackages -- \


### PR DESCRIPTION
Issues:
Fixes #526

Problem:


Analysis:
Added a command in the run_neutron_lbaas.sh script to touch the
.pytest.rootdir file in the neutron-lbaas repo directory.



@szakeri 
#### What issues does this address?
Fixes #526 

#### What's this change do?
Added a command in the run_neutron_lbaas.sh script to touch the
.pytest.rootdir file in the neutron-lbaas repo directory

#### Where should the reviewer start?

#### Any background context?
The liberty test runs now have a --meta option to pytest to exclude
certain sets of tests. This change caused the pytest root directory to
change, which means the suite name in trtl also changed in nightly
gumballs. That means that newer gumballs results don't line up with the
historical results, because gumballs views those two separate suite
names as different tests. We need to make them line up again. We do that
by creating a file '.pytest.rootdir' in the appropriate location
(/home/buildbot) so that gumballs is happy again.

#### Tests:
Ran tests in buildbot worker and pytest results are rooted at the proper
directory:

```
buildbot@750e23099fb8:/home/testlab/f5-openstack-lbaasv2-driver/systest/test_results$ cd f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_liberty-tempest_11.6.1_overcloud/api_2ac969e_20170414-155626/
buildbot@750e23099fb8:/home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_liberty-tempest_11.6.1_overcloud/api_2ac969e_20170414-155626$ ls
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson-suiteresult.json						       api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_empty_tls_container-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_create_listener_empty_tls_container-testresult.json        api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_empty_uuid_tls_container-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_create_listener_empty_uuid_tls_container-testresult.json   api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_invalid_tls_container-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_create_listener_invalid_tls_container-testresult.json      api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_none_tls_container-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_create_listener_nonexistent_tls_container-testresult.json  api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_nonexistent_tls_container-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_create_tls_listener-testresult.json			       api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_tls_port-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_delete_tls_listener-testresult.json			       api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_listener_tls_protocol-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_get_tls_listener-testresult.json			       api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_update_tls_listener-testresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_list_tls_listeners-testresult.json			       api_2ac969e_20170414-155626-sessionresult.json
api_2ac969e_20170414-155626-neutron_lbaas.tests.tempest.v2.api.test_listeners_tls.tlslistenerstestjson.test_list_tls_listeners_two-testresult.json
buildbot@750e23099fb8:/home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_liberty-tempest_11.6.1_overcloud/api_2ac969e_20170414-155626$
```