### PR TITLE
ansible_install_lbaasv2.sh should install checkout version of driver code

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -13,8 +13,15 @@
 # limitations under the License.
 #
 
-# Fixing branch to that specified in the public fork. This is necessary for build on PRs.
 export BRANCH := mitaka
+export GIT_REMOTE_URL := $(shell git config --get remote.origin.url)
+# The below operations are used for the builds on PR. The two variables are defined by the
+# Github Pull Request Builder plugin for Jenkins. --> ghprb...
+# https://wiki.jenkins.io/display/JENKINS/GitHub+pull+request+builder+plugin
+ghprbAuthorRepoGitUrl?=$(GIT_REMOTE_URL)
+ghprbActualCommit?=$(BRANCH)
+export DRIVER_PIP_INSTALL_LOCATION := git+$(ghprbAuthorRepoGitUrl)@$(ghprbActualCommit)
+
 # The branch may contain the text 'stable/' before the OpenStack release name
 # To allow this type of branch name and any other to work with the cloud deployment
 # and with Jenkins, we should strip out the forward slash, leaving something like:
@@ -50,10 +57,7 @@ export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requir
 export PATH := /tools/bin:$(PATH)
 export PYTHONPATH := /tools/lib:/tools/bin:$(PYTHONPATH)
 export USER := jenkins
-# Because the sanitized branch may still contain the string 'stable',
-# we must strip that out to get the OpenStack release name alone. This
-# will be used in the current TLC deployment of the stack.
-export TEST_OPENSTACK_DISTRO := $(subst stable,,$(SANITIZED_BRANCH))
+export TEST_OPENSTACK_DISTRO := mitaka
 export TEST_CIRROS_IMAGE := cirros-0.3.4-x86_64-disk.qcow2
 export TEST_OPENSTACK_NODE_COUNT := 3
 export TEST_OPENSTACK_DEPLOY := multinode

--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -9,7 +9,7 @@ SSH_CMD="ssh -i /home/jenkins/.ssh/id_rsa -o StrictHostKeyChecking=no testlab@${
 BIGIP_IP=`${SSH_CMD} "cat /home/testlab/ve_mgmt_ip"`
 BIGIP_IP=${BIGIP_IP%%[[:cntrl:]]}
 AGENT_LOC=git+https://github.com/F5Networks/f5-openstack-agent.git@${BRANCH}
-DRIVER_LOC=git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@${BRANCH}
+DRIVER_LOC=${DRIVER_PIP_INSTALL_LOCATION}
 NEUTRON_DRIVER_LOC=https://raw.githubusercontent.com/F5Networks/neutron-lbaas/stable/${BRANCH}/neutron_lbaas/drivers/f5/driver_v2.py
 
 # Since we don't do anything special in the __init__.py file, we can pull it from anywhere for now


### PR DESCRIPTION
@zancas 

#### What issues does this address?
Fixes #733 

#### What's this change do?
Updated the Makefile and the ansible_install_lbaasv2.sh script to get
the current checkout out repo and branch into the ansible container.

#### Where should the reviewer start?

#### Any background context?
In build on PR, the checked out version of the driver should be used as
the code to install on the OpenStack controller. We just need to change
the variable fed into the ansible_install_lbaasv2.sh script. This
variable will have the driver install location set as the checked out
version of the driver.

The build on PR will test this behavior, and this is where we really
want this change to be, so it is a good test.