### PR TITLE
Port creation in stable/newton cannot not be done in a transaction

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/scenario/f5_base.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/f5_base.py
@@ -29,6 +29,7 @@ class F5BaseTestCase(base.BaseTestCase):
 
     def setUp(self):
         super(F5BaseTestCase, self).setUp()
+        self.tenant_id = self.subnet['tenant_id']
         self.members = {}
         self.l7policy_client = l7policy_client.L7PolicyClientJSON(
             *self.client_args)
@@ -101,7 +102,7 @@ class F5BaseTestCase(base.BaseTestCase):
         # security group with a rule that allows tcp port 80 to the vip port.
         self.ports_client.update_port(
             self.load_balancer.get('vip_port_id'),
-            security_groups=[self.security_group.id])
+            security_groups=[self.security_group.get('id')])
 
     def _create_member(self, server_ip, server_position, load_balancer_id=None,
                        pool_id=None, subnet_id=None):

--- a/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
@@ -26,6 +26,7 @@ class F5StatsBaseTestCase(base.BaseTestCase):
 
     def setUp(self):
         super(F5StatsBaseTestCase, self).setUp()
+        self.tenant_id = self.subnet['tenant_id']
         self.members = {}
         self._create_servers()
         self._start_servers()

--- a/f5lbaasdriver/v2/bigip/test/test_neutron_client.py
+++ b/f5lbaasdriver/v2/bigip/test/test_neutron_client.py
@@ -1,0 +1,59 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from f5lbaasdriver.v2.bigip.neutron_client import F5NetworksNeutronClient
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def f5_neutron_client():
+    return F5NetworksNeutronClient(mock.MagicMock(name='plugin'))
+
+
+def test_create_port_on_subnet(f5_neutron_client):
+    mock_ctx = mock.MagicMock(name='context')
+    f5_neutron_client.create_port_on_subnet(mock_ctx)
+    assert not mock_ctx.session.begin.called
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.neutron_client.LOG')
+def test_create_port_on_subnet_error(mock_log):
+    mock_plugin = mock.MagicMock(name='plugin')
+    mock_plugin.db._core_plugin.update_port.side_effect = Exception('error')
+    nc = F5NetworksNeutronClient(mock_plugin)
+    mock_ctx = mock.MagicMock(name='context')
+    nc.create_port_on_subnet(mock_ctx, subnet_id='id')
+    assert mock_log.error.call_args_list == [
+        mock.call('Exception: create_port_on_subnet: %s', 'error')]
+    assert not mock_ctx.session.begin.called
+
+
+def test_delete_port(f5_neutron_client):
+    mock_ctx = mock.MagicMock(name='context')
+    f5_neutron_client.delete_port(mock_ctx, port_id='id')
+    assert not mock_ctx.session.begin.called
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.neutron_client.LOG')
+def test_delete_port_error(mock_log):
+    mock_plugin = mock.MagicMock(name='plugin')
+    mock_plugin.db._core_plugin.delete_port.side_effect = Exception('error')
+    nc = F5NetworksNeutronClient(mock_plugin)
+    mock_ctx = mock.MagicMock(name='context')
+    with pytest.raises(Exception) as ex:
+        nc.delete_port(mock_ctx, port_id='id')
+    assert ex.value.message == 'error'
+    assert not mock_ctx.session.begin.called

--- a/systest/scripts/conf/neutron-lbaas.tox.ini
+++ b/systest/scripts/conf/neutron-lbaas.tox.ini
@@ -10,7 +10,6 @@ install_command =
   {toxinidir}/tools/tox_install.sh {env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
 deps =
   -r{toxinidir}/test-requirements.txt
-  -r{toxinidir}/neutron_lbaas/tests/tempest/requirements.txt
   pytest
   git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
 whitelist_externals = sh


### PR DESCRIPTION
@szakeri @jlongstaf 

#### What issues does this address?
Fixes #606 

#### What's this change do?
Removed the transactions in port creation/update/deletions.

#### Where should the reviewer start?

#### Any background context?
The creation of ports cannot be done in a transaction in stable/newton,
as neutron has imposed a transaction guard around such CUD operations on
ports, subnets, and networks. We must perform the port creations without
a transaction.

Ran tests against newton stack. The scenario tests were failing because requests library was updated on the controller, but this is not a problem that will initially be fixed in this repo. We can handle that in dev-test. Created a few new units tests for this change as well.
