### PR TITLE
Merge issue531 from mitaka to master

### DIFF
--- a/docs/includes/topic_restrictions.rst
+++ b/docs/includes/topic_restrictions.rst
@@ -5,34 +5,24 @@
 Unsupported Features
 --------------------
 
-The following F5® features are unsupported in |release|; they will be introduced in future releases.
+The following features or integrations are unsupported in |release|; they will be introduced in future releases.
 
-* `BIG-IP® vCMP® <https://f5.com/resources/white-papers/virtual-clustered-multiprocessing-vcmp>`_
+Neutron
+-------
+
+* Distributed Virtual Router (`DVR <https://specs.openstack.org/openstack/neutron-specs/specs/juno/neutron-ovs-dvr.html>`_)
+* Role Based Access Control (`RBAC <http://specs.openstack.org/openstack/neutron-specs/specs/liberty/rbac-networks.html>`_) for networks
+* Respond to SIGUSR2 signal by dumping valuable debug information to standard error output
+* VLAN aware VMs, (`spec <https://specs.openstack.org/openstack/neutron-specs/specs/newton/vlan-aware-vms.html>`_)
+
+F5 OpenStack
+------------
+
 * Agent High Availability (HA) [#]_
-* Differentiated environments [#]_
 
-
-.. note::
-
-    The features supported in |release| are a subset of the `Neutron LBaaSv2 API <https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0>`_ delivered in the OpenStack |openstack| release. The following restriction(s) apply:
-
-    .. table::
-
-        +----------------+----------------------------------------------------+
-        | Object         | Unsupported                                        |
-        +================+====================================================+
-        | loadbalancer   || Statistics                                        |
-        |                || (e.g., ``neutron lbaas-loadbalancer-stats``)      |
-        +----------------+----------------------------------------------------+
-
-* L7 Routing
-* Unattached pools [#]_
-* Loadbalancer statistics  (e.g., ``neutron lbaas-loadbalancer-stats``)
 
 .. rubric:: Footnotes
 .. [#] Similar to BIG-IP :term:`high availability`, but applies to the F5 agent processes.
-.. [#] Multiple F5 agents running on the same host, managing *separate* BIG-IP environments.
-.. [#] Creating a pool with no listener.
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents
     Basic Environment Requirements <includes/topic_basic-environment-reqs>
     F5 LBaaSv2 to BIG-IP Mapping <includes/topic_neutron-bigip-command-mapping>
     Supported Features <map_lbaasv2-features>
+    Unsupported Features <includes/topic_restrictions>
     Sample Configuration Files <includes/ref_agent-config-file>
     Coding Example <coding-example-lbaasv2>
     Upgrading <includes/topic_upgrading-f5-lbaasv2-plugin>


### PR DESCRIPTION
Issues:
Fixes #531

Problem:
The unsupported features page lists several features that are not supported and does not indicated known limitations with Neutron features.

Analysis:
Removed F5 OpenStack features that are now supported.  Added a new section to capture Neutron features that cannot be used in conjunction with F5 OpenStack LBaaSv2.
Added page to the main index to be more transparent with feature support.  This page must be proactively managed upon each release.

Tests:
Generated page via sphinx and confirmed content.

(cherry picked from commit a931e7acca4f12173311445fa31c86a78af769df)
