### PR TITLE
Flatten systest results directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ ENV/
 
 # Buildbot logs/directories
 systest/test_results
+
+# vim
+*~
+*.swp

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -149,7 +149,7 @@ tempest_12.1.1_undercloud:
 	export TEST_OPENSTACK_CLOUD=undercloud ;\
 	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$(CHANGESOURCE)/$${GUMBALLS_PROJECT} ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\


### PR DESCRIPTION
@pjbreaux, @mattgreene 

#### What issues does this address?
Fixes #564, #566

#### What's this change do?
- Flattens the systest results directory structure to make our internal reporting tools faster.
- Adds vim support to .gitignore.

#### Where should the reviewer start?
- Probably best to just review each commit in isolation.  Doesn't really matter which one you start with.

#### Any background context?
No.
