### PR TITLE
adding upper constraints file for stable/liberty

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -61,6 +61,9 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
+export UPPER_CONSTRAINTS_BRANCH := stable/liberty
+https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(UPPER_CONSTRAINTS_BRANCH)
+
 
 # TLC path and python path requirements
 export PATH := /tools/bin:$(PATH)

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -61,8 +61,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
-export UPPER_CONSTRAINTS_BRANCH := stable/liberty
-https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(UPPER_CONSTRAINTS_BRANCH)
+https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/$(BRANCH)
 
 
 # TLC path and python path requirements

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -61,7 +61,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
-https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/$(BRANCH)
+export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(NEUTRON_LBAAS_BRANCH)
 
 
 # TLC path and python path requirements

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -25,11 +25,6 @@ source ${TEMPEST_VENV_ACTIVATE}
 # Install tox
 pip install tox
 
-# Install tempest & its config files
-rm -rf ${TEMPEST_DIR}
-git clone ${TEMPEST_REPO} ${TEMPEST_DIR}
-pip install ${TEMPEST_DIR}
-
 
 # We need to clone the OpenStack devtest repo for our TLC files
 rm -rf ${DEVTEST_DIR}
@@ -59,6 +54,9 @@ git clone\
   --single-branch \
   ${NEUTRON_LBAAS_REPO} \
   ${NEUTRON_LBAAS_DIR}
+
+# create directories for copying tempest.conf file
+mkdir -p ${TEMPEST_CONFIG_DIR}
 
 # Copy our tox.ini file to neutron so we can run py.test instead of testr
 cp -f conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -41,6 +41,5 @@ tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${SCENARIO_SESSION}
 
-
 # Returning pass so that all tests run
 exit 0

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -41,5 +41,8 @@ tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${SCENARIO_SESSION}
 
+# create directories for copying tempest.conf file
+mkdir -p ${TEMPEST_CONFIG_DIR}
+
 # Returning pass so that all tests run
 exit 0

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -41,8 +41,6 @@ tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${SCENARIO_SESSION}
 
-# create directories for copying tempest.conf file
-mkdir -p ${TEMPEST_CONFIG_DIR}
 
 # Returning pass so that all tests run
 exit 0


### PR DESCRIPTION
adding stable/liberty tag to upper_constraint.txt file and creating tempest conf dir as part of install_test_infra

@swormke @mattgreene 

**What issues does this address?**

Fixes #537

**What's this change do?**

This change will pin upper constraint file to the stable/liberty branch. Also it creates tempest config directory.

**Where should the reviewer start?**

systest/Makefile
systest/scripts/install_test_infra.sh

**Any background context?**

This fix will work with the fix that goes in to the neutron-lbaas issue27.