### PR TITLE
newton jenkins build should have a long timeout due to more tests being run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     options {
         ansiColor('xterm')
         timestamps()
-        timeout(time: 2, unit: "HOURS")
+        timeout(time: 3, unit: "HOURS")
     }
     stages {
         stage("systest") {


### PR DESCRIPTION
@szakeri 
#### What issues does this address?
Fixes #631

#### What's this change do?
Updated the timeout to three hours.

#### Where should the reviewer start?

#### Any background context?
In the stable/newton branch, the Jenkinsfile specifies a job timeout of
2 hours. We should bump this to 3 hours because nightly runs have been
intermittently failing due to the fact that they hit this timeout. This
makes sense because more tests are being run in newton than in any other
branch.