### PR TITLE
l7policy_rules test introduces timeout checks as well as retries

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -13,6 +13,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import subprocess
+
+from collections import namedtuple
 from time import sleep
 
 from neutron_lbaas.tests.tempest.v2.api import base
@@ -32,7 +35,19 @@ LOG = logging.getLogger(__name__)
 class F5BaseTestCase(base.BaseTestCase):
     """This class picks non-admin credentials and run the tempest tests."""
 
+    config_file = "/tmp/tempest.bigip.cfg"
     _lbs_to_delete = []
+    ssh_cmd = \
+        str("ssh -F /home/ubuntu/testenv_symbols/testenv_ssh_config"
+            " openstack_bigip")
+    __extract_cmd = '''{} << EOF
+tmsh -c \"cd /;
+list sys folder recursive one-line" | cut -d " " -f3 |
+while read f; do echo \"====================\";
+echo \"Folder $f\"; tmsh -c "cd /$f; list\"; done;
+exit
+EOF'''.format(ssh_cmd)
+    __ucs_cmd_fmt = "{} tmsh {} /sys ucs /tmp/backup.ucs"
     try_cnt_max = 3
     sleep_seconds = 5
 
@@ -89,6 +104,79 @@ class F5BaseTestCase(base.BaseTestCase):
             assert not method(*args, **kwargs)
         cls.assert_with_retry(negative, *args, **kwargs)
 
+    @staticmethod
+    def __exec_shell(stdin, shell=False):
+        Result = namedtuple('Result', 'stdout, stdin, stderr, exit_status')
+        try:
+            stdout = subprocess.check_output(stdin, shell=shell)
+            stderr = ''
+            exit_status = 0
+        except subprocess.CalledProcessError as error:
+            stderr = str(error)
+            stdout = error.output
+            exit_status = error.returncode
+
+        return Result(stdout, stdin, stderr, exit_status)
+
+    @classmethod
+    def _get_current_bigip_cfg(cls):
+        """Get and return the current BIG-IP Config
+
+        This method will perform the action of collecting BIG-IP config data.
+        """
+        results = cls.__exec_shell(cls.__extract_cmd, shell=True)
+        if results.exit_status:
+            raise RuntimeError(
+                "Could not extract bigip data!\nstderr:'{}'"
+                ";stdout'{}' ({})".format(results.stderr, results.stdout,
+                                          results.exit_status))
+        return results.stdout
+
+    @classmethod
+    def _get_existing_bigip_cfg(cls):
+        """Extracts the BIG-IP config and stores it within instance
+
+        This method will hold a copy of the existing BIG-IP config for later
+        comparison.
+        """
+        result = cls._get_current_bigip_cfg()
+        with open(cls.config_file, 'w') as fh:
+            fh.write(result)
+
+    @classmethod
+    def _get_exiting_neutron_cfg(cls):
+        """Place holder for attaining neutron's current cfg before test"""
+        pass
+
+    @classmethod
+    def _resulting_bigip_cfg(cls):
+        result = cls._get_current_bigip_cfg()
+        with open(cls.config_file) as fh:
+            try:
+                assert result == fh.read(), \
+                    "Test was unable to clean up BIG-IP cfg"
+            except AssertionError:
+                cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'load'),
+                                 shell=True)
+                sleep(5)  # after nuke, BIG-IP needs a delay...
+                raise
+
+    @classmethod
+    def _resulting_neutron_db(cls):
+        """Place holder for sanity check code for pollutted neutron DB"""
+        pass
+
+    @classmethod
+    def check_resulting_cfg(cls):
+        """Check the current BIG-IP cfg agianst previous Reset upon Error
+
+        This classmethod will check the current BIG-IP config and raise if
+        there are any changes from the previous snap-shot.  Upon raise, the
+        method will attempt to clear the BIG-IP back to the previous config
+        """
+        cls._resulting_bigip_cfg()
+        cls._resulting_neutron_db()
+
     @classmethod
     def resource_setup(cls):
         """Setup the clients and fixtures for test suite.
@@ -101,6 +189,8 @@ class F5BaseTestCase(base.BaseTestCase):
         with the first address in CONF.f5_lbaasv2_driver.icontrol_hostname.
         """
         super(F5BaseTestCase, cls).resource_setup()
+        cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'save'), True)
+        # Where the neutron db collection between resource setups goes
 
         cls.bigip_clients = []
         for host in CONF.f5_lbaasv2_driver.icontrol_hostname.split(","):
@@ -113,6 +203,17 @@ class F5BaseTestCase(base.BaseTestCase):
         cls.plugin_rpc = (
             plugin_rpc_client.F5PluginRPCClient()
         )
