### PR TITLE
Add support for coverage aggregation and publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### ignore sphinx / python stuff
+.contain
 venv/*
 .idea/*
 .venv/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,9 @@ pipeline {
                     . systest/scripts/init_env.sh
 
                     # - record start of build
-                    systest/scripts/record_build_start.sh
+                    if [ "${DONTRECORDTRTLRESULTS}" != "true"  ]; then
+                        systest/scripts/record_build_start.sh
+                    fi
 
                     # - setup ssh agent
                     eval $(ssh-agent -s)
@@ -37,8 +39,11 @@ pipeline {
                     make -C systest $target_name
 
                     # - record results
-                    if [ "${JOB_BASE_NAME}" != "smoke_test" ]; then
-                        systest/scripts/record_results.sh
+                    if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then
+                        systest/scripts/record_publish_agent_coverage.sh
+                        if [ "${DONTRECORDTRTLRESULTS}" != "true"  ]; then
+                            systest/scripts/record_results.sh
+                        fi
                     fi
                 '''
             }

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,9 @@ F5 Driver for OpenStack LBaaSv2
 
 |Build Status| |slack badge|
 
+.. image:: https://coveralls.io/repos/github/F5Networks/f5-openstack-lbaasv2-driver/badge.svg
+:target: https://coveralls.io/github/F5Networks/f5-openstack-lbaasv2-driver
+
 Introduction
 ------------
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,8 +6,16 @@ git+https://github.com/F5Networks/pytest-symbols.git
 git+https://github.com/F5Networks/f5-openstack-test.git@mitaka
 git+https://github.com/openstack/tempest.git@12.0.0
 
-mock==1.3.0
 pytest==2.9.1
 pytest-cov==2.2.1
-decorator==4.0.9
-paramiko==1.16.0
+
+# COMMUNITY CONSTRAINED SECTION
+# Community constrained packages, packages specified here MUST not specify a
+# version.  The versions of these packages are specified at the constraints
+# URL.  If you add a version here it will be ignored, and therefore be
+# misleading to readers of this file.
+-c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=mitaka-eol
+
+mock==IGNORED      # See section comment
+decorator==IGNORED # See section comment
+paramiko==IGNORED  # See section comment

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+export AGENTCOVERAGEDIR := ${AGENTCOVERAGEDIR}
 export BRANCH := mitaka
 export GIT_REMOTE_URL := $(shell git config --get remote.origin.url)
 # The below operations are used for the builds on PR. The two variables are defined by the

--- a/systest/scripts/ansible_install_lbaasv2.sh
+++ b/systest/scripts/ansible_install_lbaasv2.sh
@@ -43,10 +43,3 @@ sudo -E docker run \
 docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka:latest \
 /f5-openstack-ansible/playbooks/agent_driver_deploy.yaml \
 --extra-vars "${EXTRA_VARS}"
-
-# Also install the F5 OpenStack ML2 Mechanism Driver via ansible
-sudo -E docker run \
---volumes-from `hostname | xargs` \
-docker-registry.pdbld.f5net.com/openstack-test-ansibleserver-prod/mitaka:latest \
-/f5-openstack-ansible/playbooks/ml2_driver_deploy.yaml \
---extra-vars "${EXTRA_VARS}"

--- a/systest/scripts/init_env.sh
+++ b/systest/scripts/init_env.sh
@@ -4,6 +4,9 @@ set -ex
 
 # - JOB_NAME is provided by Jenkins
 #   (eg. "openstack/driver/liberty/12.1.1-undercloud-vxlan")
+
+git clone --single-branch --depth=1 -b mitaka https://github.com/F5Networks/f5-openstack-agent.git /home/jenkins/agent_commit
+export AGENT_HASH=$(cd /home/jenkins/agent_commit && git rev-parse HEAD | xargs)
 export CI_PROGRAM=$(echo $JOB_NAME | cut -d "/" -f 1)
 export CI_PROJECT=$(echo $JOB_NAME | cut -d "/" -f 2)
 export CI_BRANCH=$(echo $JOB_NAME | cut -d "/" -f 3)
@@ -12,6 +15,10 @@ job_dirname="${CI_PROGRAM}.${CI_PROJECT}.${CI_BRANCH}.${JOB_BASE_NAME}"
 build_dirname="${JOB_BASE_NAME}-${BUILD_ID}"
 export CI_RESULTS_DIR="/home/jenkins/results/${job_dirname}/${build_dirname}"
 export CI_BUILD_SUMMARY="${CI_RESULTS_DIR}/ci-build.yaml"
+# The following logic enables combined coverage reporting.
+export COVERAGEROOT=/testlab/openstack/testresults/coverage/agent/${CI_BRANCH}/${AGENT_HASH}
+export AGENTCOVERAGEDIR=${COVERAGEROOT}/from_driver/${BUILD_ID}_${JOB_BASE_NAME}
+export PYTHONDONTWRITEBYTECODE=1
 
 # - source this job's environment variables
 export CI_ENV_FILE=systest/${JOB_BASE_NAME}.env

--- a/systest/scripts/record_publish_agent_coverage.sh
+++ b/systest/scripts/record_publish_agent_coverage.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script combines and publishes the results of the tests run on a
+# particular commit for the agent.
+
+echo ${COVERAGEROOT}
+ls -al ${COVERAGEROOT}
+cd ${COVERAGEROOT} && mkdir -p coveragefiles && \
+find . -iname ".coverage_*" -exec cp -f {} coveragefiles/ \; && \
+coverage combine ${COVERAGEROOT}/coveragefiles/.coverage*
+cp -f ${COVERAGEROOT}/.coverage ${COVERAGEROOT}/source_code
+cp -f ${COVERAGEROOT}/.coveragerc ${COVERAGEROOT}/source_code
+source /home/jenkins/coverallstoken
+
+cd ${COVERAGEROOT}/source_code && coveralls -v


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #827

#### What's this change do?

If the driver Jenkins-driven tests run after the agent tests have run for a particular version (commit) of the agent this PR with aggregate and publish that coverage data.
