### PR TITLE
Add neutron port note to docs

### DIFF
--- a/docs/coding-example-lbaasv2.rst
+++ b/docs/coding-example-lbaasv2.rst
@@ -41,6 +41,9 @@ Use the command below to create a  member for the pool, specifying the subnet, I
 
     $ neutron lbaas-member-create --subnet private-subnet --address 172.16.101.89 --protocol-port 80 pool1
 
+.. include:: /includes/topic_lbaasv2-plugin-overview.rst
+   :start-after: start-neutron-port-note:
+   :end-before: end-neutron-port-note
 
 Create a health monitor
 ```````````````````````

--- a/docs/coding-example-lbaasv2.rst
+++ b/docs/coding-example-lbaasv2.rst
@@ -41,9 +41,14 @@ Use the command below to create a  member for the pool, specifying the subnet, I
 
     $ neutron lbaas-member-create --subnet private-subnet --address 172.16.101.89 --protocol-port 80 pool1
 
-.. include:: /includes/topic_lbaasv2-plugin-overview.rst
-   :start-after: start-neutron-port-note:
-   :end-before: end-neutron-port-note
+.. warning::
+
+   If a Neutron port does not exist for the assigned subnet and IP address, you may see the following warnings in the logs: ::
+
+      f5-openstack-agent.log -- “Member definition does not include Neutron port"
+      server.log -- “Lbaas member has no associated neutron port”
+
+   If you see these warnings, you may need to manually create a Neutron port for the pool member.
 
 Create a health monitor
 ```````````````````````

--- a/docs/includes/topic_hierarchical-port-binding.rst
+++ b/docs/includes/topic_hierarchical-port-binding.rst
@@ -11,6 +11,11 @@ Disconnected Services
 
 Because it is possible for LBaaSv2 objects to be provisioned on a Neutron network which has not yet been bound to a segment, the F5 agent can provision LBaaSv2 services in a disconnected state. When the agent discovers the intended network(s), these 'disconnected services' will be connected to the VLAN(s) and BIG-IP(s) as intended. You can customize how often the F5 agent will poll, and the maximum amount of time it should wait, for the network to be created before the request fails. This is, essentially, a fail-safe built into the F5 agent that allows for a certain degree of variation in the timing of the VLAN deployment and the request to create the LBaaS objects for it.
 
+.. include:: /includes/topic_lbaasv2-plugin-overview.rst
+   :start-after: start-neutron-port-note
+   :end-before: end-neutron-port-note
+
+
 Use Case
 --------
 

--- a/docs/includes/topic_lbaasv2-plugin-overview.rst
+++ b/docs/includes/topic_lbaasv2-plugin-overview.rst
@@ -13,7 +13,22 @@ The F5 LBaaSv2 plugin consists of an :ref:`agent <agent:home>` and a service pro
 The F5 agent manages services on your BIG-IP. When it first receives a task from the F5 driver, it starts and communicates with the BIG-IP(s) identified in the :ref:`agent configuration file`. Then, it registers its own named queue. The F5 driver assigns all ``lbaas`` tasks in the Neutron messaging queue to the agent's queue. The F5 agent makes callbacks to the F5® driver to query additional Neutron network, port, and subnet information; to allocate Neutron objects (for example, fixed IP addresses); and to report provisioning and pool status.
 
 .. image:: http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/_images/f5-lbaas-architecture.png
-    :alt: F5 LBaaSv2 Plugin architecture
+   :alt: F5 LBaaSv2 Plugin architecture
 
 
+.. _start-neutron-port-note:
 
+.. important::
+
+   As of v8.3.1, the F5 LBaaSv2 driver no longer manages Neutron ports.
+
+   When you create a pool member using the command ::
+
+     neutron lbaas-member-create --subnet private-subnet --address 172.16.101.89 --protocol-port 80 pool1
+
+   if the requested :code:`protocol-port` doesn't already exist on Neutron, you must create it manually.
+   Previously, the F5 LBaaSv2 driver created a corresponding Neutron port for the member if it didn't exist.
+
+   Likewise, if you create a pool member for which a corresponding Neutron port doesn't already exist, the F5 OpenStack Agent will not create a BIG-IP forwarding database (FBD) entry for the member.
+
+.. _end-neutron-port-note:

