### PR TITLE
Fix docs deploy failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ deploy:
       python: 2.7
     skip_cleanup: true
   # deploy docs to s3
-  # if this is not a tagged release, the docs will deploy to /products/openstack/$TRAVIS_BRANCH/lbaasv2-driver/
+  # if this is not a tagged release, the docs will deploy to /products/openstack/lbaasv2-driver/$TRAVIS_BRANCH/
   - provider: script
     skip_cleanup: true
     on:
@@ -71,8 +71,8 @@ deploy:
       repo: F5Networks/f5-openstack-lbaasv2-driver
       condition: $TRAVIS_TAG = ""
     script:
-    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/$TRAVIS_BRANCH lbaasv2-driver
-   # if this is a tagged release, the docs go to /products/openstack/$TRAVIS_BRANCH/lbaasv2-driver/vX.Y
+    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/lbaasv2-driver $TRAVIS_BRANCH
+   # if this is a tagged release, the docs go to /products/openstack/lbaasv2-driver/$TRAVIS_BRANCH/vX.Y
   - provider: script
     skip_cleanup: true
     env:
@@ -81,4 +81,4 @@ deploy:
       tags: true
       repo: F5Networks/f5-openstack-lbaasv2-driver
     script:
-    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/$TRAVIS_BRANCH/lbaasv2-driver $RELEASE_TAG
+    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/lbaasv2-driver/$TRAVIS_BRANCH $RELEASE_TAG


### PR DESCRIPTION
@pjbreaux 

#### What issues does this address?
N/A

#### What's this change do?
Fixes travis build failure due to docs deployment failure (https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver/builds/256205331)

#### Where should the reviewer start?

#### Any background context?
First, the containthedocs image build that incorporated changes to support the OpenStack products failed, so the product path was denied by the containthedocs product-deploy script.
Then, the product path provided in the travis deploy script didn't match the policy set up in the AWS s3 bucket hosting clouddocs, so the sync was denied. 
Both issues have been addressed.

This commit was also cherry-picked to the mitaka branch, so it's present in PR #676. 
