### PR TITLE
Update docs tests

### DIFF
--- a/docs/scripts/test-docs.sh
+++ b/docs/scripts/test-docs.sh
@@ -1,14 +1,40 @@
 #!/usr/bin/env bash
 
+html="make -C docs html"
+linkcheck=$(make -C docs linkcheck | grep 'broken')
+grammar="write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches"
+
+if [[ $TRAVIS != "" ]]; then
+   OUTPUT=$TRAVIS_BUILD_DIR/_build/linkcheck/output.txt
+else
+   OUTPUT=docs/_build/linkcheck/output.txt
+fi
+
+goodjob() {
+  printf "%s\n" "$*" >&2
+
+}
+
+echo "Installing project dependencies"
+pip install --user -r requirements.docs.txt
+
 set -x
 set -e
 
-echo "Building docs and Checking links with Sphinx"
-make -C docs html
+echo "Building docs with Sphinx"
+$html
 
 echo "Checking grammar and style"
-write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches
+$grammar
+
+[[ $grammar = "" ]] || goodjob "CONGRATULATIONS! You are a grammar wizard."
 
 set +e
+set +x
 echo "Checking links"
-make -C docs linkcheck
+if [[ $linkcheck == "" ]]; then
+   echo "Linkcheck succeeded"
+else
+   echo "WARNING: linkcheck failed. Fix the following broken links:"
+   grep 'broken' $OUTPUT
+fi


### PR DESCRIPTION
@pjbreaux @szakeri 

#### What issues does this address?
Fixes #702 - adapt docs tests so linkcheck doesn't fail


#### What's this change do?
This change fixes an issue with the link checker in the docs tests. The lickcheck can cause the build to fail when creating a new release because the build artifacts referenced in some links don't exist yet.

#### Where should the reviewer start?

#### Any background context?
