### PR TITLE
test_pool_sync.py test fixups needed for assuring pool and member are created after manual deletion

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/test_pool_sync.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_pool_sync.py
@@ -57,10 +57,6 @@ class PoolSyncTestJSON(base.F5BaseTestCase):
         cls.create_pool_kwargs = {'loadbalancer_id': cls.load_balancer_id,
                                   'protocol': "HTTP",
                                   'lb_algorithm': "ROUND_ROBIN"}
-        cls.pool = (
-            cls._create_pool(**cls.create_pool_kwargs))
-        cls.pool_id = cls.pool['id']
-
         cls.partition = 'Project_' + cls.load_balancer.get('tenant_id')
 
         # Get a client to emulate the agent's behavior.
@@ -79,19 +75,25 @@ class PoolSyncTestJSON(base.F5BaseTestCase):
         name = 'Project_' + pool_id
         return self.bigip_client.delete_pool(name, partition)
 
-    def _member_exists(self, pool_id, member_id, partition):
+    def _members_exists(self, pool_id, partition):
+        '''Expects only one member to exist in pool'''
         pool_name = 'Project_' + pool_id
-        member_name = 'Project_' + member_id
-        return self.bigip_client.member_exists(
-            pool_name, member_name, partition)
+        members = self.bigip_client.get_members(pool_name, partition)
+        if len(list(members)) > 0:
+            return True
+        return False
 
-    def _remove_member(self, pool_id, member_id, partition):
+    def _remove_members(self, pool_id, partition):
         pool_name = 'Project_' + pool_id
-        member_name = 'Project_' + member_id
-        self.bigip_client.delete_member(pool_name, member_name, partition)
+        self.bigip_client.delete_members(pool_name, partition)
 
     @test.attr(type='smoke')
     def test_pool_active_sync(self):
+        self.pool = (
+            self._create_pool(**self.create_pool_kwargs))
+        self.pool_id = self.pool['id']
+        self.addCleanup(self._delete_pool, self.pool_id)
+
         # verify pool exists
         assert self._pool_exists(self.pool_id, self.partition)
 
@@ -105,21 +107,23 @@ class PoolSyncTestJSON(base.F5BaseTestCase):
         # verify pool exists
         assert self._pool_exists(self.pool_id, self.partition)
 
-        self._delete_pool(self.pool['id'])
-
     @test.attr(type='smoke')
     def test_pool_member_active_sync(self):
+        self.pool = (
+            self._create_pool(**self.create_pool_kwargs))
+        self.pool_id = self.pool['id']
+        self.addCleanup(self._delete_pool, self.pool_id)
+
         allocation_pool = self.subnet['allocation_pools'][0]
         member_kwargs = {
             'pool_id': self.pool_id,
             'address': allocation_pool['start'],
             'protocol_port': 8080,
             'subnet_id': self.subnet['id']}
-        member = self._create_member(**member_kwargs)
-        self.addCleanup(self._delete_member, self.pool_id, member.get('id'))
+        self._create_member(**member_kwargs)
 
         # delete member directly on BIG-IP
-        self._remove_member(self.pool_id, member.get('id'), self.partition)
+        self._remove_members(self.pool_id, self.partition)
         # delete pool directly on BIG-IP
         self._remove_pool(self.pool_id, self.partition)
 
@@ -128,6 +132,5 @@ class PoolSyncTestJSON(base.F5BaseTestCase):
         self._update_listener(self.listener['id'], **update_kwargs)
 
         # verify pool and member exists
-        assert self._member_exists(
-            self.pool_id, member.get('id'), self.partition)
+        assert self._members_exists(self.pool_id, self.partition)
         assert self._pool_exists(self.pool_id, self.partition)


### PR DESCRIPTION
@szakeri 
#### What issues does this address?
Fixes #714 

#### What's this change do?
Updated the expectations of the tests in this module to create the pool
and member in the tests, instead of at setup, that way we have greater
control of the create/delete operations in the tests.

#### Where should the reviewer start?

#### Any background context?
In the tests at api/test_pool_sync.py, we are checking that manual
deletion (out-of-band of the agent and neutron lbaas) will be rectified
by the agent when it performs a periodic resync or if the service object
where the pool and/or member live is updated after the manual deletion.
These tests need some fixups to get them green.

Ran the api tempest tests in the driver.

```
==================================================== test session starts ====================================================
platform linux2 -- Python 2.7.12, pytest-3.2.0, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python
cachedir: ../../../../.cache
pytest-autolog: outputdir is /home/jenkins/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_mitaka-tempest_12.1.1_undercloud_vxlan/api_eb00fdc_20170802-233031
pytest-autolog: trace is disabled
rootdir: /home/jenkins/f5-openstack-lbaasv2-driver, inifile:
plugins: f5-sdk-2.3.3, f5-openstack-test-0.2.0, autolog-1.1.0, meta-0.1.1, symbols-0.1.0a3
collected 33 items
pytest-meta: discarded 0 items

api/test_esd.py::ESDTestJSON::test_create_esd PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_pool_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_ends_with PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_many_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_multi_policy_multi_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_three_rules PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_policy_redirect_url_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_file_type_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_not_file_type PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_no_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_two_policies PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_all_rules PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_policy PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_reorder_policies PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_with_tenant_id_field_for_admin PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_without_tenant_id PASSED
api/test_member_status.py::MemberStatusTestJSON::test_disabled <- ../../../usr/local/lib/python2.7/dist-packages/tempest/lib/decorators.py SKIPPED
api/test_member_status.py::MemberStatusTestJSON::test_no_monitor PASSED
api/test_member_status.py::MemberStatusTestJSON::test_offline PASSED
api/test_member_status.py::MemberStatusTestJSON::test_online PASSED
api/test_member_subnets.py::MemberSubnetTestJSON::test_member_selfips PASSED
api/test_pool_sync.py::PoolSyncTestJSON::test_pool_active_sync PASSED
api/test_pool_sync.py::PoolSyncTestJSON::test_pool_member_active_sync PASSED
api/test_pools.py::PoolTestJSON::test_create_shared_detached_pools PASSED
api/test_pools.py::PoolTestJSON::test_create_shared_pools PASSED
api/test_service_builder.py::ServiceBuilderTestJSON::test_service_builder PASSED

===================================================== warnings summary ======================================================
f5lbaasdriver/test/tempest/tests/api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_pool_policy
  /usr/local/lib/python2.7/dist-packages/setuptools-36.0.1.post20170801-py2.7.egg/pkg_resources/__init__.py:184: RuntimeWarning: You have iterated over the result of pkg_resources.parse_version. This is a legacy behavior which is inconsistent with the new version class introduced in setuptools 8.0. In most cases, conversion to a tuple is unnecessary. For comparison of versions, sort the Version instances directly. If you have another use case requiring the tuple, please file a bug with the setuptools project describing that need.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
==================================== 32 passed, 1 skipped, 1 warnings in 674.48 seconds =====================================
__________________________________________________________ summary __________________________________________________________
  tempest: commands succeeded
  congratulations :)
```