### PR TITLE
Retry needed on TLC setup command in setup_tlc_session.sh build script

### DIFF
--- a/systest/scripts/setup_tlc_session.sh
+++ b/systest/scripts/setup_tlc_session.sh
@@ -15,10 +15,84 @@
 # limitations under the License.
 #
 
-set -ex
+set -x
 
-# Run the setup & commands for the session
-/tools/bin/tlc --session ${TEST_SESSION} --config ${TLC_FILE} --debug setup
+set +e
+
+runTLCSetup() {
+  # Excecute the TLC setup command given.
+  eval $1
+  tlc_setup_rc=$?
+}
+
+doesTLCSessionExist() {
+  # For the grep below, an rc of 1 means that the session does not exist.
+  # With an rc of 0, the session does exist because the grep found it.
+  tlc_exist_rc=1
+  if [[ -n "$1" ]]; then
+    /tools/bin/tlc sessions | grep $1
+    tlc_exist_rc=$?
+  fi
+}
+
+cleanupFailedTLCSession() {
+  # Cleanup the failed TLC session, if necessary.
+  typeset tlc_session_name=$1
+  typeset failed_session_iteration=$2
+  if [[ -n "${tlc_session_name}" ]]; then
+    # When you perform a TLC setup, first the session directory is created in
+    # /testlab/sessions directory. Then, eventually a TLC session is registered
+    # with TLC based on the reservations that are done for those hosts. We need
+    # to check both events to ensure we teardown properly, if a failure occurs.
+    backup_loc="/testlab/sessions/failed_setup_session_backup"
+    doesTLCSessionExist "${tlc_session_name}"
+
+    # Check if tlc reservation exists
+    if [[ $tlc_exist_rc == 0 ]]; then
+      echo "Cleaning up failed TLC session because it does exist."
+      /tools/bin/tlc --session ${tlc_session_name} cleanup
+    fi
+
+    # Check if tlc session directory exists on server
+    if [[ -d "/testlab/sessions/${tlc_session_name}" ]]; then
+      echo "Moving /testlab/sessions/${TEST_SESSION} directory to backup directory."
+      sudo mkdir -p ${backup_loc}/${tlc_session_name}_${failed_session_iteration}
+      sudo mv /testlab/sessions/${tlc_session_name} ${backup_loc}/${tlc_session_name}_${failed_session_iteration}
+    else
+      echo "Session directory does not exist."
+    fi
+  else
+    echo "TEST_SESSION variable in this script is empty. It should not be."
+    exit 1
+  fi
+}
+
+tlc_setup_cmd="/tools/bin/tlc --session ${TEST_SESSION} --config ${TLC_FILE} --debug setup"
+runTLCSetup "$tlc_setup_cmd"
+
+# Run the TLC setup command, and retry up to three times if anything goes wrong.
+for i in `seq 1 3`; do
+  if [[ $tlc_setup_rc != 0 ]]; then
+    echo "###################################################"
+    echo "TLC setup command failed with rc=${tlc_setup_rc}. Retry number ${i}"
+    echo "###################################################"
+    cleanupFailedTLCSession "$TEST_SESSION" "$i"
+    runTLCSetup "$tlc_setup_cmd"
+  else
+    break
+  fi
+done
+
+if [[ $tlc_setup_rc != 0 ]]; then
+  echo "###################################################"
+  echo "All retries for TLC setup failed. Tearing down session and exiting."
+  echo "###################################################"
+  cleanupFailedTLCSession "$TEST_SESSION" "$i"
+  exit 1
+fi
+
+set -e
+# Run the remaining TLC commands
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd ready
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd test_env
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd lbaasv2


### PR DESCRIPTION
@szakeri 

#### What issues does this address?
Fixes #608 

#### What's this change do?
Updated the setup_tlc_session.sh script to retry the setup command if it
fails. The retry limit is three times.

#### Where should the reviewer start?

#### Any background context?
Occasionally, the TLC setup command fails in nightly runs with an error
while scp'ing up scripts to the OpenStack hosts. We should retry the TLC
setup if the rc is anything other than 0. Note that we will have to do
TLC cleanup and then mv the /testlab/sessions/<failed_session_name>
before we retry, because that directory cannot exist when we try to
rerun. Unless, we gave the retry session a new name.

