### PR TITLE
Fixes #686

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ deploy:
   - provider: script
     skip_cleanup: true
     on:
-      all_branches: true
+      branch: liberty
       repo: F5Networks/f5-openstack-lbaasv2-driver
       condition: $TRAVIS_TAG = ""
     script:

--- a/docs/scripts/test-docs.sh
+++ b/docs/scripts/test-docs.sh
@@ -3,17 +3,12 @@
 set -x
 set -e
 
-#echo "Downloading project dependencies"
-#pip install --user -e . \
-#            git+https://github.com/openstack/neutron.git@liberty-eol \
-#            git+https://github.com/openstack/neutron-lbaas.git@liberty-eol
-
-#curl -O -L https://github.com/F5Networks/neutron-lbaas/releases/download/v9.1.0/f5.tgz
-#tar xvf f5.tgz -C /venv/lib/python2.7/dist-packages/neutron_lbaas/drivers/
-
 echo "Building docs and Checking links with Sphinx"
 make -C docs html
-make -C docs linkcheck
 
 echo "Checking grammar and style"
 write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches
+
+set +e
+echo "Checking links"
+make -C docs linkcheck


### PR DESCRIPTION
@pjbreaux 

#### What issues does this address?
Fixes #686 

#### What's this change do?
#. Changes the deploy conditions for documentation from `all_branches` to specific branch.
#. Makes the linkcheck in the docs test exit with a warning.

#### Where should the reviewer start?

#### Any background context?
I've updated the image we use to build/test/deploy the docs so the build won't fail when we're on a release branch (e.g., jodie-liberty-release). 
