### PR TITLE
Revert port data since we want all releases to create ports in consis…

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -549,7 +549,7 @@ class LBaaSv2PluginCallbacksRPC(object):
                     if device_id:
                         port_data['device_id'] = device_id
                     port_data[portbindings.HOST_ID] = host
-                    port_data[portbindings.VNIC_TYPE] = "f5appliance"
+                    port_data[portbindings.VIF_TYPE] = constants.VIF_TYPE
                     if ('binding:capabilities' in
                             portbindings.EXTENDED_ATTRIBUTES_2_0['ports']):
                         port_data['binding:capabilities'] = {


### PR DESCRIPTION
Merge failures prevented us from creating the ports consistently.