### PR TITLE
Fixing test_member_subnets test. Selfip check was failing.

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/test_member_subnets.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_member_subnets.py
@@ -104,7 +104,7 @@ class MemberSubnetTestJSON(base.F5BaseAdminTestCase):
         self.addCleanup(self._delete_member, pool.get('id'), member2.get('id'))
         assert self._has_selfip_for_member(member2)
 
-        # delete first and check second self IP
+        # delete first member and check second self IP
         self._delete_member(pool.get('id'), member1.get('id'))
         assert self._has_selfip_for_member(member2)
 
@@ -126,7 +126,7 @@ class MemberSubnetTestJSON(base.F5BaseAdminTestCase):
 
         selfips = self.bigip.tm.net.selfips.get_collection()
         for selfip in selfips:
-            selfip_address, selfip_rd = self._split_address(selfip.address)
+            selfip_address = self._split_address(selfip.address)
             network = ipaddress.ip_network(selfip_address, False)
             if member_address in network:
                 return True

--- a/f5lbaasdriver/test/tempest/tests/api/test_member_subnets.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_member_subnets.py
@@ -91,7 +91,6 @@ class MemberSubnetTestJSON(base.F5BaseAdminTestCase):
                          'protocol_port': 8080,
                          'subnet_id': self.subnet2['id']}
         member1 = self._create_member(**member_kwargs)
-        self.addCleanup(self._delete_member, pool.get('id'), member1.get('id'))
         assert self._has_selfip_for_member(member1)
 
         # create second member on subnet3


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #707 

#### What's this change do?
Fixed the expected return value from the function call, so now it only
looks for selfip_address.

#### Where should the reviewer start?

#### Any background context?
The api test api.test_member_subnets.MemberSubnetTestJSON fails
consistently with a ValueError. It appears as though the selfip address
and route domain are expected back from a function call, but the route
domain is not used. The function call also does not return a tuple, but
only a single value.

The test now passes. Ran it on my local mitaka stack.