--- a/docs/includes/topic_lbaasv2-plugin-overview.rst
+++ b/docs/includes/topic_lbaasv2-plugin-overview.rst
@@ -6,7 +6,7 @@ Overview
 The F5® OpenStack LBaaSv2 service provider driver and agent (also called the 'F5 LBaaSv2 plugin') make it possible to provision F5 BIG-IP® `Local Traffic Manager <https://f5.com/products/modules/local-traffic-manager>`_ (LTM®) services in an OpenStack cloud.
 
 How the plugin works
-````````````````````
+--------------------
 
 The F5 LBaaSv2 plugin consists of an :ref:`agent <agent:home>` and a service provider driver (also just called 'driver', for short). The driver listens to the Neutron RPC messaging queue. When you make a call to the LBaaSv2 API -- for example, ``neutron lbaas-loadbalancer-create`` -- the F5 LBaaSv2 service provider driver picks it up and directs it to the agent.
 
@@ -16,19 +16,25 @@ The F5 agent manages services on your BIG-IP. When it first receives a task from
    :alt: F5 LBaaSv2 Plugin architecture
 
 
-.. _start-neutron-port-note:
+.. start-neutron-port-note
 
 .. important::
 
-   As of v8.3.1, the F5 LBaaSv2 driver no longer manages Neutron ports.
+   As of v8.3.1, the F5 LBaaSv2 driver no longer manages Neutron ports for LBaaS pool members.
 
-   When you create a pool member using the command ::
+   For example, say you create a pool member using the command below: ::
 
      neutron lbaas-member-create --subnet private-subnet --address 172.16.101.89 --protocol-port 80 pool1
 
-   if the requested :code:`protocol-port` doesn't already exist on Neutron, you must create it manually.
-   Previously, the F5 LBaaSv2 driver created a corresponding Neutron port for the member if it didn't exist.
 
-   Likewise, if you create a pool member for which a corresponding Neutron port doesn't already exist, the F5 OpenStack Agent will not create a BIG-IP forwarding database (FBD) entry for the member.
+   If a Neutron port corresponding to the requested subnet and IP address exists, it will be allocated to the pool member.
+   If no corresponding Neutron port exists, the following warnings print to the logs: ::
 
-.. _end-neutron-port-note:
+      f5-openstack-agent.log -- “Member definition does not include Neutron port"
+      server.log -- “Lbaas member has no associated neutron port”
+
+   In addition, the F5 OpenStack Agent does not create a forwarding database (FBD) entry for the pool member if it doesn't have a corresponding Neutron port.
+
+   If the requested subnet and IP address do not already have a corresponding Neutron port, you may need to create one manually. This depends on your deployment and use case.
+
+.. end-neutron-port-note

--- a/docs/includes/topic_neutron-bigip-command-mapping.rst
+++ b/docs/includes/topic_neutron-bigip-command-mapping.rst
@@ -9,12 +9,17 @@ Overview
 When you issue ``neutron lbaas`` commands on your OpenStack Neutron controller or host, the F5® LBaaSv2 driver and F5 agent configure objects on your BIG-IP® device(s). Here, we've provided some insight into what exactly happens behind the scenes to configure BIG-IP objects. You can also view the actual calls made by setting the F5 agent's DEBUG level to 'True' in the :ref:`agent configuration file` and viewing the logs (:file:`/var/log/neutron/f5-openstack-agent.log`).
 
 .. include:: ref_neutron-to-bigip-configs-table.rst
-    :start-line: 5
-    :end-line: 26
+   :start-line: 5
+   :end-line: 26
 
 
 
 The configurations applied when you issue ``neutron lbaas`` commands depend on how your BIG-IP is deployed and your network architecture. Far fewer configurations are made for an :term:`overcloud`, :term:`standalone` BIG-IP deployment than for an :term:`undercloud` :term:`active-standby pair` or :term:`device service cluster`.
+
+.. include:: /includes/topic_lbaasv2-plugin-overview.rst
+   :start-after: start-neutron-port-note:
+   :end-before: end-neutron-port-note
+
 
 The table below shows what happens on the BIG-IP when various commands are issued in Neutron to the F5 agent for a standalone, overcloud BIG-IP.
 

