### PR TITLE
When testing BIG-IP clusters, validate configuration on multiple BIG-IPs

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -34,13 +34,25 @@ class F5BaseTestCase(base.BaseTestCase):
 
     @classmethod
     def resource_setup(cls):
-        """Setup the clients and fixtures for test suite."""
+        """Setup the clients and fixtures for test suite.
+
+        When testing BIG-IP clusters, CONF.f5_lbaasv2_driver.icontrol_hostname
+        will be a comma delimited string of IP addresses. A list of clients is
+        created, and test writers should iterate the list when validating
+        BIG-IP operations. Test writers can choose to reference a single
+        BIG-IP using self.bigip_client, which points to the client created
+        with the first address in CONF.f5_lbaasv2_driver.icontrol_hostname.
+        """
         super(F5BaseTestCase, cls).resource_setup()
 
-        cls.bigip_client = BigIpClient(
-            CONF.f5_lbaasv2_driver.icontrol_hostname,
-            CONF.f5_lbaasv2_driver.icontrol_username,
-            CONF.f5_lbaasv2_driver.icontrol_password)
+        cls.bigip_clients = []
+        for host in CONF.f5_lbaasv2_driver.icontrol_hostname.split(","):
+            cls.bigip_clients.append(BigIpClient(
+                host,
+                CONF.f5_lbaasv2_driver.icontrol_username,
+                CONF.f5_lbaasv2_driver.icontrol_password))
+        cls.bigip_client = cls.bigip_clients[0]
+
         cls.plugin_rpc = (
             plugin_rpc_client.F5PluginRPCClient()
         )

--- a/f5lbaasdriver/test/tempest/tests/api/test_esd.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_esd.py
@@ -101,14 +101,15 @@ class ESDTestJSON(base.F5BaseTestCase):
 
     def check_esd(self):
         vs_name = 'Project_' + self.listener_id
-        assert self.bigip_client.virtual_server_has_profile(
-            vs_name, 'clientssl', self.partition)
-        assert self.bigip_client.virtual_server_has_profile(
-            vs_name, 'serverssl', self.partition)
-        assert self.bigip_client.virtual_server_has_profile(
-            vs_name, 'tcp-mobile-optimized', self.partition)
-        assert self.bigip_client.virtual_server_has_profile(
-            vs_name, 'tcp-lan-optimized', self.partition)
-        assert self.bigip_client.virtual_server_has_value(
-            vs_name, 'fallbackPersistence',
-            '/Common/source_addr', self.partition)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.virtual_server_has_profile(
+                vs_name, 'clientssl', self.partition)
+            assert bigip_client.virtual_server_has_profile(
+                vs_name, 'serverssl', self.partition)
+            assert bigip_client.virtual_server_has_profile(
+                vs_name, 'tcp-mobile-optimized', self.partition)
+            assert bigip_client.virtual_server_has_profile(
+                vs_name, 'tcp-lan-optimized', self.partition)
+            assert bigip_client.virtual_server_has_value(
+                vs_name, 'fallbackPersistence',
+                '/Common/source_addr', self.partition)

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -111,11 +111,12 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.policies.append(l7policy)
         self._wait_for_load_balancer_status(self.load_balancer_id)
         assert (l7policy.get('action') == "REJECT")
-        assert not self.bigip_client.policy_exists(
-            "wrapper_policy",
-            "Project_" +
-            self.project_tenant_id,
-            should_exist=False)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists(
+                "wrapper_policy",
+                "Project_" +
+                self.project_tenant_id,
+                should_exist=False)
 
     def test_policy_reject_header_ends_with(self):
         '''Reject traffic when header value ends with value.'''
@@ -127,19 +128,20 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self._wait_for_load_balancer_status(self.load_balancer_id)
         self._create_l7rule(l7policy.get('id'), **rule_args)
 
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "endsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "endsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
 
     def test_policy_reject_header_contains(self):
         '''Reject traffic when header value ends with value.'''
