### PR TITLE
Service object related to pools and associated listeners needs to be cleaned up

### DIFF
--- a/f5lbaasdriver/test/tempest/services/clients/bigip_client.py
+++ b/f5lbaasdriver/test/tempest/services/clients/bigip_client.py
@@ -217,3 +217,13 @@ class BigIpClient(object):
             name=vs_name, partition=partition)
 
         return getattr(vs, attr, None) == value
+
+    def virtual_server_has_pool(self, vs_name, partition, pool_name):
+        vs = self.bigip.tm.ltm.virtuals.virtual.load(
+            name=vs_name, partition=partition)
+        expected_pool = '/' + partition + '/' + pool_name
+        if not hasattr(vs, 'pool'):
+            return False
+        elif vs.pool == expected_pool:
+            return True
+        return False

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -221,15 +221,6 @@ class LBaaSv2ServiceBuilder(object):
 
         return self.net_cache[network_id]
 
-    @log_helpers.log_method_call
-    def _get_listener(self, context, listener_id):
-        """Retrieve listener from Neutron db."""
-        listener = self.plugin.db.get_listener(
-            context,
-            listener_id
-        )
-        return listener.to_api_dict()
-
     def _populate_member_network(self, context, member, network):
         """Add vtep networking info to pool member and update the network."""
         member['vxlan_vteps'] = []
@@ -507,17 +498,11 @@ class LBaaSv2ServiceBuilder(object):
                                  session_persistence=False)
 
         pool_dict['members'] = [{'id': member.id} for member in pool.members]
-        pool_dict['listeners'] = [{'id': listener.id}
-                                  for listener in pool.listeners]
         pool_dict['l7_policies'] = [{'id': l7_policy.id}
                                     for l7_policy in pool.l7_policies]
         if pool.session_persistence:
             pool_dict['session_persistence'] = (
                 pool.session_persistence.to_api_dict())
-        if pool.listener:
-            pool_dict['listener_id'] = pool.listener.id
-        else:
-            pool_dict['listener_id'] = None
 
         return pool_dict
 

--- a/f5lbaasdriver/v2/bigip/test/test_service_builder.py
+++ b/f5lbaasdriver/v2/bigip/test/test_service_builder.py
@@ -274,3 +274,16 @@ def test_get_members(pools, members):
 
     for test_member, member in zip(test_members, members):
         assert test_member is member
+
+
+def test__pool_to_dict():
+    '''Ensure function does not add listeners or listener_id to pool dict.'''
+    driver = mock.MagicMock()
+    fake_pool = FakeDict()
+    fake_pool.members = []
+    fake_pool.l7_policies = []
+
+    sb = LBaaSv2ServiceBuilder(driver)
+    pool_dict = sb._pool_to_dict(fake_pool)
+    assert 'listener_id' not in pool_dict
+    assert 'listeners' not in pool_dict


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #611 

#### What's this change do?
Removed the pool's listeners and listener_id from the service object.

#### Where should the reviewer start?

#### Any background context?
A shared pool is one which is associated with multiple listeners. There
is a period of time where the pool is not updated with associated
listeners, and that period of time could overlap with the building of
the service object. If it does, then the pool's list of listeners may
not be accurate. This means the service would be built based on stale
information. The listener, however, does have the correct references to
its associated pool. We will tweak the service object to reflect this
fact. We can have the agent rely upon the listener's view of its pool,
instead of relying upon the pool's view of the listeners. This issue
tracks cleaning up the service object to reflect this change.

Created a unit test to ensure we don't add listeners to a pool dict,
nor the listener_id field. Created a new api test to perform backend validation.