### PR TITLE
Fixes #753 - travis configs are incorrect -- stable/newton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,11 +67,11 @@ deploy:
   - provider: script
     skip_cleanup: true
     on:
-      branch: mitaka
+      branch: stable/newton
       repo: F5Networks/f5-openstack-lbaasv2-driver
       condition: $TRAVIS_TAG = ""
     script:
-    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/lbaasv2-driver $TRAVIS_BRANCH
+    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/lbaasv2-driver newton
    # if this is a tagged release, the docs go to /products/openstack/lbaasv2-driver/$TRAVIS_BRANCH/vX.Y
   - provider: script
     skip_cleanup: true


### PR DESCRIPTION
@pjbreaux @szakeri 

#### What issues does this address?
Fixes #753 

#### What's this change do?
Corrects the allowed branch for docs deployment to clouddocs.f5.com on stable/newton branch.

#### Where should the reviewer start?

#### Any background context?
