### PR TITLE
Liberty.fixing neutron lbaas branch clone

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -60,8 +60,8 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 # neutron-lbaas (OpenStack Neutron LBaaS repo for the test cases to run)
 export NEUTRON_LBAAS_DIR := /home/jenkins/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
-export NEUTRON_LBAAS_BRANCH := mitaka-eol
-export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(NEUTRON_LBAAS_BRANCH)
+export NEUTRON_LBAAS_BRANCH := stable/mitaka
+export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=mitaka-eol
 
 
 # TLC path and python path requirements


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixing multiple uses of the same variable for what branch to use across our neutron-lbaas specific and openstack's github repos.

#### What's this change do?
Separates the two by using separate settings for both.

#### Where should the reviewer start?
The Makefile.

#### Any background context?
This follows the traces:
```
12:31:29 + rm -rf /home/jenkins/neutron-lbaas
12:31:29 + git clone -b mitaka-eol --single-branch https://github.com/F5Networks/neutron-lbaas.git /home/jenkins/neutron-lbaas
12:31:29 Cloning into '/home/jenkins/neutron-lbaas'...
12:31:29 warning: Could not find remote branch mitaka-eol to clone.
12:31:29 fatal: Remote branch mitaka-eol not found in upstream origin
12:31:29 Makefile:113: recipe for target 'install_test_infra' failed
12:31:29 make[1]: *** [install_test_infra] Error 128
12:31:29 make[1]: Leaving directory '/home-local/jenkins/workspace/openstack/driver/liberty/12.1.2-undercloud-vxlan/systest'
12:31:29 Makefile:163: recipe for target 'tempest_12.1.2_undercloud_vxlan' failed
```
After this latest change and:
```
10:56:50 Exception:
10:56:50 Traceback (most recent call last):
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
10:56:50     status = self.run(options, args)
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/commands/install.py", line 312, in run
10:56:50     wheel_cache
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/basecommand.py", line 269, in populate_requirement_set
10:56:50     session=session, wheel_cache=wheel_cache):
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/req/req_file.py", line 84, in parse_requirements
10:56:50     filename, comes_from=comes_from, session=session
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/download.py", line 418, in get_file_content
10:56:50     resp.raise_for_status()
10:56:50   File "/home/jenkins/neutron-lbaas/.tox/apiv2/local/lib/python2.7/site-packages/pip/_vendor/requests/models.py", line 862, in raise_for_status
10:56:50     raise HTTPError(http_error_msg, response=self)
10:56:50 HTTPError: 404 Client Error: Not found for url: https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka
```
Is the original attempted fix.  This should separate the two issues.