### PR TITLE
docker pull should be run to get latest ansible container from docker registry

### DIFF
--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -37,6 +37,7 @@ EXTRA_VARS="${EXTRA_VARS} neutron_lbaas_init_location=${NEUTRON_INIT_LOC} restar
 EXTRA_VARS="${EXTRA_VARS} f5_global_routed_mode=${GLOBAL_ROUTED_MODE} bigip_netloc=${BIGIP_IP} agent_service_name=f5-openstack-agent.service"
 EXTRA_VARS="${EXTRA_VARS} use_barbican_cert_manager=True neutron_lbaas_shim_install_dest=/usr/lib/python2.7/site-packages/neutron_lbaas/drivers/f5"
 
+sudo -E docker pull docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka
 sudo -E docker run \
 --volumes-from `hostname | xargs` \
 docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka:latest \


### PR DESCRIPTION
@ssorenso 

#### What issues does this address?
Fixes #792 

#### What's this change do?
Added a docker pull just before the docker run statement in the
ansible_install_lbaasv2.sh script, so we get the latest container.

#### Where should the reviewer start?

#### Any background context?
A docker pull command should be run before the docker run for the
ansible container used to deploy the heat plugins and the agent/driver.
If we don't pull, we are prone to using a stale container, whichever one
might exist on the docker host. This could produce difficult to debug
errors.


