### PR TITLE
neutron-lbaas branch being used DOES NOT have eol

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -23,6 +23,7 @@ tempest_12.1.2_undercloud_vxlan tempest_13.0.0_undercloud_vxlan
 # Fixing branch to that specified in the public fork. This is necessary for build on PRs.
 export BRANCH := liberty
 # The branch may contain the text 'stable/' before the OpenStack release name
+# OR it may contain '-eol' after it for the eol tag.
 # To allow this type of branch name and any other to work with the cloud deployment
 # and with Jenkins, we should strip out the forward slash, leaving something like:
 # stable/newton -> stablenewton
@@ -59,7 +60,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 # neutron-lbaas (OpenStack Neutron LBaaS repo for the test cases to run)
 export NEUTRON_LBAAS_DIR := /home/jenkins/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
-export NEUTRON_LBAAS_BRANCH := stable/mitaka
+export NEUTRON_LBAAS_BRANCH := mitaka-eol
 export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(NEUTRON_LBAAS_BRANCH)
 
 


### PR DESCRIPTION
Issues:
Build issues for getting tests to pass.

Problem:
* mitaka is used for neutron-lbaas for tempest tests
  * But stable/mitaka no longer is in use
  * Because we're depending on mitaka, we need to reference the eol tag

Analysis:
* This forces the use of the eol tag for mitaka tag
* This is following the OS convention of eol tagging for EOL'ed versions

Tests:
This is for test building

@jlongstaf 
#### What issues does this address?
Building issues for liberty in nightly

#### What's this change do?
Change the mitaka neutron-lbaas reference to mitaka-eol branch/tag

#### Where should the reviewer start?
The systest/Makefile.

This was tested for `stable/mitaka`, but it fails every time.  In order to get this to simply pass, it HAS to be the eol tag or not mitaka.

#### Any background context?
This is for failing nightly jobs.  The signature that highlights this need is:
```
10:56:50 Exception:
10:56:50 Traceback (most recent call last):
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
10:56:50     status = self.run(options, args)
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/commands/install.py", line 312, in run
10:56:50     wheel_cache
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/basecommand.py", line 269, in populate_requirement_set
10:56:50     session=session, wheel_cache=wheel_cache):
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/req/req_file.py", line 84, in parse_requirements
10:56:50     filename, comes_from=comes_from, session=session
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/download.py", line 418, in get_file_content
10:56:50     resp.raise_for_status()
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/_vendor/requests/models.py", line 862, in raise_for_status
10:56:50     raise HTTPError(http_error_msg, response=self)
10:56:50 HTTPError: 404 Client Error: Not found for url: https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
```