### PR TITLE
Revert "make the nightly test run start by chowning"

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -13,6 +13,18 @@
 # limitations under the License.
 #
 
+# Inform make that targets are NOT files.
+.PHONY: all functest \
+tempest_13.0.0_undercloud_vxlan tempest_11.5.4_overcloud \
+tempest_11.6.0_overcloud tempest_11.6.1_overcloud \
+tempest_12.1.1_undercloud_vxlan tempest_11.5.4_undercloud_vxlan \
+tempest_11.5.4_undercloud_gre tempest_11.5.4_undercloud_vlan \
+tempest_11.6.0_undercloud_vxlan tempest_11.6.0_undercloud_gre \
+tempest_11.6.0_undercloud_vlan tempest_11.6.1_undercloud_vxlan \
+tempest_11.6.1_undercloud_gre tempest_11.6.1_undercloud_vlan \
+tempest_12.1.1_undercloud_vxlan tempest_12.1.1_undercloud_gre \
+tempest_12.1.1_undercloud_vlan 
+
 # Fixing branch to that specified in the public fork. This is necessary for build on PRs.
 export BRANCH := mitaka
 # The branch may contain the text 'stable/' before the OpenStack release name
@@ -90,7 +102,6 @@ export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 microservice_setup_tlc_session:
 	@echo "setting up TLC session..."
-	sudo -E chown -Rf jenkins:jenkins $(PROJROOTDIR) && \
 	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:

--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -34,8 +34,8 @@ EXTRA_VARS="${EXTRA_VARS} neutron_lbaas_init_location=${NEUTRON_INIT_LOC} restar
 EXTRA_VARS="${EXTRA_VARS} f5_global_routed_mode=${GLOBAL_ROUTED_MODE} bigip_netloc=${BIGIP_IP} agent_service_name=f5-openstack-agent.service"
 EXTRA_VARS="${EXTRA_VARS} use_barbican_cert_manager=True neutron_lbaas_shim_install_dest=/usr/lib/python2.7/site-packages/neutron_lbaas/drivers/f5"
 
-bash -c "echo [hosts] > /home/jenkins/zancas_tmp/ansible_conf.ini"
-bash -c "echo \"${OS_CONTROLLER_IP} ansible_ssh_common_args='-o StrictHostKeyChecking=no' host_key_checking=False ansible_connection=ssh ansible_ssh_user=testlab ansible_ssh_private_key_file=/root/id_rsa\" >> /home/jenkins/zancas_tmp/ansible_conf.ini"
+sudo -E bash -c "echo [hosts] > /home/jenkins/zancas_tmp/ansible_conf.ini"
+sudo -E bash -c "echo \"${OS_CONTROLLER_IP} ansible_ssh_common_args='-o StrictHostKeyChecking=no' host_key_checking=False ansible_connection=ssh ansible_ssh_user=testlab ansible_ssh_private_key_file=/root/id_rsa\" >> /home/jenkins/zancas_tmp/ansible_conf.ini"
 
 sudo -E docker pull docker-registry.pdbld.f5net.com/f5-openstack/ansiblemicroservice
 sudo -E docker run \

--- a/systest/scripts/configure_test_infra.sh
+++ b/systest/scripts/configure_test_infra.sh
@@ -18,11 +18,11 @@
 set -ex
 
 # Copy over our tox.ini
-mkdir -p ${TEMPEST_CONFIG_DIR}
-cp -f ${PROJROOTDIR}/systest/scripts/conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
+sudo -E mkdir -p ${TEMPEST_CONFIG_DIR}
+sudo -E cp -f ${PROJROOTDIR}/systest/scripts/conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
 # Copy over our default tempest files
-cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
-cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
+sudo -E cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
+sudo -E cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
 
 # Find the values for tempest.conf and substitute them
 OS_CONTROLLER_IP=`/tools/bin/tlc --sid ${TEST_SESSION} symbols \
@@ -39,10 +39,10 @@ OS_CIRROS_IMAGE_ID=`${ssh_cmd} "source ~/keystonerc_testlab && glance image-list
     | grep ${TEST_CIRROS_IMAGE} \
     | awk '{print $2}'`
 
-bash -c "cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig | sed \"s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/\" | sed \"s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/\" | sed \"s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/\" | sed \"s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/\" > ${TEMPEST_CONFIG_DIR}/tempest.conf"
+sudo -E bash -c "cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig | sed \"s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/\" | sed \"s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/\" | sed \"s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/\" | sed \"s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/\" > ${TEMPEST_CONFIG_DIR}/tempest.conf"
 
 # Add tempest configuration options for running tempest tests in f5lbaasv2driver
 BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
-bash -c "echo \"[f5_lbaasv2_driver]\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
-bash -c "echo \"icontrol_hostname = ${BIGIP_IP}\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
-bash -c "echo \"transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+sudo -E bash -c "echo \"[f5_lbaasv2_driver]\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+sudo -E bash -c "echo \"icontrol_hostname = ${BIGIP_IP}\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+sudo -E bash -c "echo \"transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -20,8 +20,8 @@ set -x
 # Create .pytest.rootdir files at the root of the driver and neutron-lbaas
 # respositories to make the results suite names be rooted at the top-level
 # of the respective test repository
-touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
-touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
+sudo -E touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
+sudo -E touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 
 
 # The following tox commands will fail, if the ${EXCLUDE_FILE}
@@ -30,7 +30,7 @@ touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${PROJROOTDIR}
 
-bash -c "tox --sitepackages -e tempest -c tox.ini -- \
+sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
@@ -39,14 +39,14 @@ bash -c "tox --sitepackages -e tempest -c tox.ini -- \
 cd ${NEUTRON_LBAAS_DIR}
 
 # LBaaSv2 API test cases with F5 tox.ini file
-bash -c "tox -e apiv2 -c f5.tox.ini --sitepackages -- \
+sudo -E bash -c "tox -e apiv2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${API_SESSION}"
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
-bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
+sudo -E bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \

--- a/systest/scripts/run_smoke_tests.sh
+++ b/systest/scripts/run_smoke_tests.sh
@@ -24,13 +24,13 @@ cd ${NEUTRON_LBAAS_DIR}
 # doesn't exist in the ${EXCLUDE_DIR}.
 
 # Create .pytest.rootdir file at root of the neutron-lbaas repository directory
-touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
+sudo -E touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
 # The scenario tests are the current set of smoke tests. This is sufficient
 # for now, but we will be able to amend this set as needed.
 # In the near future, we should add our scenario tests as well.
-bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
+sudo -E bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \


### PR DESCRIPTION
Reverts F5Networks/f5-openstack-lbaasv2-driver#711

I don't want to iterate on this problem while having a broken nightly build. I'm reverting this change, so we can test the correct solution at our leisure.