### PR TITLE
changing stable/mitaka to mitaka-eol for upstream packages

### DIFF
--- a/f5lbaasdriver/test/tempest/Docker/tempest_tests
+++ b/f5lbaasdriver/test/tempest/Docker/tempest_tests
@@ -12,8 +12,8 @@ RUN apt-get -y update \
 RUN pip install --upgrade pip
 RUN pip install tempest
 RUN pip install crudini
-RUN pip install git+https://github.com/openstack/neutron.git@stable/mitaka
-RUN pip install git+https://github.com/openstack/neutron-lbaas.git@stable/mitaka
+RUN pip install git+https://github.com/openstack/neutron.git@mitaka-eol
+RUN pip install git+https://github.com/openstack/neutron-lbaas.git@mitaka-eol
 RUN mkdir -p /etc/tempest
 RUN mkdir -p /root/f5-openstack-lbaasv2-driver
 RUN tempest workspace register --name tempest_test --path /root/f5-openstack-lbaasv2-driver/

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,7 +1,7 @@
 -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
 -e .
-git+https://github.com/openstack/neutron.git@stable/mitaka
-git+https://github.com/openstack/neutron-lbaas.git@stable/mitaka
+git+https://github.com/openstack/neutron.git@mitaka-eol
+git+https://github.com/openstack/neutron-lbaas.git@mitaka-eol
 git+https://github.com/F5Networks/pytest-symbols.git
 git+https://github.com/F5Networks/f5-openstack-test.git@mitaka
 git+https://github.com/openstack/tempest.git@12.0.0


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #653 

#### What's this change do?
This will fix all the dependencies to stable/mitaka branch by changing it to mitaka-eol


#### Any background context?
I was able to install packages using mitaka-eol tag. I also tried to run the tests in my bbot worker but ran into testenv problems.