### PR TITLE
Physical BIG-IPs supporting HPB should create their own ports on netw…

### DIFF
--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -54,6 +54,7 @@ class DisconnectedService(object):
                                            filter_dynamic=None)
 
         for segment in segments:
+            LOG.debug("F5 disconnected service check segment: %s" % segment)
             if ((network_segment_physical_network ==
                  segment['physical_network']) and
                 (segment['network_type'].lower() in

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -714,3 +714,58 @@ class LBaaSv2PluginCallbacksRPC(object):
                 except Exception as exc:
                     LOG.error('could not remove allowed address pair: %s'
                               % exc.message)
+
+    @log_helpers.log_method_call
+    def create_port_on_network(self, context, network_id=None,
+                               mac_address=None, name=None, host=None):
+        """Create a port on a network."""
+        ports = []
+        if network_id and name:
+            filters = {'name': [name]}
+            ports = self.driver.plugin.db._core_plugin.get_ports(
+                context,
+                filters=filters
+            )
+
+        if not ports:
+            with context.session.begin(subtransactions=True):
+                network = self.driver.plugin.db._core_plugin.get_network(
+                    context,
+                    network_id
+                )
+
+                if not mac_address:
+                    mac_address = attributes.ATTR_NOT_SPECIFIED
+                if not host:
+                    host = ''
+                if not name:
+                    name = ''
+
+                device_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, str(host)))
+                port_data = {
+                    'tenant_id': network['tenant_id'],
+                    'name': name,
+                    'network_id': network_id,
+                    'mac_address': mac_address,
+                    'admin_state_up': True,
+                    'device_id': device_id,
+                    'device_owner': 'network:f5lbaasv2',
+                    'status': neutron_const.PORT_STATUS_ACTIVE,
+                    'fixed_ips': attributes.ATTR_NOT_SPECIFIED
+                }
+                port_data[portbindings.HOST_ID] = host
+                port_data[portbindings.VIF_TYPE] = 'f5'
+                extended_attrs = portbindings.EXTENDED_ATTRIBUTES_2_0['ports']
+                if 'binding:capabilities' in extended_attrs:
+                    port_data['binding:capabilities'] = {'port_filter': False}
+                port = self.driver.plugin.db._core_plugin.create_port(
+                    context, {'port': port_data})
+                # Because ML2 marks ports DOWN by default on creation
+                update_data = {
+                    'status': neutron_const.PORT_STATUS_ACTIVE
+                }
+                self.driver.plugin.db._core_plugin.update_port(
+                    context, port['id'], {'port': update_data})
+                return port
+        else:
+            return ports[0]

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -175,6 +175,7 @@ class LBaaSv2ServiceBuilder(object):
             member_dict['port'] = ports[0]
             self._populate_member_network(context, member_dict, network)
         elif len(ports) == 0:
+            self._populate_member_network(context, member_dict, network)
             LOG.warning("Lbaas member %s has no associated neutron port"
                         % member.address)
         elif len(ports) > 1:


### PR DESCRIPTION
…ork.

Issues:
Fixes #665

Problem:
When a physical BIG-IP is connected to a SDN which supports HPB,
the presence of pool members which are mapped back from their subnet_id
to a Neutron network, should cause the BIG-IP to assure if an existing
port already exists and if not create a port on the appropriate Neutron
network. The port creation thus signals the SDN that segment connectivity
is required for the BIG-iP to complete the LBaaS request. There must be
an agreed upon way in the port attributes to signal the SDN that it is
the BIG-IP which requires a segment connection. With Cisco ACI the host_id
attribute on the port needs to be specified as the LBaaS agent_id.

This applies only to network connectivity required for pool members as
the load balancer side port is automatically created by the community
LBaaS plugin.

Analysis:
This commit extends the driver to provide a create_port_on_network()
callback.  It also calls _populate_member_network() in the case where
a port does not exist for the member to ensure that a member network
segment definition exists for that network.

Tests:
Manual

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