--- a/docs/includes/topic_neutron-bigip-command-mapping.rst
+++ b/docs/includes/topic_neutron-bigip-command-mapping.rst
@@ -16,11 +16,6 @@ When you issue ``neutron lbaas`` commands on your OpenStack Neutron controller o
 
 The configurations applied when you issue ``neutron lbaas`` commands depend on how your BIG-IP is deployed and your network architecture. Far fewer configurations are made for an :term:`overcloud`, :term:`standalone` BIG-IP deployment than for an :term:`undercloud` :term:`active-standby pair` or :term:`device service cluster`.
 
-.. include:: /includes/topic_lbaasv2-plugin-overview.rst
-   :start-after: start-neutron-port-note:
-   :end-before: end-neutron-port-note
-
-
 The table below shows what happens on the BIG-IP when various commands are issued in Neutron to the F5 agent for a standalone, overcloud BIG-IP.
 
 
@@ -70,12 +65,15 @@ Command                                    Action
                                            |    - It is assigned to the virtual server (or, listener) specified in the
                                            |    command.
 --------------------------------------     ---------------------------------------------------------------------------------
-``neutron lbaas-member-create``            | 1. A new member is created in the specified pool using the IP address and port
-                                           |    supplied in the command.
+``neutron lbaas-member-create``            | 1. A new member is created in the specified pool using the IP address and
+                                           |    subnet supplied in the command.
                                            |    - If the member is the first created for the specified pool, the pool
                                            |    status will change on the BIG-IP.
                                            |    - If the member is the first created with the supplied IP address, a new
                                            |    node is also created.
+                                           |    - If the member's IP address and subnet correspond to an existing Neutron
+                                           |      port, the agent creates a forwarding database (FDB) entry for the member
+                                           |      on the BIG-IP device(s). [#tablefn7]_
 --------------------------------------     ---------------------------------------------------------------------------------
 ``neutron lbaas-healthmonitor-create``     | 1. A new health monitor is created on the BIG-IP for the specified pool.
                                            |    - If the health monitor is the first created for the specified pool, the
@@ -103,7 +101,7 @@ Further Reading
 .. [#] If using :ref:`global routed mode`, all traffic is directed to the self IP (no tunnel is created).
 .. [#] Configured in :ref:`L3 Segmentation Mode` Settings --> ``f5_snat_addresses_per_subnet``.
 .. [#] See :ref:`Certificate Manager / SSL Offloading`.
-
+.. [#tablefn7] If the pool member does not have a corresponding Neutron port, warnings will print to the :code:`f5-openstack-agent` and :code:`neutron-server` log; the agent **will not** create an FDB entry for the member on the BIG-IP device(s).
 
 .. _self IP: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/6.html#conceptid
 .. _SNAT automap: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/8.html#unique_375712497

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,11 +11,16 @@ F5 OpenStack Neutron LBaaSv2
     <script async defer src="https://f5-openstack-slack.herokuapp.com/slackin.js"></script>
 
 
-Contents
-========
+.. include:: includes/ref_lbaasv2-version-compatibility.rst
+    :start-line: 2
+
+.. include:: includes/topic_lbaasv2-plugin-overview.rst
+    :start-line: 2
+
 
 .. toctree::
-    :maxdepth: 2
+   :caption: Contents
+   :maxdepth: 2
 
     Quick Start Guide <map_quick-start-guide>
     User Guide <map_f5-lbaasv2-user-guide>
@@ -30,12 +35,6 @@ Contents
     troubleshooting
     Solution Test Plan <solution-test-plan>
 
-
-.. include:: includes/ref_lbaasv2-version-compatibility.rst
-    :start-line: 2
-
-.. include:: includes/topic_lbaasv2-plugin-overview.rst
-    :start-line: 2
 
 
 .. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver.svg?branch=liberty


### PR DESCRIPTION
@pjbreaux @dflanigan 

#### What issues does this address?
Fixes #598 

#### What's this change do?

There are functional changes introduced in v8.3.1 that need to be documented.
I added a note regarding the changed behavior to the index.rst page and reused that note in the coding example and LBaaSv2 to BIG-IP command mapping doc.

#### Where should the reviewer start?
View changes in-line below. Actual text appears in docs/includes/topic_lbaasv2-plugin-overview.rst. It is reused in the coding example and command-mapping docs.

#### Any background context?
n/a