### PR TITLE
install_test_infra.sh script needs to clone dev-test repo from unsanitized branch in makefile

### DIFF
--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -28,7 +28,7 @@ pip install tox
 
 # We need to clone the OpenStack devtest repo for our TLC files
 rm -rf ${DEVTEST_DIR}
-git clone -b ${TEST_OPENSTACK_DISTRO} ${DEVTEST_REPO} ${DEVTEST_DIR}
+git clone -b ${BRANCH} ${DEVTEST_REPO} ${DEVTEST_DIR}
 
 pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
 # This should be listed in requirement.test.txt also, but will not succeed


### PR DESCRIPTION
@zancas 

#### What issues does this address?
Fixes #582 

#### What's this change do?
Set the branch to be $BRANCH variable exported from Makefile and not the
TEST_OPENSTACK_DISTRO environment variable.

#### Where should the reviewer start?

#### Any background context?
This only affects newton, but I'm making the change in liberty and
merging it forward so the changes will be consistent across the
branches. The environment variable TEST_OPENSTACK_DISTRO is used as the
branch to clone for the dev-test repo. In the past, this was fine. As of
newton, the branch is now called 'stable/newton', so this will not work,
because that environment variable has been sanitized to be only
'newton'. We need to set the branch properly to the same branch as being
used in driver, because the branches all have the same names across
repos.

Ran the tests in my jenkins container. The autolog output:

```
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_liberty-tempest_12.1.1_undercloud_vxlan/scenario_1c43335_20170531-143239
```

Also ran the scenario tests and they all pass:

```
scenariov2 runtests: commands[0] | py.test --meta ../../../../../../../testlab/f5-openstack-lbaasv2-driver/systest/exclude/tempest_12.1.1_undercloud_vxlan.yaml -lvv --tb=short --autolog-outputdir ../../../../../../../testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_liberty-tempest_12.1.1_undercloud_vxlan --autolog-session scenario_1c43335_20170531-143239
========================================================================================= test session starts ==========================================================================================
platform linux2 -- Python 2.7.12, pytest-3.1.1, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/neutron-lbaas/.tox/scenariov2/bin/python
cachedir: ../../../../../../../testlab/f5-openstack-lbaasv2-driver/.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_liberty-tempest_12.1.1_undercloud_vxlan/scenario_1c43335_20170531-143239
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: autolog-0.1.0a3, symbols-0.1.0a3, meta-0.1.1, f5-sdk-2.3.3
collected 6 items
pytest-meta: discarded 0 items

../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitorBasic::test_health_monitor_basic <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestListenerBasic::test_listener_basic <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerBasic::test_load_balancer_basic <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerTLS::test_load_balancer_tls <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerTLS::test_load_balancer_tls <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestSessionPersistence::test_session_persistence <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED

=========================================================================================== warnings summary ===========================================================================================
::TestHealthMonitorBasic::test_health_monitor_basic
  /usr/lib/python2.7/dist-packages/Crypto/Cipher/blockalgo.py:141: FutureWarning: CTR mode needs counter parameter, not IV
    self._cipher = factory.new(key, *args, **kwargs)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
================================================================================ 6 passed, 1 warnings in 374.27 seconds ================================================================================
_______________________________________________________________________________________________ summary ________________________________________________________________________________________________
  scenariov2: commands succeeded
  congratulations :)
+ exit 0
make[2]: Leaving directory '/home/testlab/f5-openstack-lbaasv2-driver/systest'
#make -C . run_agent_transfers
#make -C . cleanup_tlc_session
make[1]: Leaving directory '/home/testlab/f5-openstack-lbaasv2-driver/systest'
+ set -e
buildbot@d58331998396:/home/testlab/f5-openstack-lbaasv2-driver/systest$
```