### PR TITLE
Smoke test failures on PR are no longer causing build failure in Jenkins

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -362,7 +362,11 @@ tempest_smoke_test:
 	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_smoke
+	export SMOKE_RC_RESULT_FILE=$(PROJROOTDIR)/systest/smoke_rc_result ;\
+	$(MAKE) -C . run_smoke ;\
+	SMOKE_RC=$$(cat smoke_rc_result) ;\
+	exit $$SMOKE_RC
+
 
 run_tests:
 	$(MAKE) -C . microservice_setup_tlc_session
@@ -373,6 +377,5 @@ run_tests:
 run_smoke:
 	$(MAKE) -C . microservice_setup_tlc_session
 	$(MAKE) -C . configure_test_infra
-	$(MAKE) -C . run_smoke_tests ; SMOKE_RC=$$? ;\
+	$(MAKE) -C . run_smoke_tests ;\
 	$(MAKE) -C . cleanup_tlc_session
-	exit $$SMOKE_RC

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -373,5 +373,6 @@ run_tests:
 run_smoke:
 	$(MAKE) -C . microservice_setup_tlc_session
 	$(MAKE) -C . configure_test_infra
-	$(MAKE) -C . run_smoke_tests
+	$(MAKE) -C . run_smoke_tests ; SMOKE_RC=$$? ;\
 	$(MAKE) -C . cleanup_tlc_session
+	exit $$SMOKE_RC

--- a/systest/scripts/run_smoke_tests.sh
+++ b/systest/scripts/run_smoke_tests.sh
@@ -23,8 +23,15 @@ touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
 # Navigate to the root of the repo, where the tox.ini file is found
 cd ${PROJROOTDIR}
 
+# Remove smoke test rc file, in case someone is iterating on smoke tests
+rm -rf ${SMOKE_RC_RESULT_FILE}
+
 bash -c "tox -e tempest -c tox.ini --sitepackages -- \
       --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
         -lvv \
           --autolog-outputdir ${RESULTS_DIR} \
-          --autolog-session ${API_SESSION} scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_contains"
+          --autolog-session ${API_SESSION} scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_contains" || echo $? > ${SMOKE_RC_RESULT_FILE}
+
+if [ ! -f "${SMOKE_RC_RESULT_FILE}" ]; then
+    echo 0 > ${SMOKE_RC_RESULT_FILE}
+fi

--- a/systest/scripts/run_smoke_tests.sh
+++ b/systest/scripts/run_smoke_tests.sh
@@ -17,21 +17,14 @@
 
 set -ex
 
-# Activate our tempest virtualenv
-cd ${NEUTRON_LBAAS_DIR}
+# Create .pytest.rootdir files at the root of the driver.
+touch ${PROJROOTDIR}f5lbaasdriver/test/tempest/tests/.pytest.rootdir
 
-# The following tox commands will fail, if the ${EXCLUDE_FILE}
-# doesn't exist in the ${EXCLUDE_DIR}.
+# Navigate to the root of the repo, where the tox.ini file is found
+cd ${PROJROOTDIR}
 
-# Create .pytest.rootdir file at root of the neutron-lbaas repository directory
-touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
-
-# LBaaSv2 Scenario test cases with F5 tox.ini file
-# The scenario tests are the current set of smoke tests. This is sufficient
-# for now, but we will be able to amend this set as needed.
-# In the near future, we should add our scenario tests as well.
-bash -c "tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
-  --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
-  -lvv \
-  --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${SCENARIO_SESSION}"
+bash -c "tox -e tempest -c tox.ini --sitepackages -- \
+      --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
+        -lvv \
+          --autolog-outputdir ${RESULTS_DIR} \
+          --autolog-session ${API_SESSION} scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_contains"


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #774 

#### What's this change do?
Made the change to capture the rc from the smoke test run. Also, changed
the smoke test that is run on this target invocation.

#### Where should the reviewer start?

#### Any background context?
This may be due to a change in the Makefile, as this was working at one
time. I've made a more obvious change to capture the rc of the test run
and pass it up to the caller in the agent Makefile. I think that change
may be in order here to ensure we produce a non-zero rc if tests fail.

Testing in our jenkins. Will test success and failure modes.