### PR TITLE
Setup liberty to run SAP specific tests

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -17,12 +17,6 @@
 .PHONY: all functest \
 install_tlc \
 install_test_infra \
-tempest_11.5.4_overcloud tempest_11.5.4_undercloud \
-tempest_11.5.4_undercloud_gre tempest_11.5.4_undercloud_vlan \
-tempest_11.6.0_overcloud tempest_11.6.0_undercloud \
-tempest_11.6.0_undercloud_gre tempest_11.6.0_undercloud_vlan \
-tempest_11.6.1_overcloud tempest_11.6.1_undercloud \
-tempest_11.6.1_undercloud_gre tempest_11.6.1_undercloud_vlan \
 tempest_12.1.1_overcloud tempest_12.1.1_undercloud \
 tempest_12.1.1_undercloud_gre tempest_12.1.1_undercloud_vlan
 
@@ -33,7 +27,7 @@ TIMESTAMP ?= $(shell date +"%Y%m%d-%H%M%S")
 export TIMESTAMP   # Only eval TIMESTAMP in the top make.
 CHANGESOURCE := f5-openstack-lbaasv2-driver
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
+export MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
 export TEST_DIR := $(abspath $(MAKEFILE_DIR))/../test
 
 # Test exclude directory
@@ -68,9 +62,9 @@ export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requir
 export PATH := /tools/bin:$(PATH)
 export PYTHONPATH := /tools/lib:/tools/bin:$(PYTHONPATH)
 export USER := buildbot
-export TEST_OPENSTACK_DISTRO := liberty
+export TEST_OPENSTACK_DISTRO := $(BRANCH)
 export TEST_CIRROS_IMAGE := cirros-0.3.4-x86_64-disk.qcow2
-export TEST_OPENSTACK_NODE_COUNT := 2
+export TEST_OPENSTACK_NODE_COUNT := 3
 export TEST_OPENSTACK_DEPLOY := multinode
 export TEST_COMMON_LIB := $(DEVTEST_DIR)/common
 export GLANCE_COMPUTE_STORAGE := NFS
@@ -85,6 +79,7 @@ export TEMPEST_VENV_ACTIVATE := $(TEMPEST_VENV_DIR)/bin/activate
 # Results Directories
 export API_SESSION := api_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
+export DRIVER_TEMPEST_SESSION := driver.tempest_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 # LEAF MAKE TARGETS:
@@ -143,169 +138,10 @@ cleanup_failed_tlc:
 # These are all of the functests that we want to run as part of bbot job
 # We ignore the return value so that we run all of the tests
 functest: install_tlc install_test_infra
-	-$(MAKE) -C . tempest_11.5.4_overcloud
-	-$(MAKE) -C . tempest_11.6.0_overcloud
-	-$(MAKE) -C . tempest_11.6.1_overcloud
-	-$(MAKE) -C . tempest_12.1.1_overcloud
-	-$(MAKE) -C . tempest_11.5.4_undercloud
-	-$(MAKE) -C . tempest_11.5.4_undercloud_gre
-	-$(MAKE) -C . tempest_11.5.4_undercloud_vlan
-	-$(MAKE) -C . tempest_11.6.0_undercloud
-	-$(MAKE) -C . tempest_11.6.0_undercloud_gre
-	-$(MAKE) -C . tempest_11.6.0_undercloud_vlan
-	-$(MAKE) -C . tempest_11.6.1_undercloud
-	-$(MAKE) -C . tempest_11.6.1_undercloud_gre
-	-$(MAKE) -C . tempest_11.6.1_undercloud_vlan
 	-$(MAKE) -C . tempest_12.1.1_undercloud
-	-$(MAKE) -C . tempest_12.1.1_undercloud_gre
-	-$(MAKE) -C . tempest_12.1.1_undercloud_vlan
 
 # Not using the tempest TLC files for liberty because they install barbican
 # which causes the tests to lockup/hang
-
-# Tempest Tests for 11.5.x overcloud VE deployment
-tempest_11.5.4_overcloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=overcloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-# Tempest Tests for 11.6.x overcloud VE deployment
-tempest_11.6.0_overcloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=overcloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.6.1_overcloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=overcloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-# Tempest Tests for 12.1.x overcloud VE deployment
-tempest_12.1.1_overcloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=overcloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-# Tempest Tests for 11.5.x undercloud VE deployment
-tempest_11.5.4_undercloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.5.4_undercloud_gre:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=gre ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.5.4_undercloud_vlan:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.5.4.2.0.291.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-# Tempest Tests for 11.6.x undercloud VE deployment
-tempest_11.6.0_undercloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.6.0_undercloud_gre:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=gre ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.6.0_undercloud_vlan:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.0.0.0.401.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.6.1_undercloud:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.6.1_undercloud_gre:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=gre ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_11.6.1_undercloud_vlan:
-	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x undercloud VE deployment
 tempest_12.1.1_undercloud:
@@ -318,29 +154,6 @@ tempest_12.1.1_undercloud:
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
 	$(MAKE) -C . run_tests
-
-tempest_12.1.1_undercloud_gre:
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=gre ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_12.1.1_undercloud_vlan:
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
 
 run_tests:
 	$(MAKE) -C . setup_tlc_session


### PR DESCRIPTION
This is the change necessary for this repository to turn on SAP specific testing in the nightly builds.