### PR TITLE
Modify test runner code to be compatible with bdo test infrastructure.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,7 @@ pipeline {
                     ssh-add
 
                     # - run systests
-                    target_name=tempest_$(echo $JOB_BASE_NAME | sed s/-/_/g)
-                    make -C systest $target_name
+                    make -C systest zancas_test_new_container_11.6.1_undercloud_vxlan
 
                     # - record results
                     systest/scripts/record_results.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,8 @@ pipeline {
                     ssh-add
 
                     # - run systests
-                    make -C systest zancas_test_new_container_11.6.1_undercloud_vxlan
+                    target_name=tempest_$(echo $JOB_BASE_NAME | sed s/-/_/g)
+                    make -C systest $target_name
 
                     # - record results
                     systest/scripts/record_results.sh

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -259,7 +259,7 @@ tempest_11.6.0_undercloud_vlan:
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.1 undercloud VE deployment
-zancas_test_new_container_11.6.1_undercloud_vxlan:
+tempest_11.6.1_undercloud_vxlan:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -103,15 +103,15 @@ export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 microservice_setup_tlc_session:
 	@echo "setting up TLC session..."
-	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:
 	@echo "injecting TLC symbol and openstack IDs into 'tempest' conf files..."
-	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 run_neutron_lbaas:
 	@echo "running tests extracted from 'neutron_lbaas' project..."
-	cd scripts && ./disallow_dangerous_vars.sh && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
 
 run_agent_transfers:
 	@echo "running tests extracted from 'f5-openstack-agent' project..."

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -39,7 +39,7 @@ CHANGESOURCE := f5-openstack-lbaasv2-driver
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 export MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
 export PROJROOTDIR := $(abspath $(MAKEFILE_DIR))/../
-export TEST_DIR := $(abspath $(MAKEFILE_DIR))/../test
+export TEST_DIR := $(abspath $(MAKEFILE_DIR))../test
 
 # Test exclude directory
 export EXCLUDE_DIR := $(MAKEFILE_DIR)/exclude/
@@ -49,7 +49,7 @@ export DEVTEST_DIR := /home/jenkins/dev-test
 export DEVTEST_REPO := git@gitlab.pdbld.f5net.com:openstack/dev-test.git
 
 # tempest (OpenStack tempest test library)
-export TEMPEST_DIR := /home/jenkins/tempest
+export TEMPEST_DIR := $(PROJROOTDIR)tempest
 export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 
 # neutron-lbaas (OpenStack Neutron LBaaS repo for the test cases to run)
@@ -175,18 +175,6 @@ tempest_11.6.1_overcloud_vxlan:
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
 	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
 	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-# Tempest Tests for 12.1.1 undercloud VE deployment
-tempest_12.1.1_undercloud_vxlan:
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
 	$(MAKE) -C . run_tests
 

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -38,6 +38,7 @@ export TIMESTAMP   # Only eval TIMESTAMP in the top make.
 CHANGESOURCE := f5-openstack-lbaasv2-driver
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 export MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
+export PROJROOTDIR := $(abspath $(MAKEFILE_DIR))/../
 export TEST_DIR := $(abspath $(MAKEFILE_DIR))/../test
 
 # Test exclude directory
@@ -270,7 +271,8 @@ tempest_11.6.0_undercloud_vlan:
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.1 undercloud VE deployment
-tempest_11.6.1_undercloud_vxlan:
+zancas_test_new_container_11.6.1_undercloud_vxlan:
+	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\
 	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\

--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -35,14 +35,11 @@ EXTRA_VARS="${EXTRA_VARS} neutron_lbaas_init_location=${NEUTRON_INIT_LOC} restar
 EXTRA_VARS="${EXTRA_VARS} f5_global_routed_mode=${GLOBAL_ROUTED_MODE} bigip_netloc=${BIGIP_IP} agent_service_name=f5-openstack-agent.service"
 EXTRA_VARS="${EXTRA_VARS} use_barbican_cert_manager=True neutron_lbaas_shim_install_dest=/usr/lib/python2.7/site-packages/neutron_lbaas/drivers/f5"
 
-echo [hosts] > ansible_conf.ini
-echo "${OS_CONTROLLER_IP} ansible_ssh_common_args='-o StrictHostKeyChecking=no' host_key_checking=False ansible_connection=ssh ansible_ssh_user=testlab ansible_ssh_private_key_file=/root/id_rsa" >> ansible_conf.ini
+sudo -E bash -c "echo [hosts] > /home/jenkins/zancas_tmp/ansible_conf.ini"
+sudo -E bash -c "echo \"${OS_CONTROLLER_IP} ansible_ssh_common_args='-o StrictHostKeyChecking=no' host_key_checking=False ansible_connection=ssh ansible_ssh_user=testlab ansible_ssh_private_key_file=/root/id_rsa\" >> /home/jenkins/zancas_tmp/ansible_conf.ini"
 
 sudo -E docker pull docker-registry.pdbld.f5net.com/f5-openstack/ansiblemicroservice
 sudo -E docker run \
 --volumes-from `hostname | xargs` \
-docker-registry.pdbld.f5net.com/f5-openstack/ansiblemicroservice:48792741500c \
-ansible-playbook \
---extra-vars "${EXTRA_VARS}" \
---inventory-file=/home/jenkins/f5-openstack-lbaasv2-driver/systest/scripts/ansible_conf.ini \
-/f5-openstack-ansible/playbooks/agent_driver_deploy.yaml
+docker-registry.pdbld.f5net.com/f5-openstack/ansiblemicroservice:latest \
+--extra-vars "${EXTRA_VARS}"

--- a/systest/scripts/configure_test_infra.sh
+++ b/systest/scripts/configure_test_infra.sh
@@ -18,11 +18,11 @@
 set -ex
 
 # Copy over our tox.ini
-mkdir -p ${TEMPEST_CONFIG_DIR}
-cp -f /home/jenkins/f5-openstack-lbaasv2-driver/systest/scripts/conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
+sudo -E mkdir -p ${TEMPEST_CONFIG_DIR}
+sudo -E cp -f ${PROJROOTDIR}/systest/scripts/conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
 # Copy over our default tempest files
-cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
-cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
+sudo -E cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
+sudo -E cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
 
 # Find the values for tempest.conf and substitute them
 OS_CONTROLLER_IP=`/tools/bin/tlc --sid ${TEST_SESSION} symbols \
@@ -39,15 +39,10 @@ OS_CIRROS_IMAGE_ID=`${ssh_cmd} "source ~/keystonerc_testlab && glance image-list
     | grep ${TEST_CIRROS_IMAGE} \
     | awk '{print $2}'`
 
-cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig \
-  | sed "s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/" \
-  | sed "s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/" \
-  | sed "s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/" \
-  | sed "s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/" \
-  > ${TEMPEST_CONFIG_DIR}/tempest.conf
+sudo -E bash -c "cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig | sed \"s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/\" | sed \"s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/\" | sed \"s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/\" | sed \"s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/\" > ${TEMPEST_CONFIG_DIR}/tempest.conf"
 
 # Add tempest configuration options for running tempest tests in f5lbaasv2driver
 BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
-echo "[f5_lbaasv2_driver]" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
-echo "icontrol_hostname = ${BIGIP_IP}" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
-echo "transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/" >> ${TEMPEST_CONFIG_DIR}/tempest.conf
+sudo -E bash -c "echo \"[f5_lbaasv2_driver]\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+sudo -E bash -c "echo \"icontrol_hostname = ${BIGIP_IP}\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+sudo -E bash -c "echo \"transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"

--- a/systest/scripts/disallow_dangerous_vars.sh
+++ b/systest/scripts/disallow_dangerous_vars.sh
@@ -24,8 +24,8 @@ if [ "${DEVTEST_DIR}" != "/home/jenkins/dev-test" ];then
     echo DEVTEST_DIR "${DEVTEST_DIR}" not allowed!
     exit 31
 fi
-if [ "${TEMPEST_DIR}" != "/home/jenkins/tempest" ];then
-    echo TEMPEST_DIR "${TEMPEST_DIR}" not allowed!
+if [ "${TEMPEST_DIR}" == "" ];then
+    echo Empty value for TEMPEST_DIR not allowed!
     exit 31
 fi
 if [ "${NEUTRON_LBAAS_DIR}" != "/home/jenkins/neutron-lbaas" ];then

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -20,8 +20,8 @@ set -x
 # Create .pytest.rootdir files at the root of the driver and neutron-lbaas
 # respositories to make the results suite names be rooted at the top-level
 # of the respective test repository
-touch ${MAKEFILE_DIR}/../f5lbaasdriver/test/tempest/tests/.pytest.rootdir
-touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
+sudo -E touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
+sudo -E touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 
 
 # The following tox commands will fail, if the ${EXCLUDE_FILE}
@@ -30,26 +30,26 @@ touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${MAKEFILE_DIR}/../
 
-tox --sitepackages -e tempest -c tox.ini -- \
+sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lravv \
   --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${DRIVER_TEMPEST_SESSION}
+  --autolog-session ${DRIVER_TEMPEST_SESSION}"
 
 cd ${NEUTRON_LBAAS_DIR}
 
 # LBaaSv2 API test cases with F5 tox.ini file
-tox -e apiv2 -c f5.tox.ini --sitepackages -- \
+sudo -E bash -c "tox -e apiv2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${API_SESSION}
+  --autolog-session ${API_SESSION}"
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
-tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
+sudo -E bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${SCENARIO_SESSION}
+  --autolog-session ${SCENARIO_SESSION}"
 
 exit 0

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -30,7 +30,11 @@ sudo -E touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdi
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${PROJROOTDIR}
 
-sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- -lravv"
+sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- \
+  --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
+  -lvv \
+  --autolog-outputdir ${RESULTS_DIR} \
+  --autolog-session ${API_SESSION}"
 
 cd ${NEUTRON_LBAAS_DIR}
 

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-set -x
+set -ex
 
 # Create .pytest.rootdir files at the root of the driver and neutron-lbaas
 # respositories to make the results suite names be rooted at the top-level
@@ -28,13 +28,9 @@ sudo -E touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdi
 # doesn't exist in the ${EXCLUDE_DIR}.
 
 # Navigate to the root of the repo, where the tox.ini file is found
-cd ${MAKEFILE_DIR}/../
+cd ${PROJROOTDIR}
 
-sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- \
-  --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
-  -lravv \
-  --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${DRIVER_TEMPEST_SESSION}"
+sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- -lravv"
 
 cd ${NEUTRON_LBAAS_DIR}
 

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-set -ex
+set -x
 
 # Create .pytest.rootdir files at the root of the driver and neutron-lbaas
 # respositories to make the results suite names be rooted at the top-level

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ basepython=python2.7
 [testenv]
 whitelist_externals=/usr/local/bin/py.test
 install_command=/usr/local/bin/pip install {opts} {packages}
+list_dependencies_command=/usr/local/bin/pip freeze
 
 [testenv:tempest]
 passenv = TEMPEST_CONFIG_DIR

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-basepython = python2.7
-whitelist_externals = /usr/local/bin/py.test
-use_develop = True
-install_command = /usr/local/bin/pip {opts} {packages}
+basepython=python2.7
+
+[testenv]
+whitelist_externals=/usr/local/bin/py.test
+install_command=/usr/local/bin/pip install {opts} {packages}
 
 [testenv:tempest]
 passenv = TEMPEST_CONFIG_DIR

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ basepython = python2.7
 passenv = TEMPEST_CONFIG_DIR
 setenv =
   OS_TEST_PATH={toxinidir}/f5lbaasdriver/test/tempest/tests
-deps =
-  pytest
 changedir = f5lbaasdriver/test/tempest/tests/
 commands = py.test {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 basepython = python2.7
 whitelist_externals = /usr/local/bin/py.test
+use_develop = True
+install_command = /usr/local/bin/pip {opts} {packages}
 
 [testenv:tempest]
 passenv = TEMPEST_CONFIG_DIR

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 basepython = python2.7
+whitelist_externals = /usr/local/bin/py.test
 
 [testenv:tempest]
 passenv = TEMPEST_CONFIG_DIR


### PR DESCRIPTION
@ssorenso each commit contains a terse summary of the relevant change.

There were 2 interdependent issues blocking successful integration with the nightly build system:

(1)   file system names.
    The code under test is mounted into the testrunner, at testrunner run time, under a job-specific name.   This means that previously hard-coded values in the test infrastructure needed to be properly abstracted.
(2)  Permissions:
    More difficult was the problem of allowing the internal testrunner "jenkins" user permission to write to shared volumes, and ensuring that executables were not referenced from the shared volumes.

These changes were tested by running a custom jenkins job against a branch in my fork.