### PR TITLE
Migrate stable/newton references to newton-eol

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
--c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 -e .
-git+https://github.com/openstack/neutron.git@stable/newton
+
+git+https://github.com/openstack/neutron.git@newton-eol
 git+https://github.com/F5Networks/neutron-lbaas.git@stable/newton
 git+https://github.com/F5Networks/pytest-symbols.git
 git+https://github.com/F5Networks/f5-openstack-test.git@stable/newton
@@ -12,6 +12,8 @@ f5-sdk==2.3.3
 # version.  The versions of these packages are specified at the constraints
 # URL.  If you add a version here it will be ignored, and therefore be
 # misleading to readers of this file.
+#
+# NOTE: As of OCT-26-2017, upper-constraints is still at stable/newton, not newton-eol.
 -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 
 mock==IGNORED      # See section comment

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -54,6 +54,7 @@ export TEMPEST_REPO := http://git.openstack.org/openstack/tempest
 export NEUTRON_LBAAS_DIR := /home/jenkins/neutron-lbaas
 export NEUTRON_LBAAS_REPO := https://github.com/F5Networks/neutron-lbaas.git
 
+# NOTE: As of OCT-26-2017, upper-constraints is still at stable/newton, not newton-eol.
 export NEUTRON_LBAAS_BRANCH := stable/newton
 export UPPER_CONSTRAINTS_FILE := https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=$(NEUTRON_LBAAS_BRANCH)
 


### PR DESCRIPTION

@ssorenso 
#### What issues does this address?
#857 
Newton branches of openstack/neutron and openstack/neutron-lbaas
have moved to end-of-life.

#### What's this change do?
Changes requirements from stable/newton to newton-eol.

#### Where should the reviewer start?
requirements.test.txt

#### Any background context?
No