I conducted the test of this script on bahamas with a TLC stack. Here's the output. The first test is me unsetting the TEST_SESSION var, which is needed to name the TLC session, but also to mv the session directory to the proper place in case of a failure. If TEST_SESSION is empty, we simply exit 1 and echo a message, since we don't want to accidentally move all of /testlab/sessions to the failed directory. The second test is if we actually have a problem with the setup, we want to retry. The third test is a successful test to ensure we execute the setup as expected.

```
breaux:scripts$ unset TEST_SESSION
breaux:scripts$ ./setup_tlc_session.sh
+ set +e
+ tlc_setup_cmd='/tools/bin/tlc --session  --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ runTLCSetup '/tools/bin/tlc --session  --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ eval /tools/bin/tlc --session --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
++ /tools/bin/tlc --session --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
usage: tlc [-h] [--tool {auto,tlc.py,tlc-client}] [--arg-file ARG_FILE]
           [--deploy DEPLOY] [--sid ID] [--debug] [--no-debug] [--cfg FILE]
           [--debug_lacp] [--version] [--root DIR] [--ipmi CMD]
           [--longTimeout] [--duration HOURS] [--force] [--debug_vlan]
           [-s SERVER]

           {cleanup,create,forceoff,hcmd,help,hostfiles,hosts,ipmi,list,off,on,purge,sessionfile,sol,symbols,version,archive,cmd,extend,release,reservations,reserve,resetup,sessions,setup,ssh}
           ...
tlc: error: argument --sid/--sessionID: expected one argument
+ tlc_setup_rc=2
++ seq 1 3
+ for i in '`seq 1 3`'
+ [[ 2 != 0 ]]
+ echo '###################################################'
###################################################
+ echo 'TLC setup command failed with rc=2. Retry number 1'
TLC setup command failed with rc=2. Retry number 1
+ echo '###################################################'
###################################################
+ echo 'Moving /testlab/sessions/ directory to backup directory.'
Moving /testlab/sessions/ directory to backup directory.
+ [[ -n '' ]]
+ echo 'TEST_SESSION variable in this script is empty. It should not be.'
TEST_SESSION variable in this script is empty. It should not be.
+ exit 1
breaux:scripts$
breaux:scripts$
breaux:scripts$
breaux:scripts$
breaux:scripts$ export TEST_SESSION=breaux-liberty-test-tlc-setup
breaux:scripts$ unset TEST_OPENSTACK_DISTRO
breaux:scripts$ ./setup_tlc_session.sh
+ set +e
+ tlc_setup_cmd='/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ runTLCSetup '/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ eval /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
++ /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
2017-06-22 11:54:22.154603: Parsed Args:
2017-06-22 11:54:22.154709:   arg_file        None
2017-06-22 11:54:22.154733:   command         setup
2017-06-22 11:54:22.154750:   configFile      /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
2017-06-22 11:54:22.154768:   debug           True
2017-06-22 11:54:22.154786:   debug_lacp      False
2017-06-22 11:54:22.154802:   debug_vlan      False
2017-06-22 11:54:22.154821:   deployment      None
2017-06-22 11:54:22.154839:   expires         None
2017-06-22 11:54:22.154858:   force           False
2017-06-22 11:54:22.154875:   ipmiCmd         None
2017-06-22 11:54:22.154893:   longTimeout     False
2017-06-22 11:54:22.154910:   no_create       False
2017-06-22 11:54:22.154926:   root            /testlab
2017-06-22 11:54:22.154943:   serialconsole   no
2017-06-22 11:54:22.154959:   server_url      http://tlc-server-production:8000
2017-06-22 11:54:22.154976:   sessionID       breaux-liberty-test-tlc-setup
2017-06-22 11:54:22.154993:   tool            auto
2017-06-22 11:54:22.155010:   version         False
2017-06-22 11:54:22.155029: Unparsed args, to be passed on: []
2017-06-22 11:54:22.155093: Arg Sources:
Command Line Args:   --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
Environment Variables:
  TLC_FILE:          /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
Defaults:
  --tool:            auto
  --testlabroot:     /testlab
  --server:          http://tlc-server-production:8000

2017-06-22 11:54:22.155123: Identifying the correct tool:
2017-06-22 11:54:22.155143:   tool == auto: checking tools...
2017-06-22 11:54:22.155159:   tlc-client is available.  Checking fit...
2017-06-22 11:54:22.193971:   session (breaux-liberty-test-tlc-setup) not found via tlc-client
2017-06-22 11:54:22.194012:   tlc.py is available.  Checking fit...
2017-06-22 11:54:22.194060:   session (breaux-liberty-test-tlc-setup) not found via tlc.py
2017-06-22 11:54:22.194082:   default is tlc.py: using tlc.py
2017-06-22 11:54:22.194098:
2017-06-22 11:54:22.194115: Correct tool determined: tlc.py
2017-06-22 11:54:22.198643: Setup Command
2017-06-22 11:54:22.200090: !UNRECOGNIZED ERROR!
2017-06-22 11:54:22.200122:   'TEST_OPENSTACK_DISTRO'
Traceback (most recent call last):
  File "/tools/bin/tlc", line 562, in <module>
    main()
  File "/tools/bin/tlc", line 317, in main
    sys.exit(old_tlc_main(args, unknown_args))
  File "/tools/bin/tlc", line 536, in old_tlc_main
    tlc.cmds.get(options.command)(options, unknown_args)
  File "/tools/lib/tlc_lib.py", line 5053, in cmdSetup
    session, options.sessionID = create_internal(options, args)
  File "/tools/lib/tlc_lib.py", line 4983, in create_internal
    testcfg = getTestCfg(options.configFile)
  File "/tools/lib/tlc_lib.py", line 4810, in getTestCfg
    cfgFile = cfgFileTemplate.substitute(os.environ)
  File "/usr/local/lib/python2.7/string.py", line 172, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/local/lib/python2.7/string.py", line 162, in convert
    val = mapping[named]
  File "/usr/local/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TEST_OPENSTACK_DISTRO'
+ tlc_setup_rc=1
++ seq 1 3
+ for i in '`seq 1 3`'
+ [[ 1 != 0 ]]
+ echo '###################################################'
###################################################
+ echo 'TLC setup command failed with rc=1. Retry number 1'
TLC setup command failed with rc=1. Retry number 1
+ echo '###################################################'
###################################################
+ echo 'Moving /testlab/sessions/breaux-liberty-test-tlc-setup directory to backup directory.'
Moving /testlab/sessions/breaux-liberty-test-tlc-setup directory to backup directory.
+ [[ -n breaux-liberty-test-tlc-setup ]]
+ backup_loc=/testlab/sessions/failed_setup_session_backup
+ sudo mkdir -p /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_1
+ sudo mv /testlab/sessions/breaux-liberty-test-tlc-setup /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_1
mv: rename /testlab/sessions/breaux-liberty-test-tlc-setup to /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_1/breaux-liberty-test-tlc-setup: No such file or directory
+ runTLCSetup '/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ eval /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
++ /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
2017-06-22 11:54:22.724827: Parsed Args:
2017-06-22 11:54:22.724943:   arg_file        None
2017-06-22 11:54:22.724967:   command         setup
2017-06-22 11:54:22.724984:   configFile      /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
2017-06-22 11:54:22.725003:   debug           True
2017-06-22 11:54:22.725020:   debug_lacp      False
2017-06-22 11:54:22.725037:   debug_vlan      False
2017-06-22 11:54:22.725057:   deployment      None
2017-06-22 11:54:22.725074:   expires         None
2017-06-22 11:54:22.725093:   force           False
2017-06-22 11:54:22.725110:   ipmiCmd         None
2017-06-22 11:54:22.725129:   longTimeout     False
2017-06-22 11:54:22.725145:   no_create       False
2017-06-22 11:54:22.725164:   root            /testlab
2017-06-22 11:54:22.725180:   serialconsole   no
2017-06-22 11:54:22.725198:   server_url      http://tlc-server-production:8000
2017-06-22 11:54:22.725214:   sessionID       breaux-liberty-test-tlc-setup
2017-06-22 11:54:22.725230:   tool            auto
2017-06-22 11:54:22.725248:   version         False
2017-06-22 11:54:22.725271: Unparsed args, to be passed on: []
2017-06-22 11:54:22.725335: Arg Sources:
Command Line Args:   --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
Environment Variables:
  TLC_FILE:          /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
Defaults:
  --tool:            auto
  --testlabroot:     /testlab
  --server:          http://tlc-server-production:8000

2017-06-22 11:54:22.725364: Identifying the correct tool:
2017-06-22 11:54:22.725384:   tool == auto: checking tools...
2017-06-22 11:54:22.725400:   tlc-client is available.  Checking fit...
2017-06-22 11:54:22.758684:   session (breaux-liberty-test-tlc-setup) not found via tlc-client
2017-06-22 11:54:22.758718:   tlc.py is available.  Checking fit...
2017-06-22 11:54:22.758764:   session (breaux-liberty-test-tlc-setup) not found via tlc.py
2017-06-22 11:54:22.758789:   default is tlc.py: using tlc.py
2017-06-22 11:54:22.758805:
2017-06-22 11:54:22.758823: Correct tool determined: tlc.py
2017-06-22 11:54:22.762907: Setup Command
2017-06-22 11:54:22.763765: !UNRECOGNIZED ERROR!
2017-06-22 11:54:22.763797:   'TEST_OPENSTACK_DISTRO'
Traceback (most recent call last):
  File "/tools/bin/tlc", line 562, in <module>
    main()
  File "/tools/bin/tlc", line 317, in main
    sys.exit(old_tlc_main(args, unknown_args))
  File "/tools/bin/tlc", line 536, in old_tlc_main
    tlc.cmds.get(options.command)(options, unknown_args)
  File "/tools/lib/tlc_lib.py", line 5053, in cmdSetup
    session, options.sessionID = create_internal(options, args)
  File "/tools/lib/tlc_lib.py", line 4983, in create_internal
    testcfg = getTestCfg(options.configFile)
  File "/tools/lib/tlc_lib.py", line 4810, in getTestCfg
    cfgFile = cfgFileTemplate.substitute(os.environ)
  File "/usr/local/lib/python2.7/string.py", line 172, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/local/lib/python2.7/string.py", line 162, in convert
    val = mapping[named]
  File "/usr/local/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TEST_OPENSTACK_DISTRO'
+ tlc_setup_rc=1
+ for i in '`seq 1 3`'
+ [[ 1 != 0 ]]
+ echo '###################################################'
###################################################
+ echo 'TLC setup command failed with rc=1. Retry number 2'
TLC setup command failed with rc=1. Retry number 2
+ echo '###################################################'
###################################################
+ echo 'Moving /testlab/sessions/breaux-liberty-test-tlc-setup directory to backup directory.'
Moving /testlab/sessions/breaux-liberty-test-tlc-setup directory to backup directory.
+ [[ -n breaux-liberty-test-tlc-setup ]]
+ backup_loc=/testlab/sessions/failed_setup_session_backup
+ sudo mkdir -p /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_2
+ sudo mv /testlab/sessions/breaux-liberty-test-tlc-setup /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_2
mv: rename /testlab/sessions/breaux-liberty-test-tlc-setup to /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_2/breaux-liberty-test-tlc-setup: No such file or directory
+ runTLCSetup '/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ eval /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
++ /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
2017-06-22 11:54:23.286193: Parsed Args:
2017-06-22 11:54:23.286316:   arg_file        None
2017-06-22 11:54:23.286340:   command         setup
2017-06-22 11:54:23.286357:   configFile      /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
2017-06-22 11:54:23.286376:   debug           True
2017-06-22 11:54:23.286393:   debug_lacp      False
2017-06-22 11:54:23.286410:   debug_vlan      False
2017-06-22 11:54:23.286427:   deployment      None
2017-06-22 11:54:23.286444:   expires         None
2017-06-22 11:54:23.286461:   force           False
2017-06-22 11:54:23.286478:   ipmiCmd         None
2017-06-22 11:54:23.286495:   longTimeout     False
2017-06-22 11:54:23.286512:   no_create       False
2017-06-22 11:54:23.286528:   root            /testlab
2017-06-22 11:54:23.286546:   serialconsole   no
2017-06-22 11:54:23.286563:   server_url      http://tlc-server-production:8000
2017-06-22 11:54:23.286578:   sessionID       breaux-liberty-test-tlc-setup
2017-06-22 11:54:23.286594:   tool            auto
2017-06-22 11:54:23.286611:   version         False
2017-06-22 11:54:23.286629: Unparsed args, to be passed on: []
2017-06-22 11:54:23.286692: Arg Sources:
Command Line Args:   --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
Environment Variables:
  TLC_FILE:          /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
Defaults:
  --tool:            auto
  --testlabroot:     /testlab
  --server:          http://tlc-server-production:8000

2017-06-22 11:54:23.286722: Identifying the correct tool:
2017-06-22 11:54:23.286742:   tool == auto: checking tools...
2017-06-22 11:54:23.286759:   tlc-client is available.  Checking fit...
2017-06-22 11:54:23.321178:   session (breaux-liberty-test-tlc-setup) not found via tlc-client
2017-06-22 11:54:23.321212:   tlc.py is available.  Checking fit...
2017-06-22 11:54:23.321261:   session (breaux-liberty-test-tlc-setup) not found via tlc.py
2017-06-22 11:54:23.321286:   default is tlc.py: using tlc.py
2017-06-22 11:54:23.321302:
2017-06-22 11:54:23.321320: Correct tool determined: tlc.py
2017-06-22 11:54:23.325401: Setup Command
2017-06-22 11:54:23.326263: !UNRECOGNIZED ERROR!
2017-06-22 11:54:23.326295:   'TEST_OPENSTACK_DISTRO'
Traceback (most recent call last):
  File "/tools/bin/tlc", line 562, in <module>
    main()
  File "/tools/bin/tlc", line 317, in main
    sys.exit(old_tlc_main(args, unknown_args))
  File "/tools/bin/tlc", line 536, in old_tlc_main
    tlc.cmds.get(options.command)(options, unknown_args)
  File "/tools/lib/tlc_lib.py", line 5053, in cmdSetup
    session, options.sessionID = create_internal(options, args)
  File "/tools/lib/tlc_lib.py", line 4983, in create_internal
    testcfg = getTestCfg(options.configFile)
  File "/tools/lib/tlc_lib.py", line 4810, in getTestCfg
    cfgFile = cfgFileTemplate.substitute(os.environ)
  File "/usr/local/lib/python2.7/string.py", line 172, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/local/lib/python2.7/string.py", line 162, in convert
    val = mapping[named]
  File "/usr/local/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TEST_OPENSTACK_DISTRO'
+ tlc_setup_rc=1
+ for i in '`seq 1 3`'
+ [[ 1 != 0 ]]
+ echo '###################################################'
###################################################
+ echo 'TLC setup command failed with rc=1. Retry number 3'
TLC setup command failed with rc=1. Retry number 3
+ echo '###################################################'
###################################################
+ echo 'Moving /testlab/sessions/breaux-liberty-test-tlc-setup directory to backup directory.'
Moving /testlab/sessions/breaux-liberty-test-tlc-setup directory to backup directory.
+ [[ -n breaux-liberty-test-tlc-setup ]]
+ backup_loc=/testlab/sessions/failed_setup_session_backup
+ sudo mkdir -p /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_3
+ sudo mv /testlab/sessions/breaux-liberty-test-tlc-setup /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_3
mv: rename /testlab/sessions/breaux-liberty-test-tlc-setup to /testlab/sessions/failed_setup_session_backup/breaux-liberty-test-tlc-setup_3/breaux-liberty-test-tlc-setup: No such file or directory
+ runTLCSetup '/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ eval /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
++ /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
2017-06-22 11:54:23.846723: Parsed Args:
2017-06-22 11:54:23.846844:   arg_file        None
2017-06-22 11:54:23.846868:   command         setup
2017-06-22 11:54:23.846885:   configFile      /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
2017-06-22 11:54:23.846904:   debug           True
2017-06-22 11:54:23.846921:   debug_lacp      False
2017-06-22 11:54:23.846937:   debug_vlan      False
2017-06-22 11:54:23.846955:   deployment      None
2017-06-22 11:54:23.846974:   expires         None
2017-06-22 11:54:23.846992:   force           False
2017-06-22 11:54:23.847009:   ipmiCmd         None
2017-06-22 11:54:23.847026:   longTimeout     False
2017-06-22 11:54:23.847043:   no_create       False
2017-06-22 11:54:23.847059:   root            /testlab
2017-06-22 11:54:23.847075:   serialconsole   no
2017-06-22 11:54:23.847091:   server_url      http://tlc-server-production:8000
2017-06-22 11:54:23.847107:   sessionID       breaux-liberty-test-tlc-setup
2017-06-22 11:54:23.847123:   tool            auto
2017-06-22 11:54:23.847139:   version         False
2017-06-22 11:54:23.847158: Unparsed args, to be passed on: []
2017-06-22 11:54:23.847221: Arg Sources:
Command Line Args:   --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
Environment Variables:
  TLC_FILE:          /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
Defaults:
  --tool:            auto
  --testlabroot:     /testlab
  --server:          http://tlc-server-production:8000

2017-06-22 11:54:23.847251: Identifying the correct tool:
2017-06-22 11:54:23.847274:   tool == auto: checking tools...
2017-06-22 11:54:23.847291:   tlc-client is available.  Checking fit...
2017-06-22 11:54:23.876799:   session (breaux-liberty-test-tlc-setup) not found via tlc-client
2017-06-22 11:54:23.876833:   tlc.py is available.  Checking fit...
2017-06-22 11:54:23.876879:   session (breaux-liberty-test-tlc-setup) not found via tlc.py
2017-06-22 11:54:23.876904:   default is tlc.py: using tlc.py
2017-06-22 11:54:23.876920:
2017-06-22 11:54:23.876938: Correct tool determined: tlc.py
2017-06-22 11:54:23.881027: Setup Command
2017-06-22 11:54:23.881895: !UNRECOGNIZED ERROR!
2017-06-22 11:54:23.881927:   'TEST_OPENSTACK_DISTRO'
Traceback (most recent call last):
  File "/tools/bin/tlc", line 562, in <module>
    main()
  File "/tools/bin/tlc", line 317, in main
    sys.exit(old_tlc_main(args, unknown_args))
  File "/tools/bin/tlc", line 536, in old_tlc_main
    tlc.cmds.get(options.command)(options, unknown_args)
  File "/tools/lib/tlc_lib.py", line 5053, in cmdSetup
    session, options.sessionID = create_internal(options, args)
  File "/tools/lib/tlc_lib.py", line 4983, in create_internal
    testcfg = getTestCfg(options.configFile)
  File "/tools/lib/tlc_lib.py", line 4810, in getTestCfg
    cfgFile = cfgFileTemplate.substitute(os.environ)
  File "/usr/local/lib/python2.7/string.py", line 172, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/local/lib/python2.7/string.py", line 162, in convert
    val = mapping[named]
  File "/usr/local/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TEST_OPENSTACK_DISTRO'
+ tlc_setup_rc=1
+ set -e
+ /tools/bin/tlc --session breaux-liberty-test-tlc-setup --debug cmd ready
2017-06-22 11:54:24.333088: Parsed Args:
2017-06-22 11:54:24.333210:   arg_file        None
2017-06-22 11:54:24.333233:   command         cmd
2017-06-22 11:54:24.333250:   configFile      /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
2017-06-22 11:54:24.333273:   config_command  ready
2017-06-22 11:54:24.333291:   debug           True
2017-06-22 11:54:24.333308:   debug_lacp      False
2017-06-22 11:54:24.333327:   debug_vlan      False
2017-06-22 11:54:24.333345:   deployment      None
2017-06-22 11:54:24.333362:   expires         None
2017-06-22 11:54:24.333378:   force           False
2017-06-22 11:54:24.333395:   ipmiCmd         None
2017-06-22 11:54:24.333414:   longTimeout     False
2017-06-22 11:54:24.333430:   root            /testlab
2017-06-22 11:54:24.333446:   server_url      http://tlc-server-production:8000
2017-06-22 11:54:24.333462:   sessionID       breaux-liberty-test-tlc-setup
2017-06-22 11:54:24.333478:   tool            auto
2017-06-22 11:54:24.333494:   version         False
2017-06-22 11:54:24.333513: Unparsed args, to be passed on: []
2017-06-22 11:54:24.333577: Arg Sources:
Command Line Args:   --session breaux-liberty-test-tlc-setup --debug cmd ready
Environment Variables:
  TLC_FILE:          /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
Defaults:
  --tool:            auto
  --testlabroot:     /testlab
  --server:          http://tlc-server-production:8000

2017-06-22 11:54:24.333606: Identifying the correct tool:
2017-06-22 11:54:24.333626:   tool == auto: checking tools...
2017-06-22 11:54:24.333642:   tlc-client is available.  Checking fit...
2017-06-22 11:54:24.366121:   session (breaux-liberty-test-tlc-setup) not found via tlc-client
2017-06-22 11:54:24.366155:   tlc.py is available.  Checking fit...
2017-06-22 11:54:24.366201:   session (breaux-liberty-test-tlc-setup) not found via tlc.py
2017-06-22 11:54:24.366225:   default is tlc.py: using tlc.py
2017-06-22 11:54:24.366242:
2017-06-22 11:54:24.366264: Correct tool determined: tlc.py
2017-06-22 11:54:24.370944: ERROR: Unable to load session breaux-liberty-test-tlc-setup
breaux:scripts$ ls /testlab/sessions/failed_setup_session_backup/
total 84
drwxr-xr-x    8 root  wheel   4096 Jun 22 11:54 .
drwxr-xr-x    2 root  wheel   4096 Jun 22 11:54 breaux-liberty-test-tlc-setup_3
drwxr-xr-x    2 root  wheel   4096 Jun 22 11:54 breaux-liberty-test-tlc-setup_2
drwxr-xr-x    2 root  wheel   4096 Jun 22 11:54 breaux-liberty-test-tlc-setup_1
drwxrwxrwx  450 root  wheel  53248 Jun 22 11:52 ..
drwxr-xr-x    2 root  wheel   4096 Jun 22 11:40 breaux-test-tlc-retry_3
drwxr-xr-x    2 root  wheel   4096 Jun 22 11:40 breaux-test-tlc-retry_2
drwxr-xr-x    2 root  wheel   4096 Jun 22 11:40 breaux-test-tlc-retry_1
breaux:scripts$ export TEST_OPENSTACK_DISTRO=liberty
breaux:scripts$ ./setup_tlc_session.sh
+ set +e
+ tlc_setup_cmd='/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ runTLCSetup '/tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup'
+ eval /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
++ /tools/bin/tlc --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
2017-06-22 11:54:50.792363: Parsed Args:
2017-06-22 11:54:50.792483:   arg_file        None
2017-06-22 11:54:50.792507:   command         setup
2017-06-22 11:54:50.792524:   configFile      /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
2017-06-22 11:54:50.792543:   debug           True
2017-06-22 11:54:50.792561:   debug_lacp      False
2017-06-22 11:54:50.792580:   debug_vlan      False
2017-06-22 11:54:50.792597:   deployment      None
2017-06-22 11:54:50.792617:   expires         None
2017-06-22 11:54:50.792634:   force           False
2017-06-22 11:54:50.792653:   ipmiCmd         None
2017-06-22 11:54:50.792671:   longTimeout     False
2017-06-22 11:54:50.792689:   no_create       False
2017-06-22 11:54:50.792706:   root            /testlab
2017-06-22 11:54:50.792724:   serialconsole   no
2017-06-22 11:54:50.792740:   server_url      http://tlc-server-production:8000
2017-06-22 11:54:50.792757:   sessionID       breaux-liberty-test-tlc-setup
2017-06-22 11:54:50.792775:   tool            auto
2017-06-22 11:54:50.792792:   version         False
2017-06-22 11:54:50.792812: Unparsed args, to be passed on: []
2017-06-22 11:54:50.792878: Arg Sources:
Command Line Args:   --session breaux-liberty-test-tlc-setup --config /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc --debug setup
Environment Variables:
  TLC_FILE:          /home/breaux/dev-test/traffic/undercloud/tempest_ve_undercloud.tlc
Defaults:
  --tool:            auto
  --testlabroot:     /testlab
  --server:          http://tlc-server-production:8000

2017-06-22 11:54:50.792908: Identifying the correct tool:
2017-06-22 11:54:50.792928:   tool == auto: checking tools...
2017-06-22 11:54:50.792947:   tlc-client is available.  Checking fit...
2017-06-22 11:54:50.826891:   session (breaux-liberty-test-tlc-setup) not found via tlc-client
2017-06-22 11:54:50.826926:   tlc.py is available.  Checking fit...
2017-06-22 11:54:50.826973:   session (breaux-liberty-test-tlc-setup) not found via tlc.py
2017-06-22 11:54:50.826997:   default is tlc.py: using tlc.py
2017-06-22 11:54:50.827013:
2017-06-22 11:54:50.827031: Correct tool determined: tlc.py
2017-06-22 11:54:50.831258: Setup Command
2017-06-22 11:54:50.849891: Config file version: 1.0
2017-06-22 11:54:50.850062: Setting up session directory...
2017-06-22 11:54:50.853732: Setting up session file...
2017-06-22 11:54:50.873940: Building reservation request...
2017-06-22 11:54:50.874013: Identifying IPID's...
2017-06-22 11:54:50.874095: Identifying Hosts...
2017-06-22 11:54:50.874136: Looking through resources for host groups...
2017-06-22 11:54:50.874167: Found hostgroup openstack_controller
2017-06-22 11:54:50.874205: Querying inventory DB for cabable hosts...
```