### PR TITLE
test_stats test failing in stable/newton due to changes in neutron_lbaas test setup

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/test_stats.py
@@ -75,7 +75,7 @@ class F5StatsBaseTestCase(base.BaseTestCase):
                     config.network.project_networks_reachable):
                 self._assign_floating_ip_to_lb_vip(self.load_balancer)
                 self.vip_ip = self.floating_ips[
-                    self.load_balancer.id][0]['floating_ip_address']
+                    load_balancer_id][0]['floating_ip_address']
 
         # Currently the ovs-agent is not enforcing security groups on the
         # vip port - see https://bugs.launchpad.net/neutron/+bug/1163569
@@ -83,7 +83,7 @@ class F5StatsBaseTestCase(base.BaseTestCase):
         # security group with a rule that allows tcp port 80 to the vip port.
         self.ports_client.update_port(
             self.load_balancer.get('vip_port_id'),
-            security_groups=[self.security_group.id])
+            security_groups=[self.security_group.get('id')])
 
     def _create_member(self, server_ip, server_position, load_balancer_id=None,
                        pool_id=None, subnet_id=None):


### PR DESCRIPTION
@szakeri 

#### What issues does this address?
Fixes #609 

#### What's this change do?
Changed the object attribute accesses to dictionary key accesses for the
security group. For the loadbalancer id, we just use a variable created
previously in the test.

#### Where should the reviewer start?

#### Any background context?
The test_stats scenario test fails in nightly consistently due to
changes made in the parent class of that test. The test expects the
loadbalancer id and the security group id to be attributes of a
loabalancer object and a security group object respectively, but those
are dictionary objects, not lbaasv2 model objects. Only the test needs
to be changed here.

Ran test on my local stable/newton jenkins worker and it passes.

```
platform linux2 -- Python 2.7.12, pytest-3.0.1, py-1.4.31, pluggy-0.3.1 -- /home/testlab/f5-openstack-lbaasv2-driver/.tox/tempest/bin/python
cachedir: ../../../../.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_stablenewton-tempest_12.1.1_undercloud_vxlan/driver.tempest_2130415_20170614-110846
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: cov-2.2.1, f5-openstack-test-0.2.1, symbols-0.1.0a3, meta-0.1.1, autolog-0.1.0a3, f5-sdk-2.3.3
collected 1 items
pytest-meta: discarded 0 items

scenario/test_stats.py::TestLoadBalancerStats::test_stats PASSED
```