### PR TITLE
Multi-provider didn't work, only one agent registered in neutron.

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -103,14 +103,22 @@ class F5DriverV2(object):
         self.plugin.agent_notifiers.update(
             {q_const.AGENT_TYPE_LOADBALANCER: self.agent_rpc})
 
-        registry.subscribe(
-            self.post_fork_callback, resources.PROCESS, events.AFTER_CREATE)
+        registry.subscribe(self._bindRegistryCallback(),
+                           resources.PROCESS,
+                           events.AFTER_CREATE)
 
-    def post_fork_callback(self, resources, event, trigger):
-        LOG.debug("F5DriverV2 received post neutron child fork "
-                  "notification pid(%d) print trigger(%s)" % (
-                      os.getpid(), trigger))
-        self.plugin_rpc.create_rpc_listener()
+    def _bindRegistryCallback(self):
+        # Defines a callback function with name tied to driver env. Need to
+        # enusre unique name, as registry callback manager references callback
+        # functions by name.
+        def post_fork_callback(resources, event, trigger):
+            LOG.debug("F5DriverV2 with env %s received post neutron child "
+                      "fork notification pid(%d) print trigger(%s)" % (
+                          self.env, os.getpid(), trigger))
+            self.plugin_rpc.create_rpc_listener()
+
+        post_fork_callback.__name__ += '_' + str(self.env)
+        return post_fork_callback
 
 
 class LoadBalancerManager(object):

--- a/f5lbaasdriver/v2/bigip/test/test_callback_functions.py
+++ b/f5lbaasdriver/v2/bigip/test/test_callback_functions.py
@@ -1,0 +1,53 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from f5lbaasdriver.v2.bigip.driver_v2 import F5DriverV2
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.agent_rpc.LBaaSv2AgentRPC')
+def test_bind_registry_callback(mock_agent_rpc):
+    """Test creating callback functions for registering RPC events in driver.
+
+    Simulates multiple drivers in differentiated environments, testing
+    that two drivers create two distinct callback functions to register
+    with Neutron callback manager.
+
+    Also, see related functional test,
+    f5_openstack_lbaasv2_driver/test/functional/test_registry_callback.py
+
+    :param mock_agent_rpc: Not used. Needed satisfy creating F5DriverV2.
+    """
+    plugin = mock.MagicMock()
+
+    # create default driver
+    default_driver = F5DriverV2(plugin)
+
+    # create a differentiated environment driver
+    dmz_driver = F5DriverV2(plugin, 'dmz')
+
+    # get callback functions for each
+    default_callback_func = default_driver._bindRegistryCallback()
+    dmz_callback_func = dmz_driver._bindRegistryCallback()
+
+    # two different callback functions created
+    assert default_callback_func != dmz_callback_func
+
+    # callback functions have diffent names
+    assert default_callback_func.__name__ != dmz_callback_func.__name__
+
+    # expected function names
+    assert default_callback_func.__name__ == 'post_fork_callback_None'
+    assert dmz_callback_func.__name__ == 'post_fork_callback_dmz'

--- a/test/functional/test_registry_callback.py
+++ b/test/functional/test_registry_callback.py
@@ -1,0 +1,88 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from neutron.callbacks import events
+from neutron.callbacks import registry
+from neutron.callbacks import resources
+
+from f5lbaasdriver.v2.bigip.driver_v2 import F5DriverV2
+
+
+@mock.patch('f5lbaasdriver.v2.bigip.agent_rpc.LBaaSv2AgentRPC')
+def test_neutron_registry_callback(mock_agent_rpc):
+    """Test callback functions used for registering for RPC events in driver.
+
+    Creates two drivers to simulate a differentiated environment
+    deployment, then tests that each driver registers different functions
+    to receive notification from Neutron after subscribing for events, and
+    that the functions are called by the Neutron callback manager.
+
+    Also, see related unit test,
+    f5lbaasdriver/v2/bigip/test/test_bind_registry_callback.py
+
+    :param mock_agent_rpc: Not used. Mock needed to create F5DriverV2.
+    """
+    plugin = mock.MagicMock()
+
+    # start with empty Neutron RPC callback registry
+    registry.clear()
+
+    # create default driver
+    default_driver = F5DriverV2(plugin)
+    default_driver.plugin_rpc = mock.MagicMock()
+
+    # create a differentiated environment driver
+    dmz_driver = F5DriverV2(plugin, 'dmz')
+    dmz_driver.plugin_rpc = mock.MagicMock()
+
+    default_callback_func = default_driver._bindRegistryCallback()
+    dmz_callback_func = dmz_driver._bindRegistryCallback()
+
+    # two different callback functions created
+    assert default_callback_func != dmz_callback_func
+
+    # registry holds two callbacks
+    callback_mgr = registry._get_callback_manager()
+    assert len(
+        callback_mgr._callbacks[resources.PROCESS][events.AFTER_CREATE]) == 2
+
+    # both callbacks are in registry
+    callbacks = callback_mgr._callbacks[resources.PROCESS][events.AFTER_CREATE]
+    callback_iter = iter(callbacks)
+
+    callback_name = next(callback_iter).split('.')[-1]
+    assert callback_name == default_callback_func.__name__
+
+    callback_name = next(callback_iter).split('.')[-1]
+    assert callback_name == dmz_callback_func.__name__
+
+    # callbacks can be called back
+    with mock.patch('f5lbaasdriver.v2.bigip.driver_v2.LOG') as mock_log:
+        # invoke callbacks from callback manager
+        callback_mgr.notify(
+            resources.PROCESS, events.AFTER_CREATE, mock.MagicMock())
+
+        # create_rpc_listener called
+        assert default_driver.plugin_rpc.create_rpc_listener.called
+        assert dmz_driver.plugin_rpc.create_rpc_listener.called
+
+        # debug messages logged
+        log_iter = iter(mock_log.debug.call_args_list)
+        args, kwargs = log_iter.next()
+        assert str(args[0]).startswith("F5DriverV2 with env None received")
+
+        args, kwargs = log_iter.next()
+        assert str(args[0]).startswith("F5DriverV2 with env dmz received")


### PR DESCRIPTION

@ssorenso 
#### What issues does this address?
#642 Multi-provider didn't work, only one agent registered in neutron. 

#### What's this change do?
Multiple drivers register for Neutron  callbacks using the same
function name. Because the same name is used for all drivers, RPC
consumers are only created for one topic (i.e., one agent).

Each differentiated environment driver needs to register
a function with the Neutron registry callback manager. The registry
callback manager references callback functions by name, so that
each registration with the same name overwrites the last. Added
a function to the driver which creates a callback function with
a name using its env string, ensuring that drivers with different
env will be able to register with the registry callback manager.

#### Where should the reviewer start?
driver_v2.py

#### Any background context?
No.