### PR TITLE
adding upper constraints file for stable/liberty (#539)

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -61,6 +61,8 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/buildbot/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 export NEUTRON_LBAAS_BRANCH := stable/mitaka
+export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(NEUTRON_LBAAS_BRANCH)
+
 
 # TLC path and python path requirements
 export PATH := /tools/bin:$(PATH)

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -25,11 +25,6 @@ source ${TEMPEST_VENV_ACTIVATE}
 # Install tox
 pip install tox
 
-# Install tempest & its config files
-rm -rf ${TEMPEST_DIR}
-git clone ${TEMPEST_REPO} ${TEMPEST_DIR}
-pip install ${TEMPEST_DIR}
-
 
 # We need to clone the OpenStack devtest repo for our TLC files
 rm -rf ${DEVTEST_DIR}
@@ -59,6 +54,9 @@ git clone\
   --single-branch \
   ${NEUTRON_LBAAS_REPO} \
   ${NEUTRON_LBAAS_DIR}
+
+# create directories for copying tempest.conf file
+mkdir -p ${TEMPEST_CONFIG_DIR}
 
 # Copy our tox.ini file to neutron so we can run py.test instead of testr
 cp -f conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini


### PR DESCRIPTION
adding stable/liberty tag to upper_constraint.txt file and creating tempest conf dir as part of install_test_infra

Fixes:
Issus #537

Problem:
Tests failing due to missing object attributes.

Analysis:
Incorrect version pining for neutron_lbass resulted in using upper-constraints from master.  Master have moved forward and changed objects that are not backwards compatible.  This change will pin upper constraint file to the stable/liberty branch. Also it creates tempest config directory.