### PR TITLE
Stable/newton

### DIFF
--- a/f5lbaasdriver/test/tempest/services/clients/bigip_client.py
+++ b/f5lbaasdriver/test/tempest/services/clients/bigip_client.py
@@ -217,3 +217,13 @@ class BigIpClient(object):
             name=vs_name, partition=partition)
 
         return getattr(vs, attr, None) == value
+
+    def virtual_server_has_pool(self, vs_name, partition, pool_name):
+        vs = self.bigip.tm.ltm.virtuals.virtual.load(
+            name=vs_name, partition=partition)
+        expected_pool = '/' + partition + '/' + pool_name
+        if not hasattr(vs, 'pool'):
+            return False
+        elif vs.pool == expected_pool:
+            return True
+        return False

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -221,15 +221,6 @@ class LBaaSv2ServiceBuilder(object):
 
         return self.net_cache[network_id]
 
-    @log_helpers.log_method_call
-    def _get_listener(self, context, listener_id):
-        """Retrieve listener from Neutron db."""
-        listener = self.plugin.db.get_listener(
-            context,
-            listener_id
-        )
-        return listener.to_api_dict()
-
     def _populate_member_network(self, context, member, network):
         """Add vtep networking info to pool member and update the network."""
         member['vxlan_vteps'] = []
@@ -507,17 +498,11 @@ class LBaaSv2ServiceBuilder(object):
                                  session_persistence=False)
 
         pool_dict['members'] = [{'id': member.id} for member in pool.members]
-        pool_dict['listeners'] = [{'id': listener.id}
-                                  for listener in pool.listeners]
         pool_dict['l7_policies'] = [{'id': l7_policy.id}
                                     for l7_policy in pool.l7_policies]
         if pool.session_persistence:
             pool_dict['session_persistence'] = (
                 pool.session_persistence.to_api_dict())
-        if pool.listener:
-            pool_dict['listener_id'] = pool.listener.id
-        else:
-            pool_dict['listener_id'] = None
 
         return pool_dict
 

--- a/f5lbaasdriver/v2/bigip/test/test_service_builder.py
+++ b/f5lbaasdriver/v2/bigip/test/test_service_builder.py
@@ -274,3 +274,16 @@ def test_get_members(pools, members):
 
     for test_member, member in zip(test_members, members):
         assert test_member is member
+
+
+def test__pool_to_dict():
+    '''Ensure function does not add listeners or listener_id to pool dict.'''
+    driver = mock.MagicMock()
+    fake_pool = FakeDict()
+    fake_pool.members = []
+    fake_pool.l7_policies = []
+
+    sb = LBaaSv2ServiceBuilder(driver)
+    pool_dict = sb._pool_to_dict(fake_pool)
+    assert 'listener_id' not in pool_dict
+    assert 'listeners' not in pool_dict

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,7 +1,7 @@
 -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 -e .
 git+https://github.com/openstack/neutron.git@stable/newton
-git+https://github.com/openstack/neutron-lbaas.git@stable/newton
+git+https://github.com/F5Networks/neutron-lbaas.git@stable/newton
 git+https://github.com/F5Networks/pytest-symbols.git
 git+https://github.com/F5Networks/f5-openstack-test.git@stable/newton
 tempest==12.1.0


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #620 

#### What's this change do?
Bringing stable/newton branch up-to-date with mitaka changes and changing reference in requirements.test.txt to F5Networks fork of neturon-lbaas.

#### Where should the reviewer start?

#### Any background context?

Here's the results for a test with my fork of the driver, agent, and neutron-lbaas:

```
platform linux2 -- Python 2.7.12, pytest-3.0.1, py-1.4.31, pluggy-0.3.1 -- /home/testlab/f5-openstack-lbaasv2-driver/.tox/tempest/bin/python
cachedir: ../../../../.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_stablenewton-tempest_12.1.1_undercloud_vxlan/driver.tempest_e00ec36_20170621-115127
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: cov-2.2.1, f5-openstack-test-0.2.1, symbols-0.1.0a3, meta-0.1.1, autolog-0.1.0a3, f5-sdk-2.3.3
collected 46 items
pytest-meta: discarded 0 items

api/test_esd.py::ESDTestJSON::test_create_esd FAILED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_pool_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_ends_with PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_many_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_multi_policy_multi_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_three_rules PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_policy_redirect_url_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_file_type_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_not_file_type PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_no_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_two_policies PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_all_rules PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_policy PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_reorder_policies PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_with_tenant_id_field_for_admin PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_without_tenant_id PASSED
api/test_member_status.py::MemberStatusTestJSON::test_disabled <- .tox/tempest/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
api/test_member_status.py::MemberStatusTestJSON::test_no_monitor PASSED
api/test_member_status.py::MemberStatusTestJSON::test_offline PASSED
api/test_member_status.py::MemberStatusTestJSON::test_online PASSED
api/test_pools.py::PoolTestJSON::test_create_shared_detached_pools PASSED
api/test_pools.py::PoolTestJSON::test_create_shared_pools PASSED
api/test_service_builder.py::ServiceBuilderTestJSON::test_service_builder PASSED
scenario/test_esd.py::TestEsdBasic::test_policy_abort_deployment PASSED
scenario/test_esd.py::TestEsdBasic::test_policy_deployment PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_deployment PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_not_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_header_equal_to PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_hostname_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_file_type_fails_bad_compare_type PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_file_type_not_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_hostname_ends_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_path_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_file_type_equal_to PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_header_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicUpdate::test_policy_deployment_operand_match PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicUpdate::test_policy_reorder_and_rule_update PASSED
scenario/test_stats.py::TestLoadBalancerStats::test_stats PASSED
============================================ 1 failed, 44 passed, 1 skipped, 1 pytest-warnings in 2165.45 seconds ============================================
```

