### PR TITLE
fixing scenario tests failure for both driver and neutron-lbaas

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -61,7 +61,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
-export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
+export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(NEUTRON_LBAAS_BRANCH)
 
 # TLC path and python path requirements
 export PATH := /tools/bin:$(PATH)
@@ -78,8 +78,7 @@ export TLC_FILE_DIR := $(DEVTEST_DIR)/traffic
 # Virtualenv & tempest requirements
 export VENVDIR := /home/buildbot/virtualenvs
 export TEMPEST_VENV_DIR := $(VENVDIR)/tempest
-export TEMPEST_VENV_ETC_DIR := $(TEMPEST_VENV_DIR)/etc
-export TEMPEST_CONFIG_DIR := $(TEMPEST_VENV_ETC_DIR)/tempest
+export TEMPEST_CONFIG_DIR := $(TEMPEST_VENV_DIR)/etc/tempest
 export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 
 # Results Directories

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -61,6 +61,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
+export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
 
 # TLC path and python path requirements
 export PATH := /tools/bin:$(PATH)
@@ -77,7 +78,8 @@ export TLC_FILE_DIR := $(DEVTEST_DIR)/traffic
 # Virtualenv & tempest requirements
 export VENVDIR := /home/buildbot/virtualenvs
 export TEMPEST_VENV_DIR := $(VENVDIR)/tempest
-export TEMPEST_CONFIG_DIR := $(TEMPEST_VENV_DIR)/etc/tempest
+export TEMPEST_VENV_ETC_DIR := $(TEMPEST_VENV_DIR)/etc
+export TEMPEST_CONFIG_DIR := $(TEMPEST_VENV_ETC_DIR)/tempest
 export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 
 # Results Directories

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -56,8 +56,7 @@ git clone\
   ${NEUTRON_LBAAS_DIR}
 
 # create directories for copying tempest.conf file
+mkdir -p ${TEMPEST_CONFIG_DIR}
 
-mkdir ${TEMPEST_VENV_ETC_DIR}
-mkdir ${TEMPEST_CONFIG_DIR}
 # Copy our tox.ini file to neutron so we can run py.test instead of testr
 cp -f conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -25,11 +25,6 @@ source ${TEMPEST_VENV_ACTIVATE}
 # Install tox
 pip install tox
 
-# Install tempest & its config files
-rm -rf ${TEMPEST_DIR}
-git clone ${TEMPEST_REPO} ${TEMPEST_DIR}
-pip install ${TEMPEST_DIR}
-
 
 # We need to clone the OpenStack devtest repo for our TLC files
 rm -rf ${DEVTEST_DIR}
@@ -60,5 +55,9 @@ git clone\
   ${NEUTRON_LBAAS_REPO} \
   ${NEUTRON_LBAAS_DIR}
 
+# create directories for copying tempest.conf file
+
+mkdir ${TEMPEST_VENV_ETC_DIR}
+mkdir ${TEMPEST_CONFIG_DIR}
 # Copy our tox.ini file to neutron so we can run py.test instead of testr
 cp -f conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini


### PR DESCRIPTION
adding stable/mitaka tag to upper_constraint.txt file and removing tempest installation as part of install_test_infra

@swormke @mattgreene 

#### What issues does this address?
Fixes #537 

#### What's this change do?
This change will pin upper constraint file to the stable/mitaka branch. Also it gets rid of installing tempest from upstream as part of installing test infrastructure.

#### Where should the reviewer start?
systest/Makefile
systest/scripts/install_test_infra.sh

#### Any background context?
This fix will work with the fix that goes in to the neutron-lbaas issue27.