### PR TITLE
Make error logging more verbose

### DIFF
--- a/systest/scripts/run_agent_transfers.sh
+++ b/systest/scripts/run_agent_transfers.sh
@@ -21,7 +21,7 @@ set -x
 source ${TEMPEST_VENV_ACTIVATE}
 
 tox --sitepackages -e functional -- \
-  -lvv --tb=short \
+  -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${FROM_AGENT_SESSION} \
   ${TEST_DIR}/functional/from_agent

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -35,7 +35,7 @@ cd ${MAKEFILE_DIR}/../
 
 tox --sitepackages -e tempest -c tox.ini -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
-  -lvv --tb=line \
+  -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${DRIVER_TEMPEST_SESSION}
 
@@ -44,14 +44,14 @@ cd ${NEUTRON_LBAAS_DIR}
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
-  -lvv --tb=short \
+  -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${API_SESSION}
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
 tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
-  -lvv --tb=short \
+  -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${SCENARIO_SESSION}
 


### PR DESCRIPTION
Issues:
Fixes #547

Problem: "--tb=" flags were passed to py.test invocations

Analysis: This change removes the "--tb=" flags.

Tests: This was manually tested in buildbot.

