### PR TITLE
Tempest tests should be run against an HA pair

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         docker {
             label "docker"
             registryUrl "https://docker-registry.pdbld.f5net.com"
-            image "openstack-test-testrunner-breaux/mitaka:latest"
+            image "openstack-test-testrunner-prod/mitaka:latest"
             args "-v /etc/localtime:/etc/localtime:ro" \
                 + " -v /srv/mesos/trtl/results:/home/jenkins/results" \
                 + " -v /srv/nfs:/testlab" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         docker {
             label "docker"
             registryUrl "https://docker-registry.pdbld.f5net.com"
-            image "openstack-test-testrunner/mitaka:latest"
+            image "openstack-test-testrunner-breaux/mitaka:latest"
             args "-v /etc/localtime:/etc/localtime:ro" \
                 + " -v /srv/mesos/trtl/results:/home/jenkins/results" \
                 + " -v /srv/nfs:/testlab" \

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -177,6 +177,18 @@ tempest_11.6.1_overcloud:
 	export EXCLUDE_FILE=$@.yaml ;\
 	$(MAKE) -C . run_tests
 
+tempest_ha_11.6.1_overcloud:
+	export PROJROOTDIR=$(PROJROOTDIR) ;\
+	export TEST_VE_IMAGE=os_ready-BIGIP-11.6.1.1.0.326.qcow2 ;\
+	export TEST_OPENSTACK_CLOUD=overcloud ;\
+	export TLC_FILE=$(TLC_FILE_DIR)/$${TEST_OPENSTACK_CLOUD}/tempest_ha_$${TEST_OPENSTACK_CLOUD}.tlc ;\
+	export GUMBALLS_PROJECT=$(CHANGESOURCE)_$(SANITIZED_BRANCH)-$@ ;\
+	export RESULTS_DIR=$(MAKEFILE_DIR)/test_results/$${GUMBALLS_PROJECT} ;\
+	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
+	export EXCLUDE_FILE=$@.yaml ;\
+	export HA_TYPE=pair ;\
+	$(MAKE) -C . run_tests
+
 # Tempest Tests for 12.1.x overcloud VE deployment
 tempest_12.1.2_overcloud:
 	export PROJROOTDIR=$(PROJROOTDIR) ;\

--- a/systest/exclude/tempest_ha_11.6.1_overcloud.yaml
+++ b/systest/exclude/tempest_ha_11.6.1_overcloud.yaml
@@ -1,0 +1,12 @@
+{
+    "exclude": ["test_health_monitor_basic",
+                "test_listener_basic",
+                "test_load_balancer_basic",
+                "test_load_balancer_tls",
+                "test_session_persistence",
+                "test_policy_deployment",
+                "test_policy_abort_deployment",
+                "test_policy_deployment",
+                "test_stats",
+                "test_create_load_balancer_for_another_tenant"]
+}

--- a/systest/scripts/ansible_install_heat_plugins.sh
+++ b/systest/scripts/ansible_install_heat_plugins.sh
@@ -7,9 +7,9 @@ PIP_INSTALL_LOC=/usr/lib/python2.7/site-packages/f5_heat
 HEAT_PLUGIN_LOC=/usr/lib/heat
 HEAT_EXTRA_VARS="remote_user=testlab heat_plugins_pkg_location=${HEAT_PKG_LOC} pip_install_dest=${PIP_INSTALL_LOC} heat_plugin_install_dest=${HEAT_PLUGIN_LOC} heat_engine_service_name=openstack-heat-engine"
 
-sudo -E docker pull docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-breaux/mitaka
+sudo -E docker pull docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka
 sudo -E docker run \
     --volumes-from `hostname | xargs` \
-docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-breaux/mitaka:latest \
+docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka:latest \
 /f5-openstack-ansible/playbooks/heat_plugins_deploy.yaml \
 --extra-vars "${HEAT_EXTRA_VARS}"

--- a/systest/scripts/ansible_install_heat_plugins.sh
+++ b/systest/scripts/ansible_install_heat_plugins.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+
+HEAT_PKG_LOC="git+https://github.com/F5Networks/f5-openstack-heat-plugins.git@${BRANCH}"
+PIP_INSTALL_LOC=/usr/lib/python2.7/site-packages/f5_heat
+HEAT_PLUGIN_LOC=/usr/lib/heat
+HEAT_EXTRA_VARS="remote_user=testlab heat_plugins_pkg_location=${HEAT_PKG_LOC} pip_install_dest=${PIP_INSTALL_LOC} heat_plugin_install_dest=${HEAT_PLUGIN_LOC} heat_engine_service_name=openstack-heat-engine"
+
+sudo -E docker pull docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-breaux/mitaka
+sudo -E docker run \
+    --volumes-from `hostname | xargs` \
+docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-breaux/mitaka:latest \
+/f5-openstack-ansible/playbooks/heat_plugins_deploy.yaml \
+--extra-vars "${HEAT_EXTRA_VARS}"

--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -3,8 +3,8 @@
 set -ex
 
 OS_CONTROLLER_IP=`/tools/bin/tlc --sid ${TEST_SESSION} symbols \
-    | grep openstack_controller1ip_data_direct \
-    | awk '{print $3}' | xargs`
+            | grep openstack_controller1ip_data_direct \
+                    | awk '{print $3}' | xargs`
 SSH_CMD="ssh -i /home/jenkins/.ssh/id_rsa -o StrictHostKeyChecking=no testlab@${OS_CONTROLLER_IP}"
 BIGIP_IP=`${SSH_CMD} "cat /home/testlab/ve_mgmt_ip"`
 BIGIP_IP=${BIGIP_IP%%[[:cntrl:]]}
@@ -14,7 +14,6 @@ NEUTRON_DRIVER_LOC=https://raw.githubusercontent.com/F5Networks/neutron-lbaas/st
 
 # Since we don't do anything special in the __init__.py file, we can pull it from anywhere for now
 NEUTRON_INIT_LOC=https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v9.1.0/neutron_lbaas/drivers/f5/__init__.py
-
 
 EXTRA_VARS="agent_pkg_location=${AGENT_LOC} driver_pkg_location=${DRIVER_LOC} neutron_lbaas_driver_location=${NEUTRON_DRIVER_LOC}"
 
@@ -30,15 +29,16 @@ else
     GLOBAL_ROUTED_MODE="True"
 fi
 
+if [[ -n ${HA_TYPE} ]]; then
+    EXTRA_VARS="${EXTRA_VARS} f5_ha_type=${HA_TYPE}"
+fi
+
 EXTRA_VARS="${EXTRA_VARS} neutron_lbaas_init_location=${NEUTRON_INIT_LOC} restart_all_neutron_services=true remote_user=testlab"
 EXTRA_VARS="${EXTRA_VARS} f5_global_routed_mode=${GLOBAL_ROUTED_MODE} bigip_netloc=${BIGIP_IP} agent_service_name=f5-openstack-agent.service"
 EXTRA_VARS="${EXTRA_VARS} use_barbican_cert_manager=True neutron_lbaas_shim_install_dest=/usr/lib/python2.7/site-packages/neutron_lbaas/drivers/f5"
-sudo -E chown -Rf jenkins:jenkins /home/jenkins/container_mailbox
-bash -c "echo [hosts] > /home/jenkins/container_mailbox/ansible_conf.ini"
-bash -c "echo \"${OS_CONTROLLER_IP} ansible_ssh_common_args='-o StrictHostKeyChecking=no' host_key_checking=False ansible_connection=ssh ansible_ssh_user=testlab ansible_ssh_private_key_file=/root/id_rsa\" >> /home/jenkins/container_mailbox/ansible_conf.ini"
 
-sudo -E docker pull docker-registry.pdbld.f5net.com/f5-openstack/ansiblemicroservice-prod/mitaka
 sudo -E docker run \
 --volumes-from `hostname | xargs` \
-docker-registry.pdbld.f5net.com/f5-openstack/ansiblemicroservice-prod/mitaka:latest \
+docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-breaux/mitaka:latest \
+/f5-openstack-ansible/playbooks/agent_driver_deploy.yaml \
 --extra-vars "${EXTRA_VARS}"

--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -39,6 +39,6 @@ EXTRA_VARS="${EXTRA_VARS} use_barbican_cert_manager=True neutron_lbaas_shim_inst
 
 sudo -E docker run \
 --volumes-from `hostname | xargs` \
-docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-breaux/mitaka:latest \
+docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka:latest \
 /f5-openstack-ansible/playbooks/agent_driver_deploy.yaml \
 --extra-vars "${EXTRA_VARS}"

--- a/systest/scripts/microservice_setup_tlc_session.sh
+++ b/systest/scripts/microservice_setup_tlc_session.sh
@@ -96,5 +96,16 @@ set -e
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd ready
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd test_env
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd barbican
+
+# Setup container mailbox for ansible playbooks
+./prepare_controller.sh
+
+# Optionally install heat plugins
+if [[ ${HA_TYPE} == "pair" ]]; then
+  ./ansible_install_heat_plugins.sh
+  /tools/bin/tlc --session ${TEST_SESSION} --debug cmd configure_cluster
+fi
+
+# Install lbaas components
 ./ansible_install_lbaasv2.sh
 /tools/bin/tlc --session ${TEST_SESSION} --debug cmd configure_lbaasv2

--- a/systest/scripts/prepare_controller.sh
+++ b/systest/scripts/prepare_controller.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ex
+
+OS_CONTROLLER_IP=`/tools/bin/tlc --sid ${TEST_SESSION} symbols \
+        | grep openstack_controller1ip_data_direct \
+        | awk '{print $3}' | xargs`
+sudo -E chown -Rf jenkins:jenkins /home/jenkins/container_mailbox
+bash -c "echo [hosts] > /home/jenkins/container_mailbox/ansible_conf.ini"
+bash -c "echo \"${OS_CONTROLLER_IP} ansible_ssh_common_args='-o StrictHostKeyChecking=no' host_key_checking=False ansible_connection=ssh ansible_ssh_user=testlab ansible_ssh_private_key_file=/root/id_rsa\" >> /home/jenkins/container_mailbox/ansible_conf.ini"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 basepython=python2.7
 
 [testenv]
-skip_intall=True
+skip_install=True
 whitelist_externals=/usr/local/bin/py.test
 install_command=/usr/local/bin/pip install {opts} {packages}
 list_dependencies_command=/usr/local/bin/pip freeze


### PR DESCRIPTION
@zancas @jlongstaf 

**If someone lands this with the code in my fork, remember to change the name of the testrunner and ansible containers to prod!**

#### What issues does this address?
Fixes #775

#### What's this change do?
Added the new tempest_ha_11.6.1_overcloud target, which is tied to a new
tlc file that creates two bigips then clusters them with the f5 heat
plugins. A new script in the systest directory installs the heat plugins
with ansible and makes the call to the tlc command to cluster the
devices.

#### Where should the reviewer start?

#### Any background context?
We need to add a new deployment in our nightly (or weekly) regression
runs. This means adding a new target in the makefile to create an HA
pair of BIG-IP devices and run the driver tempest and neutron-lbaas
tempest tests against them. This is coupled with changes in dev-test,
ansible, and the testrunner container.

Ran tests with the test jenkins instance, running a full set of
regression tests.

Latest result can be found here:

http://10.190.25.149:49001/job/devs/job/ha-11.6.1-overcloud/20/consoleFull

There is still work to do in the testrunner container, but I believe the driver
changes are complete.