### PR TITLE
Update mitaka branch with changes from liberty

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -36,16 +36,16 @@ export EXCLUDE_DIR := $(MAKEFILE_DIR)/exclude/
 # Repos that are used for the tests and environment
 # TLC
 export TLC_DIR := /home/buildbot/tlc
-export TLC_REPO := https://bldr-git.int.lineratesystems.com/openstack/tlc.git
+export TLC_REPO := https://gitlab.pdbld.f5net.com/openstack/tlc.git
 export TLC_BRANCH := buildbot
 
 # toolsbase (replicate internal directory structure for TLC install)
 export TOOLSBASE_DIR := /toolsbase
-export TOOLSBASE_REPO := https://bldr-git.int.lineratesystems.com/openstack/tlc-toolsbase.git
+export TOOLSBASE_REPO := https://gitlab.pdbld.f5net.com/openstack/tlc-toolsbase.git
 
 # dev-test (contains all of our TLC files for configuration)
 export DEVTEST_DIR := /home/buildbot/dev-test
-export DEVTEST_REPO := git@bldr-git.int.lineratesystems.com:openstack/dev-test.git
+export DEVTEST_REPO := git@gitlab.pdbld.f5net.com:openstack/dev-test.git
 
 # tempest (OpenStack tempest test library)
 export TEMPEST_DIR := /home/buildbot/tempest

--- a/systest/scripts/conf/neutron-lbaas.tox.ini
+++ b/systest/scripts/conf/neutron-lbaas.tox.ini
@@ -12,7 +12,7 @@ deps =
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/neutron_lbaas/tests/tempest/requirements.txt
   pytest
-  git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
+  git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
 whitelist_externals = sh
 
 [testenv:apiv2]

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -30,7 +30,7 @@ pip install tox
 rm -rf ${DEVTEST_DIR}
 git clone -b ${TEST_OPENSTACK_DISTRO} ${DEVTEST_REPO} ${DEVTEST_DIR}
 
-pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
+pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
 # This should be listed in requirement.test.txt also, but will not succeed
 # from that location without sudo
 sudo pip install git+https://github.com/F5Networks/f5-openstack-agent.git@${BRANCH}


### PR DESCRIPTION
@zancas 

#### What issues does this address?

#### What's this change do?
Updates the mitaka branch with changes from liberty

#### Where should the reviewer start?

#### Any background context?

Ran all tests against this branch in my buildbot sandbox. Against an 11.6.1 box. Should I be testing against some other standard deployment @zancas?