+
+    def setUp(self):
+        """Performs basic teardown operations for assocaited tests"""
+        self._get_existing_bigip_cfg()
+        self._get_exiting_neutron_cfg()
+        super(F5BaseTestCase, self).setUp()
+
+    def tearDown(self):
+        """Performs basic teardown operations for assocaited tests"""
+        self.check_resulting_cfg()
+        super(F5BaseTestCase, self).tearDown()
 
 
 class F5BaseAdminTestCase(base.BaseTestCase):

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy.py
@@ -37,44 +37,43 @@ class L7PolicyTestJSON(base.F5BaseTestCase):
     3) Creating a L7 policy with a REDIRECT_POOL action.
     """
 
-    @classmethod
-    def resource_setup(cls):
-        super(L7PolicyTestJSON, cls).resource_setup()
+    def resource_setup(self):
+        super(L7PolicyTestJSON, self).resource_setup()
         if not test.is_extension_enabled('lbaasv2', 'network'):
             msg = "lbaas extension not enabled."
-            raise cls.skipException(msg)
+            raise self.skipException(msg)
         network_name = data_utils.rand_name('network')
-        cls.network = cls.create_network(network_name)
-        cls.subnet = cls.create_subnet(cls.network)
-        cls.create_lb_kwargs = {'tenant_id': cls.subnet['tenant_id'],
+        self.network = cls.create_network(network_name)
+        self.subnet = cls.create_subnet(cls.network)
+        self.create_lb_kwargs = {'tenant_id': cls.subnet['tenant_id'],
                                 'vip_subnet_id': cls.subnet['id']}
-        cls.load_balancer = \
+        selfload_balancer = \
             cls._create_active_load_balancer(**cls.create_lb_kwargs)
-        cls.load_balancer_id = cls.load_balancer['id']
+        self.load_balancer_id = cls.load_balancer['id']
 
         # Create listener for tests
-        cls.create_listener_kwargs = {'loadbalancer_id': cls.load_balancer_id,
+        self.create_listener_kwargs = {'loadbalancer_id': cls.load_balancer_id,
                                       'protocol': "HTTP",
                                       'protocol_port': "80"}
-        cls.listener = (
+        self.listener = (
             cls._create_listener(**cls.create_listener_kwargs))
-        cls.listener_id = cls.listener['id']
+        self.listener_id = cls.listener['id']
 
         # Create pool for tests
-        cls.create_pool_kwargs = {'listener_id': cls.listener_id,
+        self.create_pool_kwargs = {'listener_id': cls.listener_id,
                                   'protocol': "HTTP",
                                   'lb_algorithm': "ROUND_ROBIN"}
-        cls.pool = (
+        self.pool = (
             cls._create_pool(**cls.create_pool_kwargs))
-        cls.pool_id = cls.pool['id']
+        self.pool_id = cls.pool['id']
 
         # Create basic args for policy creation
-        cls.create_l7policy_kwargs = {'listener_id': cls.listener_id,
+        self.create_l7policy_kwargs = {'listener_id': cls.listener_id,
                                       'admin_state_up': "true"}
 
         # Get a client to emulate the agent's behavior.
-        cls.client = cls.plugin_rpc.get_client()
-        cls.context = cls.plugin_rpc.get_context()
+        self.client = cls.plugin_rpc.get_client()
+        self.context = cls.plugin_rpc.get_context()
 
     @classmethod
     def resource_cleanup(cls):


### PR DESCRIPTION
### Introduces timeout checks as well as retries

#### Issues:
Fixes #832

#### Problems:
* Often cfg cruft on failed tests or misbehaving tests in tempest on BIGIP
  * This often results in tests that fail due to lingering cruft
* There are numerous events where there is a false assertion
  * This is done because the BIG-IP has not yet had the chance to impliment
   * Provisioning status does not get tracked on rules and policies

#### Analysis:
* This will snap-shot the setUp's BIG-IP cfg
* Compare against the end-of test tearDown's cfg
* If these differ, then a raised assertionError occurs
  * This preserves catching tests red-handed
  * This preserves tests that would otherwise fail due to lingering
     cruft
* This introduces a try/retry up to 3 times with 3 second delimit

#### Tests:
This is a test change for a test bug.

### Reviewers
@richbrowne 

#### What's this change do?
* This will snap-shot the setUp's BIG-IP cfg
* Compare against the end-of test tearDown's cfg
* If these differ, then a raised assertionError occurs
  * This preserves catching tests red-handed
  * This preserves tests that would otherwise fail due to lingering
     cruft
* This introduces a try/retry up to 3 times with 3 second delimit for l7policy rules test

#### Where should the reviewer start?
Running this in tempest tests for `test_l7policy_rules.py`, but also the rest of all tempest tests as well as this should also resolve conflicts left on the BIG-IP.

#### Any background context?
The BIG-IP was being left with config issues that needed to be cleaned up in certain circumstances.  Some items that left this config on was when tempest did not behave properly and timed out too soon.  This was often introduced with a retry-wait-retry loop introduced to resolve flakiness in the l7policy rules tests.