### PR TITLE
Newton process creation event changed from mitaka

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ version = VERSION
 release = VERSION
 
 # OpenStack release
-openstack_release = "Mitaka"
+openstack_release = "Newton"
 rst_epilog = """
 .. |openstack| replace:: {0}
 """.format(openstack_release)
@@ -311,17 +311,17 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 
 intersphinx_mapping = {'heat': (
-     'http://f5-openstack-heat.readthedocs.io/en/mitaka', None),
+     'http://f5-openstack-heat.readthedocs.io/en/newton', None),
      'heatplugins': (
-     'http://f5-openstack-heat-plugins.readthedocs.io/en/mitaka', None),
+     'http://f5-openstack-heat-plugins.readthedocs.io/en/newton', None),
      'lbaasv1': (
-     'http://f5-openstack-lbaasv1.readthedocs.io/en/mitaka/', None),
+     'http://f5-openstack-lbaasv1.readthedocs.io/en/newton/', None),
      'agent': (
-     'http://f5-openstack-agent.readthedocs.io/en/mitaka/', None),
+     'http://f5-openstack-agent.readthedocs.io/en/newton/', None),
      'f5sdk': (
      'http://f5-sdk.readthedocs.io/en/latest/', None),
      'docs': (
-     'http://f5-openstack-docs.readthedocs.io/en/mitaka/', None),
+     'http://f5-openstack-docs.readthedocs.io/en/newton/', None),
 }
 
 rst_epilog = '''

--- a/f5lbaasdriver/test/tempest/tests/scenario/f5_base.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/f5_base.py
@@ -19,7 +19,6 @@ from f5lbaasdriver.test.tempest.services.clients import l7rule_client
 
 from tempest import config
 from tempest.lib.exceptions import NotFound
-from tempest.scenario import network_resources as net_resources
 
 
 config = config.CONF
@@ -92,10 +91,9 @@ class F5BaseTestCase(base.BaseTestCase):
         if ip_version == 4:
             if (config.network.public_network_id and not
                     config.network.project_networks_reachable):
-                load_balancer = net_resources.AttributeDict(self.load_balancer)
-                self._assign_floating_ip_to_lb_vip(load_balancer)
+                self._assign_floating_ip_to_lb_vip(self.load_balancer)
                 self.vip_ip = self.floating_ips[
-                    load_balancer.id][0]['floating_ip_address']
+                    load_balancer_id][0]['floating_ip_address']
 
         # Currently the ovs-agent is not enforcing security groups on the
         # vip port - see https://bugs.launchpad.net/neutron/+bug/1163569

--- a/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
@@ -18,7 +18,6 @@ import time
 
 from neutron_lbaas.tests.tempest.v2.scenario import base
 from tempest import config
-from tempest.scenario import network_resources as net_resources
 
 config = config.CONF
 
@@ -73,10 +72,9 @@ class F5StatsBaseTestCase(base.BaseTestCase):
         if ip_version == 4:
             if (config.network.public_network_id and not
                     config.network.project_networks_reachable):
-                load_balancer = net_resources.AttributeDict(self.load_balancer)
-                self._assign_floating_ip_to_lb_vip(load_balancer)
+                self._assign_floating_ip_to_lb_vip(self.load_balancer)
                 self.vip_ip = self.floating_ips[
-                    load_balancer.id][0]['floating_ip_address']
+                    self.load_balancer.id][0]['floating_ip_address']
 
         # Currently the ovs-agent is not enforcing security groups on the
         # vip port - see https://bugs.launchpad.net/neutron/+bug/1163569

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -109,7 +109,7 @@ class F5DriverV2(object):
             {q_const.AGENT_TYPE_LOADBALANCER: self.agent_rpc})
 
         registry.subscribe(
-            self.post_fork_callback, resources.PROCESS, events.AFTER_CREATE)
+            self.post_fork_callback, resources.PROCESS, events.AFTER_INIT)
 
     def post_fork_callback(self, resources, event, trigger):
         LOG.debug("F5DriverV2 received post neutron child fork "

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,6 +1,6 @@
 Sphinx>=1.4.5
 six>=1.10.0
 sphinx-rtd-theme
-git+https://github.com/openstack/neutron.git@stable/mitaka
-git+https://github.com/openstack/neutron-lbaas.git@stable/mitaka
-pytest==2.9.1
+git+https://github.com/openstack/neutron.git@stable/newton
+git+https://github.com/openstack/neutron-lbaas.git@stable/newton
+pytest==3.0.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,13 +1,13 @@
--c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
+-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 -e .
-git+https://github.com/openstack/neutron.git@stable/mitaka
-git+https://github.com/openstack/neutron-lbaas.git@stable/mitaka
+git+https://github.com/openstack/neutron.git@stable/newton
+git+https://github.com/openstack/neutron-lbaas.git@stable/newton
 git+https://github.com/F5Networks/pytest-symbols.git
-git+https://github.com/F5Networks/f5-openstack-test.git@mitaka
-git+https://github.com/openstack/tempest.git@12.0.0
+git+https://github.com/F5Networks/f5-openstack-test.git@stable/newton
+tempest==12.1.0
 
 mock==1.3.0
-pytest==2.9.1
+pytest==3.0.1
 pytest-cov==2.2.1
 decorator==4.0.9
 paramiko==1.16.0

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -47,7 +47,7 @@ export TLC_BRANCH := buildbot
 
 # toolsbase (replicate internal directory structure for TLC install)
 export TOOLSBASE_DIR := /toolsbase
-export TOOLSBASE_REPO := https://bldr-git.int.lineratesystems.com/openstack/tlc-toolsbase.git
+export TOOLSBASE_REPO := https://gitlab.pdbld.f5net.com/openstack/tlc-toolsbase.git
 
 # dev-test (contains all of our TLC files for configuration)
 export DEVTEST_DIR := /home/buildbot/dev-test
@@ -60,7 +60,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 # neutron-lbaas (OpenStack Neutron LBaaS repo for the test cases to run)
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
-export NEUTRON_LBAAS_BRANCH := stable/mitaka
+export NEUTRON_LBAAS_BRANCH := stable/newton
 
 # TLC path and python path requirements
 export PATH := /tools/bin:$(PATH)

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -35,13 +35,13 @@ pip install ${TEMPEST_DIR}
 rm -rf ${DEVTEST_DIR}
 git clone -b ${TEST_OPENSTACK_DISTRO} ${DEVTEST_REPO} ${DEVTEST_DIR}
 
-pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
+pip install git+https://gitlab.pdbld.f5net.com/tools/pytest-autolog.git
 # This should be listed in requirement.test.txt also, but will not succeed
 # from that location without sudo
 sudo pip install git+https://github.com/F5Networks/f5-openstack-agent.git@${BRANCH}
-# Install neutron at stable/mitaka because stable/liberty tests will not work
-# because they use an upper contraints file in the installation script that
-# neutron-lbaas uses for tox tests.
+# Install neutron at stable/mitaka or stable/newton because stable/liberty tests
+# will not work because they use an upper contraints file in the installation script
+# that neutron-lbaas uses for tox tests.
 # The file that causes this to happen is: neutron-lbaas/tools/tox_install.sh
 #
 # The use of the liberty version of this file restricts the crpytography


### PR DESCRIPTION
@jlongstaf  @ssorenso 

#### What issues does this address?
Fixes #528 

#### What's this change do?
Changed the AFTER_CREATE event to AFTER_INIT and communication then
flowed between driver and agent.

Also modified requirements files, systest Makefile, and docs to reflect newton branch. A few tempest test fixups are also here since I was testing running our tempest tests to ensure my test newton stack was functioning correctly.

#### Where should the reviewer start?
Start at the doc and systest changes. 

#### Any background context?
When a neutron worker is created in mitaka, the AFTER_CREATE event is
emitted, yet when the worker is created in newton, the AFTER_INIT event
is emitted. Now that we wait for these processes to be forked before we
create the RPC listener in the driver, we must rely upon the proper
event before agent and driver communication can commence.