@@ -151,19 +153,20 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self._wait_for_load_balancer_status(self.load_balancer_id)
         self._create_l7rule(l7policy.get('id'), **rule_args)
 
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "contains",
-                                                    "es",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "contains",
+                                                   "es",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
 
     def test_policy_reject_three_rules(self):
         l7policy = self._create_l7policy(**self.reject_args)
@@ -179,66 +182,70 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.rule2 = self._create_l7rule(l7policy.get('id'), **rule2_args)
         self.rule3 = self._create_l7rule(l7policy.get('id'), **rule3_args)
 
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "contains",
-                                                    "es",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "startsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "endsWith",
-                                                    "test",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "contains",
+                                                   "es",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "startsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "endsWith",
+                                                   "test",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
 
         self._delete_l7rule(l7policy.get('id'), self.rule1.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert not \
-            self.bigip_client.rule_has_condition("wrapper_policy",
-                                                 "reject_1",
-                                                 "contains",
-                                                 "es",
-                                                 "Project_" +
-                                                 self.project_tenant_id)
-        assert \
-            self.bigip_client.rule_has_condition("wrapper_policy",
-                                                 "reject_1",
-                                                 "startsWith",
-                                                 "real",
-                                                 "Project_" +
-                                                 self.project_tenant_id)
-        assert \
-            self.bigip_client.rule_has_condition("wrapper_policy",
-                                                 "reject_1",
-                                                 "endsWith",
-                                                 "test",
-                                                 "Project_" +
-                                                 self.project_tenant_id)
+
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert not \
+                bigip_client.rule_has_condition("wrapper_policy",
+                                                "reject_1",
+                                                "contains",
+                                                "es",
+                                                "Project_" +
+                                                self.project_tenant_id)
+            assert \
+                bigip_client.rule_has_condition("wrapper_policy",
+                                                "reject_1",
+                                                "startsWith",
+                                                "real",
+                                                "Project_" +
+                                                self.project_tenant_id)
+            assert \
+                bigip_client.rule_has_condition("wrapper_policy",
+                                                "reject_1",
+                                                "endsWith",
+                                                "test",
+                                                "Project_" +
+                                                self.project_tenant_id)
 
         self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
         self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        assert not self.bigip_client.policy_exists("wrapper_policy",
-                                                   "Project_" +
-                                                   self.project_tenant_id,
-                                                   should_exist=False)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists("wrapper_policy",
+                                                  "Project_" +
+                                                  self.project_tenant_id,
+                                                  should_exist=False)
 
     def test_policy_reject_multi_policy_multi_rules(self):
         l7policy1 = self._create_l7policy(**self.reject_args)
@@ -257,71 +264,74 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.rule4 = self._create_l7rule(l7policy2.get('id'), **rule2_args)
 
         self._delete_l7rule(l7policy1.get('id'), self.rule1.get('id'))
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_2",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert not self.bigip_client.rule_has_condition("wrapper_policy",
-                                                        "reject_1",
-                                                        "contains",
-                                                        "es",
-                                                        "Project_" +
-                                                        self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "startsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_2",
-                                                    "startsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_2",
-                                                    "contains",
-                                                    "es",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_2",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert not bigip_client.rule_has_condition("wrapper_policy",
+                                                       "reject_1",
+                                                       "contains",
+                                                       "es",
+                                                       "Project_" +
+                                                       self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "startsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_2",
+                                                   "startsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_2",
+                                                   "contains",
+                                                   "es",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
 
         self._delete_l7policy(l7policy1.get('id'))
-        assert not self.bigip_client.rule_exists("wrapper_policy",
-                                                 "reject_1",
-                                                 "Project_" +
-                                                 self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_2",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_2",
-                                                    "contains",
-                                                    "es",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_2",
-                                                    "startsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        self._delete_l7policy(l7policy2.get('id'))
-        assert not self.bigip_client.policy_exists("wrapper_policy",
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.rule_exists("wrapper_policy",
+                                                "reject_1",
+                                                "Project_" +
+                                                self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_2",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_2",
+                                                   "contains",
+                                                   "es",
                                                    "Project_" +
-                                                   self.project_tenant_id,
-                                                   should_exist=False)
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_2",
+                                                   "startsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+        self._delete_l7policy(l7policy2.get('id'))
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists("wrapper_policy",
+                                                  "Project_" +
+                                                  self.project_tenant_id,
+                                                  should_exist=False)
 
     def test_policy_reject_many_rules(self):
         l7policy = self._create_l7policy(**self.reject_args)
@@ -349,62 +359,65 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.rule6 = self._create_l7rule(l7policy.get('id'), **rule6_args)
         self.rule7 = self._create_l7rule(l7policy.get('id'), **rule7_args)
 
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "reject_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "contains",
-                                                    "es",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "startsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "endsWith",
-                                                    "real",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "startsWith",
-                                                    "re",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "contains",
-                                                    "al",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "contains",
-                                                    "l",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "reject_1",
-                                                    "endsWith",
-                                                    "ireal",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "reject_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "contains",
+                                                   "es",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "startsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "endsWith",
+                                                   "real",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "startsWith",
+                                                   "re",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "contains",
+                                                   "al",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "contains",
+                                                   "l",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "reject_1",
+                                                   "endsWith",
+                                                   "ireal",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+
         self._delete_l7rule(l7policy.get('id'), self.rule1.get('id'))
-        assert not self.bigip_client.rule_has_condition("wrapper_policy",
-                                                        "reject_1",
-                                                        "contains",
-                                                        "es",
-                                                        "Project_" +
-                                                        self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.rule_has_condition("wrapper_policy",
+                                                       "reject_1",
+                                                       "contains",
+                                                       "es",
+                                                       "Project_" +
+                                                       self.project_tenant_id)
         self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
         self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
         self._delete_l7rule(l7policy.get('id'), self.rule4.get('id'))
@@ -412,10 +425,11 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self._delete_l7rule(l7policy.get('id'), self.rule6.get('id'))
         self._delete_l7rule(l7policy.get('id'), self.rule7.get('id'))
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        assert not self.bigip_client.policy_exists("wrapper_policy",
-                                                   "Project_" +
-                                                   self.project_tenant_id,
-                                                   should_exist=False)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists("wrapper_policy",
+                                                  "Project_" +
+                                                  self.project_tenant_id,
+                                                  should_exist=False)
 
 
 class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
@@ -443,19 +457,20 @@ class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
         self._wait_for_load_balancer_status(self.load_balancer_id)
         self._create_l7rule(l7policy.get('id'), **rule_args)
         self._wait_for_load_balancer_status(self.load_balancer_id)
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "redirect_to_url_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "redirect_to_url_1",
-                                                    "httpHeader",
-                                                    "es",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "redirect_to_url_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "redirect_to_url_1",
+                                                   "httpHeader",
+                                                   "es",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
 
 
 class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
@@ -479,19 +494,20 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
         rule_args = {'type': 'FILE_TYPE', 'compare_type': 'EQUAL_TO',
                      'value': 'jpg'}
         self._create_l7rule(l7policy.get('id'), **rule_args)
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "redirect_to_pool_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "redirect_to_pool_1",
-                                                    "extension",
-                                                    "jpg",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "redirect_to_pool_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "redirect_to_pool_1",
+                                                   "extension",
+                                                   "jpg",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
 
     def test_create_l7_redirect_to_pool_policy_not_file_type(self):
         """Test the creationg of a L7 pool redirect policy."""
@@ -502,32 +518,34 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
         rule_args = {'type': 'FILE_TYPE', 'compare_type': 'EQUAL_TO',
                      'value': 'qcow2', 'invert': True}
         rule1 = self._create_l7rule(l7policy.get('id'), **rule_args)
-        assert self.bigip_client.policy_exists("wrapper_policy",
-                                               "Project_" +
-                                               self.project_tenant_id)
-        assert self.bigip_client.rule_exists("wrapper_policy",
-                                             "redirect_to_pool_1",
-                                             "Project_" +
-                                             self.project_tenant_id)
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "redirect_to_pool_1",
-                                                    "extension",
-                                                    "qcow2",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
-        # Verify same rule exists, but invert is set to True
-        assert self.bigip_client.rule_has_condition("wrapper_policy",
-                                                    "redirect_to_pool_1",
-                                                    "not_",
-                                                    "qcow2",
-                                                    "Project_" +
-                                                    self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists("wrapper_policy",
+                                              "Project_" +
+                                              self.project_tenant_id)
+            assert bigip_client.rule_exists("wrapper_policy",
+                                            "redirect_to_pool_1",
+                                            "Project_" +
+                                            self.project_tenant_id)
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "redirect_to_pool_1",
+                                                   "extension",
+                                                   "qcow2",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
+            # Verify same rule exists, but invert is set to True
+            assert bigip_client.rule_has_condition("wrapper_policy",
+                                                   "redirect_to_pool_1",
+                                                   "not_",
+                                                   "qcow2",
+                                                   "Project_" +
+                                                   self.project_tenant_id)
         rule_args['invert'] = False
         # Change invert to False and check if it sticks
         self._update_l7rule(l7policy.get('id'), rule1.get('id'), **rule_args)
-        assert not self.bigip_client.rule_has_condition("wrapper_policy",
-                                                        "redirect_to_pool_1",
-                                                        "not_",
-                                                        "qcow2",
-                                                        "Project_" +
-                                                        self.project_tenant_id)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.rule_has_condition("wrapper_policy",
+                                                       "redirect_to_pool_1",
+                                                       "not_",
+                                                       "qcow2",
+                                                       "Project_" +
+                                                       self.project_tenant_id)

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_update.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_update.py
@@ -64,35 +64,37 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
 
         cls.partition = 'Project_' + cls.subnet['tenant_id']
         cls.vs_name = 'Project_' + cls.listener_id
-        cls.bigip = cls.bigip_client
 
     @classmethod
     def resource_cleanup(cls):
         super(L7PolicyRulesTestJSON, cls).resource_cleanup()
 
     def check_policy(self, policy='wrapper_policy'):
-        assert self.bigip.policy_exists(policy, partition=self.partition)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists(policy, partition=self.partition)
 
     def check_rule(self, rule='', policy='wrapper_policy',
                    action=None, condition=None, value=None):
         # Validate BIG-IP has rule
-        assert self.bigip.rule_exists(
-            policy, rule, partition=self.partition)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.rule_exists(
+                policy, rule, partition=self.partition)
 
-        if action:
-            assert self.bigip.rule_has_action(
-                policy, rule, action, partition=self.partition)
+            if action:
+                assert bigip_client.rule_has_action(
+                    policy, rule, action, partition=self.partition)
 
-        if condition:
-            assert self.bigip.rule_has_condition(
-                policy, rule, condition, value, partition=self.partition)
+            if condition:
+                assert bigip_client.rule_has_condition(
+                    policy, rule, condition, value, partition=self.partition)
 
     def check_virtual_server(self):
         # Validate virtual server has policy
         vs_name = 'Project_' + self.listener_id
-        assert self.bigip.virtual_server_exists(vs_name, self.partition)
-        assert self.bigip.virtual_server_has_policy(
-            vs_name, 'wrapper_policy', self.partition)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.virtual_server_exists(vs_name, self.partition)
+            assert bigip_client.virtual_server_has_policy(
+                vs_name, 'wrapper_policy', self.partition)
 
     @test.attr(type='smoke')
     def test_create_policy_no_rule(self):
@@ -104,11 +106,12 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
         policy_id = new_policy['id']
         self.addCleanup(self._delete_l7policy, policy_id)
 
-        assert not self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition, should_exist=False)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists(
+                'wrapper_policy', partition=self.partition, should_exist=False)
 
-        assert not self.bigip.virtual_server_has_policy(
-            self.vs_name, 'wrapper_policy', self.partition)
+            assert not bigip_client.virtual_server_has_policy(
+                self.vs_name, 'wrapper_policy', self.partition)
 
     @test.attr(type='smoke')
     def test_create_policy_one_rule(self):
@@ -249,10 +252,11 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
         # remove both rule and policy and expect policy removed from BIG-IP
         self._delete_l7rule(policy_id, rule_id, wait=True)
         self._delete_l7policy(policy_id, wait=True)
-        assert not self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition, should_exist=False)
-        assert not self.bigip.virtual_server_has_policy(
-            self.vs_name, 'wrapper_policy', self.partition)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists(
+                'wrapper_policy', partition=self.partition, should_exist=False)
+            assert not bigip_client.virtual_server_has_policy(
+                self.vs_name, 'wrapper_policy', self.partition)
 
     @test.attr(type='smoke')
     def test_delete_all_rules(self):
@@ -276,10 +280,11 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
 
         # remove rule and expect policy removed from BIG-IP
         self._delete_l7rule(policy_id, rule_id, wait=True)
-        assert not self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition, should_exist=False)
-        assert not self.bigip.virtual_server_has_policy(
-            self.vs_name, 'wrapper_policy', self.partition)
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists(
+                'wrapper_policy', partition=self.partition, should_exist=False)
+            assert not bigip_client.virtual_server_has_policy(
+                self.vs_name, 'wrapper_policy', self.partition)
 
     @test.attr(type='smoke')
     def test_delete_one_rule(self):
@@ -312,7 +317,8 @@ class L7PolicyRulesTestJSON(base.F5BaseTestCase):
 
         # remove first rule leaving second and expect new policy on BIG-IP
         self._delete_l7rule(policy_id, rule1_id, wait=True)
-        assert self.bigip.policy_exists(
-            'wrapper_policy', partition=self.partition)
-        assert self.bigip.virtual_server_has_policy(
-            self.vs_name, 'wrapper_policy', self.partition)
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.policy_exists(
+                'wrapper_policy', partition=self.partition)
+            assert bigip_client.virtual_server_has_policy(
+                self.vs_name, 'wrapper_policy', self.partition)

--- a/f5lbaasdriver/test/tempest/tests/api/test_pools.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_pools.py
@@ -92,10 +92,11 @@ class PoolTestJSON(base.F5BaseTestCase):
         vs1_name = 'Project_' + first_listener['id']
         vs2_name = 'Project_' + second_listener['id']
         pool_name = 'Project_' + shared_pool['id']
-        assert self.bigip_client.virtual_server_has_pool(
-            vs1_name, self.partition, pool_name) is True
-        assert self.bigip_client.virtual_server_has_pool(
-            vs2_name, self.partition, pool_name) is True
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.virtual_server_has_pool(
+                vs1_name, self.partition, pool_name) is True
+            assert bigip_client.virtual_server_has_pool(
+                vs2_name, self.partition, pool_name) is True
 
         res = self.client.call(self.context, 'get_service_by_loadbalancer_id',
                                loadbalancer_id=self.load_balancer_id)
@@ -152,10 +153,11 @@ class PoolTestJSON(base.F5BaseTestCase):
         vs1_name = 'Project_' + first_listener['id']
         vs2_name = 'Project_' + second_listener['id']
         pool_name = 'Project_' + shared_pool['id']
-        assert self.bigip_client.virtual_server_has_pool(
-            vs1_name, self.partition, pool_name) is True
-        assert self.bigip_client.virtual_server_has_pool(
-            vs2_name, self.partition, pool_name) is True
+        for bigip_client in self.bigip_clients:
+            assert bigip_client.virtual_server_has_pool(
+                vs1_name, self.partition, pool_name) is True
+            assert bigip_client.virtual_server_has_pool(
+                vs2_name, self.partition, pool_name) is True
         # delete shared pool
         self._delete_pool(shared_pool['id'], wait=True)
         res = self.client.call(self.context, 'get_service_by_loadbalancer_id',


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes Tempest test failures when running in a clustered environment.

#### What's this change do?
Modifies test base class to create a list of BIG-IP clients, one
for each BIG-IP under test. Modifies tests to iterate through
list of clients to verify each BIG-IP in a cluster.

#### Where should the reviewer start?
base.py

#### Any background context?
None
