### PR TITLE
Removing port creation support

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -16,7 +16,6 @@ u"""Service Module for F5® LBaaSv2."""
 #
 import datetime
 import json
-from netaddr import IPNetwork
 
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
@@ -215,8 +214,8 @@ class LBaaSv2ServiceBuilder(object):
 
         # we no longer support member port creation
         if len(ports) == 0:
-            LOG.warning("Lbaas member %s has no associated neutron port" % member.address)
-
+            LOG.warning("Lbaas member %s has no associated neutron port"
+                        % member.address)
 
         return (member_dict, subnet, network)
 

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -213,28 +213,10 @@ class LBaaSv2ServiceBuilder(object):
             filter
         )
 
-        # There should be only one.
-        if len(ports) == 1:
-            member_dict['port'] = ports[0]
-            self._populate_member_network(context, member_dict, network)
-        else:
-            if not ports:
-                cidr = IPNetwork(subnet['cidr'])
-                member_ip = IPNetwork("%s/%d" %
-                                      (member.address, cidr.prefixlen))
-                if cidr == member_ip:
-                    LOG.debug("Create port for member")
-                    member_dict['port'] = \
-                        self.q_client.create_port_for_member(
-                            context, member.address,
-                            subnet_id=subnet_id)
-                    self._populate_member_network(
-                        context, member_dict, network)
-                else:
-                    LOG.error("Member IP %s is not in subnet %s" %
-                              (member.address, subnet['cidr']))
-            else:
-                LOG.error("Multiple ports found: %s" % ports)
+        # we no longer support member port creation
+        if len(ports) == 0:
+            LOG.warning("Lbaas member %s has no associated neutron port" % member.address)
+
 
         return (member_dict, subnet, network)
 

--- a/f5lbaasdriver/v2/bigip/test/test_member.py
+++ b/f5lbaasdriver/v2/bigip/test/test_member.py
@@ -16,7 +16,6 @@ import mock
 import pytest
 from uuid import uuid4
 
-#from f5lbaasdriver.v2.bigip import exceptions as f5_exc
 from f5lbaasdriver.v2.bigip.service_builder import LBaaSv2ServiceBuilder
 
 
@@ -60,7 +59,8 @@ def test_get_extended_member_no_port(mock_log):
 
     service_builder = LBaaSv2ServiceBuilder(driver)
 
-    member_dict, subnet, net = service_builder._get_extended_member(context, member)
+    member_dict, subnet, net = \
+        service_builder._get_extended_member(context, member)
     assert mock_log.warning.call_args_list == \
         [mock.call('Lbaas member 10.2.2.10 has no associated neutron port')]
 
@@ -73,6 +73,6 @@ def test_get_extended_member_one_port(mock_log):
     driver.plugin.db._core_plugin.get_ports.return_value = [1]
 
     service_builder = LBaaSv2ServiceBuilder(driver)
-
-    test_member = service_builder._get_extended_member(context, member)
+    member_dict, subnet, net = \
+        service_builder._get_extended_member(context, member)
     assert mock_log.warning.call_args_list == []

--- a/f5lbaasdriver/v2/bigip/test/test_member.py
+++ b/f5lbaasdriver/v2/bigip/test/test_member.py
@@ -1,0 +1,78 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import pytest
+from uuid import uuid4
+
+#from f5lbaasdriver.v2.bigip import exceptions as f5_exc
+from f5lbaasdriver.v2.bigip.service_builder import LBaaSv2ServiceBuilder
+
+
+class FakeDict(dict):
+    """Can be used as Neutron model object or as service builder dict"""
+    def __init__(self, *args, **kwargs):
+        super(FakeDict, self).__init__(*args, **kwargs)
+        if 'id' not in kwargs:
+            self['id'] = _uuid()
+
+    def __getattr__(self, item):
+        """Needed for using as a model object"""
+        if item in self:
+            return self[item]
+        else:
+            return None
+
+    def to_api_dict(self):
+        return self
+
+    def to_dict(self, **kwargs):
+        return self
+
+
+def _uuid():
+    """Create a random UUID string for model object IDs"""
+    return str(uuid4())
+
+
+@pytest.fixture
+def member():
+    return [FakeDict(subnet_id=_uuid())]
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.service_builder.LOG')
+def test_get_extended_member_no_port(mock_log):
+    context = mock.MagicMock()
+    driver = mock.MagicMock()
+    member = mock.MagicMock()
+    member.address = "10.2.2.10"
+
+    service_builder = LBaaSv2ServiceBuilder(driver)
+
+    member_dict, subnet, net = service_builder._get_extended_member(context, member)
+    assert mock_log.warning.call_args_list == \
+        [mock.call('Lbaas member 10.2.2.10 has no associated neutron port')]
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.service_builder.LOG')
+def test_get_extended_member_one_port(mock_log):
+    context = mock.MagicMock()
+    driver = mock.MagicMock()
+    member = mock.MagicMock()
+    driver.plugin.db._core_plugin.get_ports.return_value = [1]
+
+    service_builder = LBaaSv2ServiceBuilder(driver)
+
+    test_member = service_builder._get_extended_member(context, member)
+    assert mock_log.warning.call_args_list == []


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #585 

#### What's this change do?
This change will address the appropriate code modification that needs to be made to the driver to remove support for member port creation. It also includes unit tests for the change.

#### Where should the reviewer start?
code change: service_builder.py
new unit-tests: test_member.py

#### Any background context?
Previously driver handled port creation in case it couldn't find a member port. We don't support this anymore.