```
+ tox --sitepackages -e tempest -c tox.ini -- --meta /home/testlab/f5-openstack-lbaasv2-driver/systest//exclude//tempest_11.6.1_undercloud.yaml -lvv --tb=line --autolog-outputdir /home/testlab/f5-openstack-lbaasv2-driver/systest//test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud --autolog-session driver.tempest_78512a9_20170503-093040
GLOB sdist-make: /home/testlab/f5-openstack-lbaasv2-driver/setup.py
tempest create: /home/testlab/f5-openstack-lbaasv2-driver/.tox/tempest
tempest installdeps: -rrequirements.test.txt
WARNING:Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
tempest inst: /home/testlab/f5-openstack-lbaasv2-driver/.tox/dist/f5-openstack-lbaasv2-driver-9.3.0.zip
tempest installed: The directory '/home/buildbot/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.,alembic==0.8.4,amqp==1.4.9,anyjson==0.3.3,appdirs==1.4.0,argcomplete==1.8.2,asn1crypto==0.22.0,astroid==1.5.2,attrs==16.3.0,Automat==0.5.0,Babel==2.2.0,backports.functools-lru-cache==1.3,backports.shutil-get-terminal-size==1.0.0,backports.ssl-match-hostname==3.5.0.1,beautifulsoup4==4.4.1,blessings==1.6,buildbot-slave==0.8.12,cachetools==1.1.5,cffi==1.5.2,cliff==2.0.0,cmd2==0.6.8,colorama==0.3.7,ConfigArgParse==0.11.0,configparser==3.5.0,constantly==15.1.0,contextlib2==0.5.1,coverage==4.0.3,cryptography==1.2.3,debtcollector==1.3.0,decorator==4.0.9,deprecation==1.0.1,docopt==0.6.2,ecdsa==0.13,enum34==1.1.2,eventlet==0.18.4,extras==0.0.3,f5-icontrol-rest==1.3.0,f5-openstack-agent==9.3.0,-e git+https://github.com/pjbreaux/f5-openstack-lbaasv2-driver.git@78512a9aa06ed9921d91d26c77f8adc32d87e1e6#egg=f5_openstack_lbaasv2_driver,f5-openstack-test==0.2.0,f5-sdk==2.3.1,Fabric==1.13.1,fasteners==0.14.1,fixtures==1.4.0,flake8==2.6.2,funcsigs==0.4,functools32==3.2.3.post2,futures==3.0.5,futurist==0.13.0,greenlet==0.4.9,httplib2==0.9.2,idna==2.0,incremental==16.10.1,ipaddress==1.0.16,iso8601==0.1.11,isort==4.2.5,Jinja2==2.8,jsonpatch==1.13,jsonpointer==1.10,jsonschema==2.5.1,keystoneauth1==2.4.3,keystonemiddleware==4.4.1,kombu==3.0.34,lazy-object-proxy==1.2.2,linecache2==1.0.0,logutils==0.3.3,Mako==1.0.3,marathon==0.8.10,MarkupSafe==0.23,mccabe==0.5.3,mock==1.3.0,monotonic==0.6,msgpack-python==0.4.7,netaddr==0.7.18,netifaces==0.10.4,neutron==8.4.1.dev20,neutron-lbaas==8.4.1.dev4,neutron-lib==0.0.2,oauth2client==4.0.0,oauthlib==2.0.2,openstacksdk==0.8.1,os-client-config==1.16.0,os-testr==0.6.0,osc-lib==1.5.0,oslo.concurrency==3.7.1,oslo.config==3.9.0,oslo.context==2.2.0,oslo.db==4.7.1,oslo.i18n==3.5.0,oslo.log==3.3.0,oslo.messaging==4.6.1,oslo.middleware==3.8.0,oslo.policy==1.6.0,oslo.reports==1.7.0,oslo.rootwrap==4.1.0,oslo.serialization==2.4.0,oslo.service==1.8.0,oslo.utils==3.8.0,oslo.versionedobjects==1.8.0,ovs==2.4.0,packaging==16.8,paramiko==1.16.0,Paste==2.0.2,PasteDeploy==1.5.2,pbr==1.8.1,pecan==1.0.4,pep257==0.7.0,pexpect==4.0.1,pika==0.10.0,pika-pool==0.1.3,pluggy==0.4.0,positional==1.0.1,prettytable==0.7.2,protobuf==2.6.1,psutil==1.2.1,ptyprocess==0.5,py==1.4.33,pyasn1==0.1.9,pyasn1-modules==0.0.8,pycadf==2.2.0,pycodestyle==2.0.0,pycparser==2.14,pycrypto==2.6.1,pyflakes==1.2.3,pyinotify==0.9.6,pykube==0.14.0,pylint==1.7.1,pyOpenSSL==0.15.1,pyparsing==2.1.10,pyrsistent==0.11.12,pytest==2.9.1,pytest-autolog==0.1.0a3,pytest-cov==2.2.1,pytest-meta==0.1.1,pytest-symbols==0.1.0a3,python-barbicanclient==4.0.1,python-cinderclient==1.6.0,python-dateutil==2.5.0,python-designateclient==2.1.0,python-editor==0.5,python-glanceclient==2.0.1,python-heatclient==1.1.0,python-keystoneclient==2.3.2,python-mimeparse==1.5.1,python-neutronclient==4.1.1,python-novaclient==3.3.2,python-openstackclient==2.3.1,python-subunit==1.2.0,python-swiftclient==3.0.0,pytz==2015.7,PyYAML==3.11,rcli==0.2.5,repoze.lru==0.6,requests==2.9.1,requests-oauthlib==0.8.0,requestsexceptions==1.1.3,retrying==1.3.3,rfc3986==0.4.1,Routes==2.2,rsa==3.4.2,ryu==4.0,schema==0.6.5,simplejson==3.8.2,singledispatch==3.4.0.3,six==1.10.0,splunk-sdk==1.6.2,SQLAlchemy==1.0.12,sqlalchemy-migrate==0.10.0,sqlparse==0.1.18,stevedore==1.12.0,systest-common==0.2.9,tempest==12.0.0,Tempita==0.5.2,testenv==0.1.18,testenv-openstack==0.1.2,testrepository==0.0.20,testscenarios==0.5.0,testtools==2.0.0,tlc-client==0.11.4,tox==2.7.0,tqdm==4.11.2,traceback2==1.4.0,Twisted==17.1.0,typing==3.6.1,tzlocal==1.4,unicodecsv==0.14.1,unittest2==1.1.0,urllib3==1.14,virtualenv==15.1.0,virtualenv-clone==0.2.6,virtualenvwrapper==4.7.2,waitress==0.8.10,warlock==1.2.0,WebOb==1.5.1,WebTest==2.0.20,wrapt==1.10.6,zope.interface==4.4.0
tempest runtests: PYTHONHASHSEED='4044061069'
tempest runtests: commands[0] | py.test -vra --meta ../../../../systest/exclude/tempest_11.6.1_undercloud.yaml -lvv --tb=line --autolog-outputdir /home/testlab/f5-openstack-lbaasv2-driver/systest//test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud --autolog-session driver.tempest_78512a9_20170503-093040
<class 'f5.bigip.BigIP'>
======================================== test session starts ========================================
platform linux2 -- Python 2.7.12, pytest-2.9.1, py-1.4.33, pluggy-0.3.1 -- /home/testlab/f5-openstack-lbaasv2-driver/.tox/tempest/bin/python
cachedir: ../../../../.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud/driver.tempest_78512a9_20170503-093040
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: cov-2.2.1, f5-openstack-test-0.2.0, symbols-0.1.0a3, meta-0.1.1, autolog-0.1.0a3, f5-sdk-2.3.1
collected 45 items
pytest-meta: discarded 0 items

api/test_esd.py::ESDTestJSON::test_create_esd FAILED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_pool_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_ends_with PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_many_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_multi_policy_multi_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_three_rules PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_policy_redirect_url_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_file_type_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_not_file_type PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_no_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_two_policies PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_all_rules PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_policy PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_reorder_policies PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_with_tenant_id_field_for_admin PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_without_tenant_id PASSED
api/test_member_status.py::MemberStatusTestJSON::test_disabled <- .tox/tempest/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
api/test_member_status.py::MemberStatusTestJSON::test_no_monitor PASSED
api/test_member_status.py::MemberStatusTestJSON::test_offline PASSED
api/test_member_status.py::MemberStatusTestJSON::test_online PASSED
api/test_pools.py::PoolTestJSON::test_create_shared_pools PASSED
api/test_service_builder.py::ServiceBuilderTestJSON::test_service_builder PASSED
scenario/test_esd.py::TestEsdBasic::test_policy_abort_deployment PASSED
scenario/test_esd.py::TestEsdBasic::test_policy_deployment PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_deployment PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_not_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_header_equal_to PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_hostname_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_file_type_fails_bad_compare_type PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_file_type_not_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_hostname_ends_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_path_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_file_type_equal_to PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_header_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicUpdate::test_policy_deployment_operand_match PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicUpdate::test_policy_reorder_and_rule_update PASSED
scenario/test_stats.py::TestLoadBalancerStats::test_stats PASSED

+ tox -e apiv2 -c f5.tox.ini --sitepackages -- --meta /home/testlab/f5-openstack-lbaasv2-driver/systest//exclude//tempest_11.6.1_undercloud.yaml -lvv --tb=short --autolog-outputdir /home/testlab/f5-openstack-lbaasv2-driver/systest//test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud --autolog-session api_78512a9_20170503-093040
apiv2 create: /home/buildbot/neutron-lbaas/.tox/apiv2
apiv2 installdeps: -r/home/buildbot/neutron-lbaas/test-requirements.txt, -r/home/buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/requirements.txt, pytest, git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
WARNING:Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
apiv2 develop-inst: /home/buildbot/neutron-lbaas
apiv2 installed: The directory '/home/buildbot/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.,alembic==0.8.4,amqp==1.4.9,anyjson==0.3.3,appdirs==1.4.0,argcomplete==1.8.2,asn1crypto==0.22.0,astroid==1.5.2,attrs==16.3.0,Automat==0.5.0,Babel==2.2.0,backports.functools-lru-cache==1.3,backports.shutil-get-terminal-size==1.0.0,backports.ssl-match-hostname==3.5.0.1,beautifulsoup4==4.4.1,blessings==1.6,buildbot-slave==0.8.12,cachetools==1.1.5,cffi==1.5.2,cliff==2.0.0,cmd2==0.6.8,colorama==0.3.7,ConfigArgParse==0.11.0,configparser==3.5.0,constantly==15.1.0,contextlib2==0.5.1,coverage==4.0.3,cryptography==1.2.3,debtcollector==1.3.0,decorator==4.0.9,deprecation==1.0.1,docopt==0.6.2,docutils==0.12,dulwich==0.17.3,ecdsa==0.13,enum34==1.1.2,eventlet==0.18.4,extras==0.0.3,f5-icontrol-rest==1.3.0,f5-openstack-agent==9.3.0,f5-sdk==2.3.1,Fabric==1.13.1,fasteners==0.14.1,fixtures==1.4.0,flake8==2.2.4,funcsigs==0.4,functools32==3.2.3.post2,futures==3.0.5,futurist==0.13.0,greenlet==0.4.9,hacking==0.10.3,httplib2==0.9.2,idna==2.0,incremental==16.10.1,ipaddress==1.0.16,iso8601==0.1.11,isort==4.2.5,Jinja2==2.8,jsonpatch==1.15,jsonpointer==1.10,jsonschema==2.5.1,keystoneauth1==2.4.3,keystonemiddleware==4.4.1,kombu==3.0.34,lazy-object-proxy==1.2.2,linecache2==1.0.0,logutils==0.3.3,Mako==1.0.3,marathon==0.8.10,MarkupSafe==0.23,mccabe==0.2.1,mock==1.3.0,monotonic==0.6,mox3==0.14.0,msgpack-python==0.4.7,netaddr==0.7.18,netifaces==0.10.4,-e git+https://git.openstack.org/openstack/neutron@4d8685da8050df79d9193f91cab572cfc6d67a47#egg=neutron,-e git+https://github.com/F5Networks/neutron-lbaas.git@7077ac5cb032f4581ce6c035130daa4ef5aa52db#egg=neutron_lbaas,neutron-lib==0.0.2,oauth2client==4.0.0,oauthlib==2.0.2,openstacksdk==0.9.16,os-client-config==1.16.0,os-testr==0.6.0,osc-lib==1.5.0,oslo.concurrency==3.7.1,oslo.config==3.9.0,oslo.context==2.2.0,oslo.db==4.7.1,oslo.i18n==3.5.0,oslo.log==3.3.0,oslo.messaging==4.6.1,oslo.middleware==3.8.0,oslo.policy==1.6.0,oslo.reports==1.7.0,oslo.rootwrap==4.1.0,oslo.serialization==2.4.0,oslo.service==1.8.0,oslo.utils==3.8.0,oslo.versionedobjects==1.8.0,oslosphinx==4.3.0,oslotest==2.4.0,ovs==2.4.0,packaging==16.8,paramiko==1.16.0,Paste==2.0.2,PasteDeploy==1.5.2,pbr==1.8.1,pecan==1.0.4,pep257==0.7.0,pep8==1.5.7,pexpect==4.0.1,pika==0.10.0,pika-pool==0.1.3,pluggy==0.4.0,positional==1.0.1,prettytable==0.7.2,protobuf==2.6.1,psutil==1.2.1,ptyprocess==0.5,py==1.4.33,pyasn1==0.1.9,pyasn1-modules==0.0.8,pycadf==2.2.0,pycodestyle==2.0.0,pycparser==2.14,pycrypto==2.6.1,pyflakes==0.8.1,Pygments==2.1.3,pyinotify==0.9.6,pykube==0.14.0,pylint==1.7.1,PyMySQL==0.7.2,pyOpenSSL==0.15.1,pyparsing==2.1.10,pyrsistent==0.11.12,pytest==3.0.7,pytest-autolog==0.1.0a3,pytest-meta==0.1.1,pytest-symbols==0.1.0a3,python-barbicanclient==4.0.1,python-cinderclient==2.0.1,python-dateutil==2.5.0,python-designateclient==2.1.0,python-editor==0.5,python-glanceclient==2.6.0,python-heatclient==1.8.0,python-keystoneclient==2.3.2,python-mimeparse==1.5.1,python-neutronclient==4.1.1,python-novaclient==3.3.2,python-openstackclient==3.6.0,python-subunit==1.2.0,python-swiftclient==3.3.0,pytz==2015.7,PyYAML==3.11,rcli==0.2.5,reno==2.2.0,repoze.lru==0.6,requests==2.9.1,requests-mock==0.7.0,requests-oauthlib==0.8.0,requestsexceptions==1.1.3,retrying==1.3.3,rfc3986==0.4.1,Routes==2.2,rsa==3.4.2,ryu==4.0,schema==0.6.5,simplejson==3.8.2,singledispatch==3.4.0.3,six==1.10.0,Sphinx==1.2.3,splunk-sdk==1.6.2,SQLAlchemy==1.0.12,sqlalchemy-migrate==0.10.0,sqlparse==0.1.18,stevedore==1.12.0,systest-common==0.2.9,tempest==12.0.0,tempest-lib==1.0.0,Tempita==0.5.2,testenv==0.1.18,testenv-openstack==0.1.2,testrepository==0.0.20,testresources==1.0.0,testscenarios==0.5.0,testtools==2.0.0,tlc-client==0.11.4,tox==2.7.0,tqdm==4.11.2,traceback2==1.4.0,Twisted==17.1.0,typing==3.6.1,tzlocal==1.4,unicodecsv==0.14.1,unittest2==1.1.0,urllib3==1.14,virtualenv==15.1.0,virtualenv-clone==0.2.6,virtualenvwrapper==4.7.2,waitress==0.8.10,warlock==1.2.0,WebOb==1.5.1,WebTest==2.0.20,wrapt==1.10.6,zope.interface==4.4.0
apiv2 runtests: PYTHONHASHSEED='3326318557'
apiv2 runtests: commands[0] | py.test --meta ../../../../../../../testlab/f5-openstack-lbaasv2-driver/systest/exclude/tempest_11.6.1_undercloud.yaml -lvv --tb=short --autolog-outputdir ../../../../../../../testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud --autolog-session api_78512a9_20170503-093040
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/buildbot/neutron-lbaas/.tox/apiv2/bin/python
cachedir: ../../../../../../../testlab/f5-openstack-lbaasv2-driver/.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud/api_78512a9_20170503-093040
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: autolog-0.1.0a3, symbols-0.1.0a3, meta-0.1.1, f5-sdk-2.3.1
collected 264 items
pytest-meta: discarded 0 items

../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitor_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_for_another_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitor_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitor_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_delay <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_expected_codes <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_http_method <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_pool_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_retries <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_url_path <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_timeout <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_type <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_extra_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_delay <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_expected_codes <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_http_method <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_max_retries <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_pool_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_timeout <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_type <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_url_path <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_expected_codes <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_http_method <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_delay <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_max_retries <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_pool_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_timeout <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_type <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_url_path <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_delete_health_monitor <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_get_health_monitor <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_list_health_monitors_empty <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_list_health_monitors_one <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_list_health_monitors_two <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_delay <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_empty_http_method <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_expected_codes <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_max_retries <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_timeout <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_url_path <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_extra_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_delay <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_expected_codes <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_http_method <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_max_retries <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_timeout <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_url_path <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_delay <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_expected_codes <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_http_method <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_max_retries <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_timeout <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_url_path <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_connection_limit <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_load_balancer_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_protocol <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_protocol_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_incorrect_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_connection_limit <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_load_balancer_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_protocol <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_protocol_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_field_loadbalancer <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_field_protocol <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_field_protocol_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_delete_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_get_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_list_listeners <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_list_listeners_two <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_connection_limit <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_incorrect_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_connection_limit <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_connection_limit <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_create_listener_empty_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_create_listener_empty_uuid_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_create_listener_invalid_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_create_listener_nonexistent_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_create_tls_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_delete_tls_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_get_tls_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_list_tls_listeners <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_list_tls_listeners_two <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_empty_tls_container <- ../../buildbot/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_empty_uuid_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_invalid_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_none_tls_container <- ../../buildbot/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_nonexistent_tls_container <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_tls_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_listener_tls_protocol <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_tls_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSListenersTestJSON::test_update_tls_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls.py ERROR
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSSNIListenersTestJSON::test_create_tls_sni_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls_sni.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TLSSNIListenersTestJSON::test_delete_tls_sni_listener <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_tls_sni.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_for_another_tenant <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_tenant_id_field_for_admin <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_tenant_id_for_other_tenant <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_admin_state_up_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_description_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_provider_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_vip_address_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_vip_subnet_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_incorrect_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_flavor_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_vip_subnet_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_provider_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_vip_address <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_vip_subnet_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_other_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_provider_flavor_conflict <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_delete_load_balancer <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_get_load_balancer <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_get_load_balancer_stats <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_get_load_balancer_status_tree <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_list_load_balancers <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_list_load_balancers_two <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_empty_admin_state_up_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_empty_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_empty_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_incorrect_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_invalid_admin_state_up_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_invalid_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_invalid_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_missing_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_missing_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_add_member <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_address <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_protocol_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_subnet_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_weight <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_address <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_protocol_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_subnet_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_weight <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_address <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_protocol_port <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_subnet_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_tenant_id <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_delete_member <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_get_member <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_list_3_members <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_list_empty_members <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_BadRequest_when_missing_attrs_during_member_create <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_exception_on_invalid_attr_on_create <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_exception_on_invalid_attr_on_update <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_immutable_when_updating_immutable_attrs_on_member <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_empty_weight <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_invalid_weight <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_missing_weight <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_for_another_tenant <- ../../buildbot/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_tenant_id_for_admin <- ../../buildbot/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_tenant_id_for_other_tenant <- ../../buildbot/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_using_empty_tenant_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_algorithm <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_description_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_listener_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_name_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_protocol <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_session_persistence_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_tenant_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_for_other_tenant_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_incorrect_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_algorithm <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_desc_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_listener_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_name_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_protocol <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_session_persistence_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_tenant_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_admin_state_up_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_description_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_lb_algorithm_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_listener_id_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_name_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_protocol_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_required_fields <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_session_pers_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_tenant_field <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_app_cookie <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_http_cookie <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_redundant_cookie_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_unsupported_type <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_without_cookie_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_delete_invalid_pool <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_delete_pool <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_get_pool <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_list_pools_empty <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_list_pools_one <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_list_pools_two <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_session_persistence <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_incorrect_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_attribute <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_desc <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_session_persistence <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_admin_state_up <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_description <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_name <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_session_persistence <- ../../buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED

+ tox -e scenariov2 -c f5.tox.ini --sitepackages -- --meta /home/testlab/f5-openstack-lbaasv2-driver/systest//exclude//tempest_11.6.1_undercloud.yaml -lvv --tb=short --autolog-outputdir /home/testlab/f5-openstack-lbaasv2-driver/systest//test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud --autolog-session scenario_78512a9_20170503-093040
scenariov2 create: /home/buildbot/neutron-lbaas/.tox/scenariov2
scenariov2 installdeps: -r/home/buildbot/neutron-lbaas/test-requirements.txt, -r/home/buildbot/neutron-lbaas/neutron_lbaas/tests/tempest/requirements.txt, pytest, git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
WARNING:Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
scenariov2 develop-inst: /home/buildbot/neutron-lbaas
scenariov2 installed: The directory '/home/buildbot/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.,alembic==0.8.4,amqp==1.4.9,anyjson==0.3.3,appdirs==1.4.0,argcomplete==1.8.2,asn1crypto==0.22.0,astroid==1.5.2,attrs==16.3.0,Automat==0.5.0,Babel==2.2.0,backports.functools-lru-cache==1.3,backports.shutil-get-terminal-size==1.0.0,backports.ssl-match-hostname==3.5.0.1,beautifulsoup4==4.4.1,blessings==1.6,buildbot-slave==0.8.12,cachetools==1.1.5,cffi==1.5.2,cliff==2.0.0,cmd2==0.6.8,colorama==0.3.7,ConfigArgParse==0.11.0,configparser==3.5.0,constantly==15.1.0,contextlib2==0.5.1,coverage==4.0.3,cryptography==1.2.3,debtcollector==1.3.0,decorator==4.0.9,deprecation==1.0.1,docopt==0.6.2,docutils==0.12,dulwich==0.17.3,ecdsa==0.13,enum34==1.1.2,eventlet==0.18.4,extras==0.0.3,f5-icontrol-rest==1.3.0,f5-openstack-agent==9.3.0,f5-sdk==2.3.1,Fabric==1.13.1,fasteners==0.14.1,fixtures==1.4.0,flake8==2.2.4,funcsigs==0.4,functools32==3.2.3.post2,futures==3.0.5,futurist==0.13.0,greenlet==0.4.9,hacking==0.10.3,httplib2==0.9.2,idna==2.0,incremental==16.10.1,ipaddress==1.0.16,iso8601==0.1.11,isort==4.2.5,Jinja2==2.8,jsonpatch==1.15,jsonpointer==1.10,jsonschema==2.5.1,keystoneauth1==2.4.3,keystonemiddleware==4.4.1,kombu==3.0.34,lazy-object-proxy==1.2.2,linecache2==1.0.0,logutils==0.3.3,Mako==1.0.3,marathon==0.8.10,MarkupSafe==0.23,mccabe==0.2.1,mock==1.3.0,monotonic==0.6,mox3==0.14.0,msgpack-python==0.4.7,netaddr==0.7.18,netifaces==0.10.4,-e git+https://git.openstack.org/openstack/neutron@4d8685da8050df79d9193f91cab572cfc6d67a47#egg=neutron,-e git+https://github.com/F5Networks/neutron-lbaas.git@7077ac5cb032f4581ce6c035130daa4ef5aa52db#egg=neutron_lbaas,neutron-lib==0.0.2,oauth2client==4.0.0,oauthlib==2.0.2,openstacksdk==0.9.16,os-client-config==1.16.0,os-testr==0.6.0,osc-lib==1.5.0,oslo.concurrency==3.7.1,oslo.config==3.9.0,oslo.context==2.2.0,oslo.db==4.7.1,oslo.i18n==3.5.0,oslo.log==3.3.0,oslo.messaging==4.6.1,oslo.middleware==3.8.0,oslo.policy==1.6.0,oslo.reports==1.7.0,oslo.rootwrap==4.1.0,oslo.serialization==2.4.0,oslo.service==1.8.0,oslo.utils==3.8.0,oslo.versionedobjects==1.8.0,oslosphinx==4.3.0,oslotest==2.4.0,ovs==2.4.0,packaging==16.8,paramiko==1.16.0,Paste==2.0.2,PasteDeploy==1.5.2,pbr==1.8.1,pecan==1.0.4,pep257==0.7.0,pep8==1.5.7,pexpect==4.0.1,pika==0.10.0,pika-pool==0.1.3,pluggy==0.4.0,positional==1.0.1,prettytable==0.7.2,protobuf==2.6.1,psutil==1.2.1,ptyprocess==0.5,py==1.4.33,pyasn1==0.1.9,pyasn1-modules==0.0.8,pycadf==2.2.0,pycodestyle==2.0.0,pycparser==2.14,pycrypto==2.6.1,pyflakes==0.8.1,Pygments==2.1.3,pyinotify==0.9.6,pykube==0.14.0,pylint==1.7.1,PyMySQL==0.7.2,pyOpenSSL==0.15.1,pyparsing==2.1.10,pyrsistent==0.11.12,pytest==3.0.7,pytest-autolog==0.1.0a3,pytest-meta==0.1.1,pytest-symbols==0.1.0a3,python-barbicanclient==4.0.1,python-cinderclient==2.0.1,python-dateutil==2.5.0,python-designateclient==2.1.0,python-editor==0.5,python-glanceclient==2.6.0,python-heatclient==1.8.0,python-keystoneclient==2.3.2,python-mimeparse==1.5.1,python-neutronclient==4.1.1,python-novaclient==3.3.2,python-openstackclient==3.6.0,python-subunit==1.2.0,python-swiftclient==3.3.0,pytz==2015.7,PyYAML==3.11,rcli==0.2.5,reno==2.2.0,repoze.lru==0.6,requests==2.9.1,requests-mock==0.7.0,requests-oauthlib==0.8.0,requestsexceptions==1.1.3,retrying==1.3.3,rfc3986==0.4.1,Routes==2.2,rsa==3.4.2,ryu==4.0,schema==0.6.5,simplejson==3.8.2,singledispatch==3.4.0.3,six==1.10.0,Sphinx==1.2.3,splunk-sdk==1.6.2,SQLAlchemy==1.0.12,sqlalchemy-migrate==0.10.0,sqlparse==0.1.18,stevedore==1.12.0,systest-common==0.2.9,tempest==12.0.0,tempest-lib==1.0.0,Tempita==0.5.2,testenv==0.1.18,testenv-openstack==0.1.2,testrepository==0.0.20,testresources==1.0.0,testscenarios==0.5.0,testtools==2.0.0,tlc-client==0.11.4,tox==2.7.0,tqdm==4.11.2,traceback2==1.4.0,Twisted==17.1.0,typing==3.6.1,tzlocal==1.4,unicodecsv==0.14.1,unittest2==1.1.0,urllib3==1.14,virtualenv==15.1.0,virtualenv-clone==0.2.6,virtualenvwrapper==4.7.2,waitress==0.8.10,warlock==1.2.0,WebOb==1.5.1,WebTest==2.0.20,wrapt==1.10.6,zope.interface==4.4.0
scenariov2 runtests: PYTHONHASHSEED='3163316073'
scenariov2 runtests: commands[0] | py.test --meta ../../../../../../../testlab/f5-openstack-lbaasv2-driver/systest/exclude/tempest_11.6.1_undercloud.yaml -lvv --tb=short --autolog-outputdir ../../../../../../../testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud --autolog-session scenario_78512a9_20170503-093040
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /home/buildbot/neutron-lbaas/.tox/scenariov2/bin/python
cachedir: ../../../../../../../testlab/f5-openstack-lbaasv2-driver/.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver/f5-openstack-lbaasv2-driver_mitaka-tempest_11.6.1_undercloud/scenario_78512a9_20170503-093040
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: autolog-0.1.0a3, symbols-0.1.0a3, meta-0.1.1, f5-sdk-2.3.1
collected 6 items
pytest-meta: discarded 0 items

../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitorBasic::test_health_monitor_basic <- ../../buildbot/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestListenerBasic::test_listener_basic <- ../../buildbot/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py FAILED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerBasic::test_load_balancer_basic <- ../../buildbot/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerTLS::test_load_balancer_tls <- ../../buildbot/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerTLS::test_load_balancer_tls <- ../../buildbot/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestSessionPersistence::test_session_persistence <- ../../buildbot/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py FAILED
```
