### PR TITLE
handle issues for #459, #457 by excluding tests

### DIFF
--- a/systest/exclude/tempest_12.1.1_overcloud_vxlan.yaml
+++ b/systest/exclude/tempest_12.1.1_overcloud_vxlan.yaml
@@ -19,5 +19,7 @@
                 "test_policy_reject_file_type_equal_to",
                 "test_policy_reorder_and_rule_update",
                 "test_policy_deployment_operand_match",
-                "test_stats"]
+                "test_stats",
+                "test_create_load_balancer_missing_tenant_id_field_for_admin",
+                "test_create_load_balancer_for_another_tenant"]
 }

--- a/systest/exclude/tempest_12.1.1_undercloud_gre.yaml
+++ b/systest/exclude/tempest_12.1.1_undercloud_gre.yaml
@@ -1,3 +1,4 @@
 {
-    "exclude": []
+    "exclude": ["test_create_load_balancer_missing_tenant_id_field_for_admin",
+                "test_create_load_balancer_for_another_tenant"]
 }

--- a/systest/exclude/tempest_12.1.1_undercloud_vlan.yaml
+++ b/systest/exclude/tempest_12.1.1_undercloud_vlan.yaml
@@ -1,3 +1,4 @@
 {
-    "exclude": []
+    "exclude": ["test_create_load_balancer_missing_tenant_id_field_for_admin",
+                "test_create_load_balancer_for_another_tenant"]
 }

--- a/systest/exclude/tempest_12.1.1_undercloud_vxlan.yaml
+++ b/systest/exclude/tempest_12.1.1_undercloud_vxlan.yaml
@@ -1,3 +1,4 @@
 {
-    "exclude": []
+    "exclude": ["test_create_load_balancer_missing_tenant_id_field_for_admin",
+                "test_create_load_balancer_for_another_tenant"]
 }


### PR DESCRIPTION
This PR removes two expected test failures from the automated test harness.  We expected these tests to FAIL because they test unsupported features.