```
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitor_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_for_another_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitor_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitor_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_delay <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_expected_codes <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_http_method <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_pool_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_retries <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_max_url_path <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_timeout <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_empty_type <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_extra_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_delay <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_expected_codes <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_http_method <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_max_retries <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_pool_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_timeout <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_type <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_invalid_url_path <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_expected_codes <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_http_method <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_delay <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_max_retries <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_pool_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_timeout <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_required_field_type <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_create_health_monitor_missing_url_path <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_delete_health_monitor <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_get_health_monitor <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_list_health_monitors_empty <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_list_health_monitors_one <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_list_health_monitors_two <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_delay <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_empty_http_method <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_expected_codes <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_max_retries <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_timeout <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_empty_url_path <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_extra_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_delay <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_expected_codes <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_http_method <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_max_retries <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_timeout <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_url_path <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_delay <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_expected_codes <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_http_method <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_max_retries <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_timeout <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_missing_url_path <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_connection_limit <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_load_balancer_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_protocol <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_protocol_port <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_empty_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_incorrect_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_connection_limit <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_load_balancer_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_protocol <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_protocol_port <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_field_loadbalancer <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_field_protocol <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_create_listener_missing_field_protocol_port <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_delete_listener <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_get_listener <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_list_listeners <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_list_listeners_two <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_connection_limit <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_empty_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_incorrect_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_connection_limit <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_connection_limit <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::ListenersTestJSON::test_update_listener_missing_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_listeners_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestAdmin::test_create_load_balancer_empty_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py ERROR
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestAdmin::test_create_load_balancer_missing_tenant_id_for_tenant <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py ERROR
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestAdmin::test_delete_load_balancer_for_tenant <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py ERROR
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestAdmin::test_update_load_balancer_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py ERROR
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_admin_state_up_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_description_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_provider_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_vip_address_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_empty_vip_subnet_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_incorrect_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_flavor_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_invalid_vip_subnet_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_provider_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_vip_address <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_missing_vip_subnet_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_other_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_create_load_balancer_provider_flavor_conflict <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_delete_load_balancer <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_get_load_balancer <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_get_load_balancer_stats <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_get_load_balancer_status_tree <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_list_load_balancers <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_list_load_balancers_two <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_empty_admin_state_up_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_empty_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_empty_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_incorrect_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_invalid_admin_state_up_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_invalid_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_invalid_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_missing_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::LoadBalancersTestJSON::test_update_load_balancer_missing_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_add_member <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_address <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_protocol_port <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_subnet_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_empty_weight <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_address <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_protocol_port <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_subnet_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_invalid_weight <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_address <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_protocol_port <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_subnet_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_missing_required_field_tenant_id <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_create_member_nonint_weight <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_delete_member <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_get_member <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_list_3_members <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_list_empty_members <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_BadRequest_when_missing_attrs_during_member_create <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_exception_on_invalid_attr_on_create <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_exception_on_invalid_attr_on_update <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_raises_immutable_when_updating_immutable_attrs_on_member <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_empty_weight <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_invalid_weight <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::MemberTestJSON::test_update_member_missing_weight <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_members_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_for_another_tenant <- ../../jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_tenant_id_for_admin <- ../../jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_tenant_id_for_other_tenant <- ../../jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_using_empty_tenant_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_delete_pool <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_sesssion_persistence_app_cookie <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_sesssion_persistence_app_to_http <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_algorithm <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_description_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_listener_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_name_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_protocol <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_session_persistence_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_empty_tenant_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_for_other_tenant_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_incorrect_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_algorithm <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_desc_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_listener_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_name_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_protocol <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_session_persistence_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_invalid_tenant_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_admin_state_up_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_description_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_lb_algorithm_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_listener_id_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_name_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_protocol_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_required_fields <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_session_pers_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_missing_tenant_field <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_app_cookie <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_http_cookie <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_redundant_cookie_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_unsupported_type <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_create_pool_with_session_persistence_without_cookie_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_delete_invalid_pool <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_delete_pool <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_get_pool <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_list_pools_empty <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_list_pools_one <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_list_pools_two <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_empty_session_persistence <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_incorrect_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_attribute <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_desc <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_invalid_session_persistence <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_admin_state_up <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_description <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_name <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestPools::test_update_pool_missing_session_persistence <- ../../jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_pools_non_admin.py PASSED
```

```
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestHealthMonitorBasic::test_health_monitor_basic <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestListenerBasic::test_listener_basic <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestLoadBalancerBasic::test_load_balancer_basic <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestSessionPersistence::test_session_persistence <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
../../../../../../../testlab/f5-openstack-lbaasv2-driver/::TestSharedPools::test_shared_pools <- ../../jenkins/neutron-lbaas/.tox/scenariov2/local/lib/python2.7/site-packages/tempest/test.py PASSED
```
