### PR TITLE
adding targets for BIGIP12.1.2

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/scenario/test_esd.py
+++ b/f5lbaasdriver/test/tempest/tests/scenario/test_esd.py
@@ -51,10 +51,7 @@ class TestEsdBasic(f5_base.F5BaseTestCase):
             try:
                 if not uri_path:
                     uri_path = 'http://{}'.format(self.vip_ip)
-                print('making request to {}'.format(uri_path))
                 res = requests.get(uri_path, headers=headers, cookies=cookies)
-                print('Expected_server: {}'.format(expected_server))
-                print('Return server: {}'.format(res.text))
                 assert expected_server in res.text
                 assert res.status_code == expected_status
             except Exception as ex:

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -178,17 +178,6 @@ tempest_11.6.1_overcloud:
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x overcloud VE deployment
-tempest_12.1.1_overcloud:
-	export PROJROOTDIR=$(PROJROOTDIR) ;\
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=overcloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
 tempest_12.1.2_overcloud:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\
@@ -312,42 +301,6 @@ tempest_11.6.1_undercloud_vlan:
 	$(MAKE) -C . run_tests
 
 # Tempest Tests for 12.1.x undercloud VE deployment
-tempest_12.1.1_undercloud_vxlan:
-	export PROJROOTDIR=$(PROJROOTDIR) ;\
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_12.1.1_undercloud_gre:
-	export PROJROOTDIR=$(PROJROOTDIR) ;\
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=gre ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
-tempest_12.1.1_undercloud_vlan:
-	export PROJROOTDIR=$(PROJROOTDIR) ;\
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
-	export TEST_OPENSTACK_CLOUD=undercloud ;\
-	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
-	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
-	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
-	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
-	export TEST_TENANT_NETWORK_TYPE=vlan ;\
-	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
-
 tempest_12.1.2_undercloud_vxlan:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -189,6 +189,17 @@ tempest_12.1.1_overcloud:
 	export EXCLUDE_FILE=$@.yaml ;\
 	$(MAKE) -C . run_tests
 
+tempest_12.1.2_overcloud:
+	export PROJROOTDIR=$(PROJROOTDIR) ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=overcloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export EXCLUDE_FILE=$@.yaml ;\
+	$(MAKE) -C . run_tests
+
 # Tempest Tests for 11.5.4 undercloud VE deployment
 tempest_11.5.4_undercloud_vxlan:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
@@ -300,7 +311,7 @@ tempest_11.6.1_undercloud_vlan:
 	export EXCLUDE_FILE=$@.yaml ;\
 	$(MAKE) -C . run_tests
 
-# Tempest Tests for 12.1.1 undercloud VE deployment
+# Tempest Tests for 12.1.x undercloud VE deployment
 tempest_12.1.1_undercloud_vxlan:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
 	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
@@ -337,10 +348,48 @@ tempest_12.1.1_undercloud_vlan:
 	export EXCLUDE_FILE=$@.yaml ;\
 	$(MAKE) -C . run_tests
 
-# Default deployment for smoke is 12.1.1 undercloud vxlan
+tempest_12.1.2_undercloud_vxlan:
+	export PROJROOTDIR=$(PROJROOTDIR) ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
+	export EXCLUDE_FILE=$@.yaml ;\
+	$(MAKE) -C . run_tests
+
+tempest_12.1.2_undercloud_gre:
+	export PROJROOTDIR=$(PROJROOTDIR) ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow22 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=gre ;\
+	export EXCLUDE_FILE=$@.yaml ;\
+	$(MAKE) -C . run_tests
+
+tempest_12.1.2_undercloud_vlan:
+	export PROJROOTDIR=$(PROJROOTDIR) ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=undercloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export TEST_TENANT_NETWORK_TYPE=vlan ;\
+	export EXCLUDE_FILE=$@.yaml ;\
+	$(MAKE) -C . run_tests
+
+
+
+# Default deployment for smoke is 12.1.2 undercloud vxlan
 tempest_smoke_test:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.1.2.0.204.qcow2 ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\
 	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -315,7 +315,7 @@ tempest_12.1.2_undercloud_vxlan:
 
 tempest_12.1.2_undercloud_gre:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\
-	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow22 ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-12.1.2.0.0.249.qcow2 ;\
 	export TEST_OPENSTACK_CLOUD=undercloud ;\
 	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ve_$${TEST_OPENSTACK_CLOUD}.tlc ;\
 	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #745

#### What's this change do?
This change adds new targets for BIGIP12.1.2. It also upgrades the image from BIGIP12.1.1 to BIGIP12.1.2 for smoke tests.

#### Where should the reviewer start?
systest/Makefile

#### Test Results:
I listed the test results outputs against a session with BIGIP12.1.2:

```
Neutron-lbaas scenariov2 tests:

../../../../../../f5-openstack-lbaasv2-driver/::TestHealthMonitorBasic::test_health_monitor_basic <- ../../../usr/local/lib/python2.7/dist-packages/tempest/test.py PASSED
../../../../../../f5-openstack-lbaasv2-driver/::TestListenerBasic::test_listener_basic <- ../../../usr/local/lib/python2.7/dist-packages/tempest/test.py PASSED
../../../../../../f5-openstack-lbaasv2-driver/::TestLoadBalancerBasic::test_load_balancer_basic <- ../../../usr/local/lib/python2.7/dist-packages/tempest/test.py PASSED
../../../../../../f5-openstack-lbaasv2-driver/::TestLoadBalancerTLS::test_load_balancer_tls <- ../../../usr/local/lib/python2.7/dist-packages/tempest/test.py PASSED
../../../../../../f5-openstack-lbaasv2-driver/::TestLoadBalancerTLS::test_load_balancer_tls <- ../../../usr/local/lib/python2.7/dist-packages/tempest/test.py PASSED
../../../../../../f5-openstack-lbaasv2-driver/::TestSessionPersistence::test_session_persistence <- ../../../usr/local/lib/python2.7/dist-packages/tempest/test.py PASSED

============== 6 passed in 480.76 seconds ============

Neutron-lbaas apiv2 tests:

==== 2 failed, 254 passed, 5 skipped in 960.98 seconds ========
../../../../../f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_expected_codes <- ../neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py FAILED
../../../../../../f5-openstack-lbaasv2-driver/::TestHealthMonitors::test_update_health_monitor_invalid_http_method <- ../neutron-lbaas/neutron_lbaas/tests/tempest/v2/api/test_health_monitors_non_admin.py FAILED

Driver tempest tests:
== 1 failed, 47 passed, 2 skipped, 1 warnings in 1803.92 seconds =====
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_header_starts_with FAILED
```

