### PR TITLE
Service building for member should map neutron port when port is

### DIFF
--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -213,9 +213,14 @@ class LBaaSv2ServiceBuilder(object):
         )
 
         # we no longer support member port creation
-        if len(ports) == 0:
+        if len(ports) == 1:
+            member_dict['port'] = ports[0]
+            self._populate_member_network(context, member_dict, network)
+        elif len(ports) == 0:
             LOG.warning("Lbaas member %s has no associated neutron port"
                         % member.address)
+        elif len(ports) > 1:
+            LOG.warning("Multiple ports found for member: %s" % member.address)
 
         return (member_dict, subnet, network)
 

--- a/f5lbaasdriver/v2/bigip/test/test_member.py
+++ b/f5lbaasdriver/v2/bigip/test/test_member.py
@@ -54,8 +54,9 @@ def member():
 def test_get_extended_member_no_port(mock_log):
     context = mock.MagicMock()
     driver = mock.MagicMock()
-    member = mock.MagicMock()
+    member = FakeDict()
     member.address = "10.2.2.10"
+    driver.plugin.db._core_plugin.get_ports.return_value = []
 
     service_builder = LBaaSv2ServiceBuilder(driver)
 
@@ -63,16 +64,34 @@ def test_get_extended_member_no_port(mock_log):
         service_builder._get_extended_member(context, member)
     assert mock_log.warning.call_args_list == \
         [mock.call('Lbaas member 10.2.2.10 has no associated neutron port')]
+    assert 'port' not in member_dict
 
 
 @mock.patch('f5lbaasdriver.v2.bigip.service_builder.LOG')
 def test_get_extended_member_one_port(mock_log):
     context = mock.MagicMock()
     driver = mock.MagicMock()
-    member = mock.MagicMock()
+    member = FakeDict()
     driver.plugin.db._core_plugin.get_ports.return_value = [1]
 
     service_builder = LBaaSv2ServiceBuilder(driver)
     member_dict, subnet, net = \
         service_builder._get_extended_member(context, member)
     assert mock_log.warning.call_args_list == []
+    assert 'port' in member_dict
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.service_builder.LOG')
+def test_get_extended_member_several_ports(mock_log):
+    context = mock.MagicMock()
+    driver = mock.MagicMock()
+    member = FakeDict()
+    member.address = "10.2.2.10"
+    driver.plugin.db._core_plugin.get_ports.return_value = [1, 2, 3, 4]
+
+    service_builder = LBaaSv2ServiceBuilder(driver)
+    member_dict, subnet, net = \
+        service_builder._get_extended_member(context, member)
+    assert mock_log.warning.call_args_list == \
+        [mock.call("Multiple ports found for member: 10.2.2.10")]
+    assert 'port' not in member_dict


### PR DESCRIPTION
@richbrowne 

**Issues:**
Fixes #601

**Problem:**
When the logic to create neutron ports for pool members was removed from
the driver, the logic to actually include a port for the member when
that port exists was also removed. However, this was producing a failure
of two neutron lbaas tests due to fdb entry creation expecting the
'port' key to exist in the member. It didn't, so the member provisioning
status was set to ERROR. That should have prompted us to look at the
driver code again, ensuring that the port was set in the service object
before continuing. But we did not have that test, or the right test did
not have the proper assertion.

**Analysis:**
A port is added to the member dict if a single port is found for that
member address and subne. If no ports are found, the warning is still
logged. If more than one port is found, a different warning is logged.

**Tests:**
Running tests against local TLC stack with this change.
