### PR TITLE
L7Policy tests can fail due to timing issue and lb status behavior in mitaka

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -111,9 +111,11 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.policies.append(l7policy)
         self._wait_for_load_balancer_status(self.load_balancer_id)
         assert (l7policy.get('action') == "REJECT")
-        assert not self.bigip_client.policy_exists("wrapper_policy",
-                                                   "Project_" +
-                                                   self.project_tenant_id)
+        assert not self.bigip_client.policy_exists(
+            "wrapper_policy",
+            "Project_" +
+            self.project_tenant_id,
+            should_exist=False)
 
     def test_policy_reject_header_ends_with(self):
         '''Reject traffic when header value ends with value.'''
@@ -233,10 +235,10 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
         self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        assert not \
-            self.bigip_client.policy_exists("wrapper_policy",
-                                            "Project_" +
-                                            self.project_tenant_id)
+        assert not self.bigip_client.policy_exists("wrapper_policy",
+                                                   "Project_" +
+                                                   self.project_tenant_id,
+                                                   should_exist=False)
 
     def test_policy_reject_multi_policy_multi_rules(self):
         l7policy1 = self._create_l7policy(**self.reject_args)
@@ -316,10 +318,10 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                     "Project_" +
                                                     self.project_tenant_id)
         self._delete_l7policy(l7policy2.get('id'))
-        assert not \
-            self.bigip_client.policy_exists("wrapper_policy",
-                                            "Project_" +
-                                            self.project_tenant_id)
+        assert not self.bigip_client.policy_exists("wrapper_policy",
+                                                   "Project_" +
+                                                   self.project_tenant_id,
+                                                   should_exist=False)
 
     def test_policy_reject_many_rules(self):
         l7policy = self._create_l7policy(**self.reject_args)
@@ -410,10 +412,10 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self._delete_l7rule(l7policy.get('id'), self.rule6.get('id'))
         self._delete_l7rule(l7policy.get('id'), self.rule7.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        assert not \
-            (self.bigip_client.policy_exists("wrapper_policy",
-                                             "Project_" +
-                                             self.project_tenant_id))
+        assert not self.bigip_client.policy_exists("wrapper_policy",
+                                                   "Project_" +
+                                                   self.project_tenant_id,
+                                                   should_exist=False)
 
 
 class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_update.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_update.py
@@ -105,7 +105,7 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
         self.addCleanup(self._delete_l7policy, policy_id)
 
         assert not self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition)
+            'wrapper_policy', partition=self.partition, should_exist=False)
 
         assert not self.bigip.virtual_server_has_policy(
             self.vs_name, 'wrapper_policy', self.partition)
@@ -250,7 +250,7 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
         self._delete_l7rule(policy_id, rule_id, wait=True)
         self._delete_l7policy(policy_id, wait=True)
         assert not self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition)
+            'wrapper_policy', partition=self.partition, should_exist=False)
         assert not self.bigip.virtual_server_has_policy(
             self.vs_name, 'wrapper_policy', self.partition)
 
@@ -277,7 +277,7 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
         # remove rule and expect policy removed from BIG-IP
         self._delete_l7rule(policy_id, rule_id, wait=True)
         assert not self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition)
+            'wrapper_policy', partition=self.partition, should_exist=False)
         assert not self.bigip.virtual_server_has_policy(
             self.vs_name, 'wrapper_policy', self.partition)
 


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #626 

#### What's this change do?
Note that the fix here is a workaround for the timing issue described
below in the background context. This is not a code fix for the
neutron-lbaas issue. Although we have ideas of how to address it,
we may open ourselves to race conditions.

Created new methods to check for existence and non-existence of a
policy. These methods sleep between iterations and only check a few
times.

This also contains a test fixup for the test_esd.py api test, which suffers
from the same problem as the L7 policy tests, since the lb status does
not go into PENDING_UPDATE when a policy or rule is modified.

#### Where should the reviewer start?

#### Any background context?
This is a combination of a test issue and an actual issue in
neutron-lbaas (although some might purport it was a design decision in
neutron-lbaas). The intermittent failures of the l7policy tests below
are often caused by the policy not yet existing on the BIG-IP device.
This is because, in the test, the lb provisioning status is used as a
guide for when objects are changing beneath it. This means that if a
listener is created or updated or deleted, the lb's provisioning status
goes into PENDING_UPDATE. Yet when a policy is created (only on the
creation event), the lb's status is not set to PENDING_UPDATE. This is
true for mitaka and newton.

Tested on my local stack 12.1.1 undercloud vxlan.