### PR TITLE
Changed BIGIP-13 to use the hotfix 0.0.0.2.0-1671 image build

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -143,7 +143,7 @@ cleanup_failed_tlc:
 
 # Tempest Tests for 13.0.0 undercloud VE deployment
 tempest_13.0.0_undercloud_vxlan:
-	export TEST_VE_IMAGE=os_ready-BIGIP-13.0.0.0.0.1645.qcow2 ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-13.0.0.2.0.1671.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\
 	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\


### PR DESCRIPTION
Issues:
Fixes #636

Problem:
* BIGIP-13.0.0.0.0 was giving problems in the lab with SOAPLicenseClient

Analysis:
* BIGIP-13.0.0.2.0 hotfix seems to resolve this issue
* The SOAPLicenseClient appears to, more often, activate without issue

Tests:
This was tested in the heat templates:
https://github.com/F5Networks/f5-openstack-heat


#### What issues does this address?
Fixes #636 

#### What's this change do?
Changes the nightly focus from the 13.0.0.0.0 image to the hotfix 2 image.

#### Where should the reviewer start?
This is a simple change in the Makefile for systests

#### Any background context?
The previous image for 13.0.0.0.0 had issues with SOAPLicenseClient registering the box.