### PR TITLE
Selective chowning of openstackdev specific files permits successful nightly teardown without affecting other project files.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
 
                     # - run systests
                     target_name=tempest_$(echo $JOB_BASE_NAME | sed s/-/_/g)
-                    make -C systest stubjenkins_test_11.6.1_undercloud_vxlan
+                    make -C systest $target_name
 
                     # - record results
                     if [ "${JOB_BASE_NAME}" != "smoke_test" ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
 
                     # - run systests
                     target_name=tempest_$(echo $JOB_BASE_NAME | sed s/-/_/g)
-                    make -C systest $target_name
+                    make -C systest stubjenkins_test_11.6.1_undercloud_vxlan
 
                     # - record results
                     if [ "${JOB_BASE_NAME}" != "smoke_test" ]; then

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -13,18 +13,6 @@
 # limitations under the License.
 #
 
-# Inform make that targets are NOT files.
-.PHONY: all functest \
-tempest_13.0.0_undercloud_vxlan tempest_11.5.4_overcloud \
-tempest_11.6.0_overcloud tempest_11.6.1_overcloud \
-tempest_12.1.1_undercloud_vxlan tempest_11.5.4_undercloud_vxlan \
-tempest_11.5.4_undercloud_gre tempest_11.5.4_undercloud_vlan \
-tempest_11.6.0_undercloud_vxlan tempest_11.6.0_undercloud_gre \
-tempest_11.6.0_undercloud_vlan tempest_11.6.1_undercloud_vxlan \
-tempest_11.6.1_undercloud_gre tempest_11.6.1_undercloud_vlan \
-tempest_12.1.1_undercloud_vxlan tempest_12.1.1_undercloud_gre \
-tempest_12.1.1_undercloud_vlan 
-
 # Fixing branch to that specified in the public fork. This is necessary for build on PRs.
 export BRANCH := mitaka
 # The branch may contain the text 'stable/' before the OpenStack release name
@@ -102,6 +90,7 @@ export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
 microservice_setup_tlc_session:
 	@echo "setting up TLC session..."
+	sudo -E chown -Rf jenkins:jenkins $(PROJROOTDIR) && \
 	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -91,15 +91,15 @@ export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 microservice_setup_tlc_session:
 	@echo "setting up TLC session..."
 	sudo -E chown -Rf jenkins:jenkins $(PROJROOTDIR) && \
-	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:
 	@echo "injecting TLC symbol and openstack IDs into 'tempest' conf files..."
-	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
 
 run_neutron_lbaas:
 	@echo "running tests extracted from 'neutron_lbaas' project..."
-	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
 
 run_agent_transfers:
 	@echo "running tests extracted from 'f5-openstack-agent' project..."
@@ -107,7 +107,7 @@ run_agent_transfers:
 
 run_smoke_tests:
 	@echo "running smoke tests for build on PR..."
-	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
 
 cleanup_tlc_session:
 	@echo "running tlc --session TEST_SESSION --debug cleanup..."
@@ -260,7 +260,7 @@ tempest_11.6.0_undercloud_vlan:
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.1 undercloud VE deployment
-stubjenkins_test_11.6.1_undercloud_vxlan:
+tempest_11.6.1_undercloud_vxlan:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -91,15 +91,15 @@ export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 microservice_setup_tlc_session:
 	@echo "setting up TLC session..."
 	sudo -E chown -Rf jenkins:jenkins $(PROJROOTDIR) && \
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_failed_tlc
 
 configure_test_infra:
 	@echo "injecting TLC symbol and openstack IDs into 'tempest' conf files..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_failed_tlc
+	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_failed_tlc
 
 run_neutron_lbaas:
 	@echo "running tests extracted from 'neutron_lbaas' project..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_tlc_session
 
 run_agent_transfers:
 	@echo "running tests extracted from 'f5-openstack-agent' project..."
@@ -107,7 +107,7 @@ run_agent_transfers:
 
 run_smoke_tests:
 	@echo "running smoke tests for build on PR..."
-	cd scripts && ./$@.sh || $(MAKE) -C ../ cleanup_tlc_session
+	cd scripts && ./$@.sh # $(MAKE) -C ../ cleanup_tlc_session
 
 cleanup_tlc_session:
 	@echo "running tlc --session TEST_SESSION --debug cleanup..."
@@ -260,7 +260,7 @@ tempest_11.6.0_undercloud_vlan:
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 11.6.1 undercloud VE deployment
-tempest_11.6.1_undercloud_vxlan:
+stubjenkins_test_11.6.1_undercloud_vxlan:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\

--- a/systest/scripts/configure_test_infra.sh
+++ b/systest/scripts/configure_test_infra.sh
@@ -18,11 +18,11 @@
 set -ex
 
 # Copy over our tox.ini
-sudo -E mkdir -p ${TEMPEST_CONFIG_DIR}
-sudo -E cp -f ${PROJROOTDIR}/systest/scripts/conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
+mkdir -p ${TEMPEST_CONFIG_DIR}
+cp -f ${PROJROOTDIR}/systest/scripts/conf/neutron-lbaas.tox.ini ${NEUTRON_LBAAS_DIR}/f5.tox.ini
 # Copy over our default tempest files
-sudo -E cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
-sudo -E cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
+cp -f conf/tempest.conf ${TEMPEST_CONFIG_DIR}/tempest.conf.orig
+cp -f conf/accounts.yaml ${TEMPEST_CONFIG_DIR}/accounts.yaml
 
 # Find the values for tempest.conf and substitute them
 OS_CONTROLLER_IP=`/tools/bin/tlc --sid ${TEST_SESSION} symbols \
@@ -39,10 +39,10 @@ OS_CIRROS_IMAGE_ID=`${ssh_cmd} "source ~/keystonerc_testlab && glance image-list
     | grep ${TEST_CIRROS_IMAGE} \
     | awk '{print $2}'`
 
-sudo -E bash -c "cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig | sed \"s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/\" | sed \"s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/\" | sed \"s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/\" | sed \"s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/\" > ${TEMPEST_CONFIG_DIR}/tempest.conf"
+bash -c "cat ${TEMPEST_CONFIG_DIR}/tempest.conf.orig | sed \"s/{{ OS_CONTROLLER_IP }}/${OS_CONTROLLER_IP}/\" | sed \"s/{{ OS_PUBLIC_ROUTER_ID }}/${OS_PUBLIC_ROUTER_ID}/\" | sed \"s/{{ OS_PUBLIC_NETWORK_ID }}/${OS_PUBLIC_NETWORK_ID}/\" | sed \"s/{{ OS_CIRROS_IMAGE_ID }}/${OS_CIRROS_IMAGE_ID}/\" > ${TEMPEST_CONFIG_DIR}/tempest.conf"
 
 # Add tempest configuration options for running tempest tests in f5lbaasv2driver
 BIGIP_IP=`ssh -i ~/.ssh/id_rsa_testlab testlab@${OS_CONTROLLER_IP} cat ve_mgmt_ip`
-sudo -E bash -c "echo \"[f5_lbaasv2_driver]\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
-sudo -E bash -c "echo \"icontrol_hostname = ${BIGIP_IP}\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
-sudo -E bash -c "echo \"transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+bash -c "echo \"[f5_lbaasv2_driver]\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+bash -c "echo \"icontrol_hostname = ${BIGIP_IP}\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"
+bash -c "echo \"transport_url = rabbit://guest:guest@${OS_CONTROLLER_IP}:5672/\" >> ${TEMPEST_CONFIG_DIR}/tempest.conf"

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -31,7 +31,7 @@ touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 cd ${PROJROOTDIR}
 
 sudo -E pip install .
-bash -c "tox --sitepackages -e tempest -c tox.ini -- \
+bash -c "tox -e tempest -c tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -30,6 +30,7 @@ touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${PROJROOTDIR}
 
+sudo -E pip install .
 bash -c "tox --sitepackages -e tempest -c tox.ini -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -20,8 +20,8 @@ set -x
 # Create .pytest.rootdir files at the root of the driver and neutron-lbaas
 # respositories to make the results suite names be rooted at the top-level
 # of the respective test repository
-sudo -E touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
-sudo -E touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
+touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
+touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
 
 
 # The following tox commands will fail, if the ${EXCLUDE_FILE}
@@ -30,7 +30,7 @@ sudo -E touch ${NEUTRON_LBAAS_DIR}/neutron_lbaas/tests/tempest/v2/.pytest.rootdi
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${PROJROOTDIR}
 
-sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- \
+bash -c "tox --sitepackages -e tempest -c tox.ini -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
@@ -39,14 +39,14 @@ sudo -E bash -c "tox --sitepackages -e tempest -c tox.ini -- \
 cd ${NEUTRON_LBAAS_DIR}
 
 # LBaaSv2 API test cases with F5 tox.ini file
-sudo -E bash -c "tox -e apiv2 -c f5.tox.ini --sitepackages -- \
+bash -c "tox -e apiv2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \
   --autolog-session ${API_SESSION}"
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
-sudo -E bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
+bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \

--- a/systest/scripts/run_smoke_tests.sh
+++ b/systest/scripts/run_smoke_tests.sh
@@ -24,13 +24,13 @@ cd ${NEUTRON_LBAAS_DIR}
 # doesn't exist in the ${EXCLUDE_DIR}.
 
 # Create .pytest.rootdir file at root of the neutron-lbaas repository directory
-sudo -E touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
+touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
 # The scenario tests are the current set of smoke tests. This is sufficient
 # for now, but we will be able to amend this set as needed.
 # In the near future, we should add our scenario tests as well.
-sudo -E bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
+bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv \
   --autolog-outputdir ${RESULTS_DIR} \

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 basepython=python2.7
 
 [testenv]
+skip_intall=True
 whitelist_externals=/usr/local/bin/py.test
 install_command=/usr/local/bin/pip install {opts} {packages}
 list_dependencies_command=/usr/local/bin/pip freeze


### PR DESCRIPTION
@pjbreaux 

Most of the relevant context for this PR is already documented in #711 .

For additional detail see the commit messages.

Tests:

http://jenkins.pdbld.f5net.com/job/openstack/job/driver/job/mitaka/job/za_test_11.6.1_undercloud_vxlan/22/consoleFull