### PR TITLE
Newton ml2 compatibility changes

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -232,10 +232,8 @@ class LoadBalancerManager(EntityManager):
                     'status': q_const.PORT_STATUS_ACTIVE
                 }
                 port_data[portbindings.HOST_ID] = agent_host
-                port_data[portbindings.VNIC_TYPE] = "f5appliance"
-                port_data[portbindings.PROFILE] = {
-                    'agent_id': agent_host
-                }
+                port_data[portbindings.VNIC_TYPE] = "baremetal"
+                port_data[portbindings.PROFILE] = {}
                 driver.plugin.db._core_plugin.update_port(
                     context,
                     loadbalancer.vip_port_id,


### PR DESCRIPTION
In order for the driver/agent to utilize the ML2 driver, some changes to the port creation logic need to be made.

The ML2 driver will only bind ports that are of type 'baremetal', for the BIG-IP. There needs to be a way for the agent to communicate whether or not to create 'baremetal' vs. 'normal' ports. Also, there are a couple of issues with the way that we specify attributes for port creation:

device_id --> is the loadbalancer id
host_id --> is the agent host name
vnic_type --> will be baremetal for compatibility with the ML2 driver.
binding_profile --> we have this but it is currently unused.

There a corresponding Agent change