### PR TITLE
Feature.agent ha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,9 @@ systest/test_results
 # vim
 *~
 *.swp
+
+# eclipse pydev
+.project
+.pydevproject
+.settings/
+

--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -39,7 +39,6 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
         LOG.debug('Getting agent for loadbalancer %s with env %s' %
                   (loadbalancer_id, env))
 
-        lbaas_agent = None
         with context.session.begin(subtransactions=True):
             # returns {'agent': agent_dict}
             lbaas_agent = plugin.db.get_agent_hosting_loadbalancer(
@@ -48,11 +47,12 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
             )
             # if the agent bound to this loadbalancer is alive, return it
             if lbaas_agent is not None:
-
-                if not lbaas_agent['agent']['alive'] and env is not None:
-                    # The agent bound to this loadbalancer is not live;
-                    # find another agent in the same environment
-                    # which environment group is the agent in
+                if (not lbaas_agent['agent']['alive'] or
+                        not lbaas_agent['agent']['admin_state_up']) and \
+                        env is not None:
+                    # The agent bound to this loadbalancer is not live
+                    # or is not active. Find another agent in the same
+                    # environment and environment group if possible
                     ac = self.deserialize_agent_configurations(
                         lbaas_agent['agent']['configurations']
                     )
@@ -62,23 +62,53 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
                     else:
                         gn = 1
 
-                    # find all active agents matching the environment
-                    # and group number.
-                    env_agents = self.get_agents_in_env(
-                        context,
-                        plugin,
-                        env,
-                        group=gn,
-                        active=True
-                    )
-                    LOG.debug("Primary lbaas agent is dead, env_agents: %s",
-                              env_agents)
-                    if env_agents:
-                        # return the first active agent in the
-                        # group to process this task
-                        lbaas_agent = {'agent': env_agents[0]}
+                    reassigned_agent = self.rebind_loadbalancers(
+                        context, plugin, env, gn, lbaas_agent['agent'])
+                    if reassigned_agent:
+                        lbaas_agent = {'agent': reassigned_agent}
 
             return lbaas_agent
+
+    def rebind_loadbalancers(
+            self, context, plugin, env, group, current_agent):
+        env_agents = self.get_agents_in_env(context, plugin, env,
+                                            group=group, active=True)
+        if env_agents:
+            reassigned_agent = env_agents[0]
+            bindings = \
+                context.session.query(
+                    agent_scheduler.LoadbalancerAgentBinding).filter_by(
+                        agent_id=current_agent['id']).all()
+            for binding in bindings:
+                binding.agent_id = reassigned_agent['id']
+                context.session.add(binding)
+            LOG.debug("%s Loadbalancers bound to agent %s now bound to %s" %
+                      (len(bindings),
+                       current_agent['id'],
+                       reassigned_agent['id']))
+            return reassigned_agent
+        else:
+            return None
+
+    def get_dead_agents_in_env(
+            self, context, plugin, env, group=None):
+        return_agents = []
+        all_agents = self.get_agents_in_env(context,
+                                            plugin,
+                                            env,
+                                            group,
+                                            active=None)
+
+        for agent in all_agents:
+            if not plugin.db.is_eligible_agent(active=True, agent=agent):
+                if not agent['admin_state_up']:
+                    return_agents.append(agent)
+        return return_agents
+
+    def scrub_dead_agents(self, context, plugin, env, group=None):
+        dead_agents = self.get_dead_agents_in_env(context, plugin, env, group)
+        for agent in dead_agents:
+            self.rebind_loadbalancers(context, plugin, env, group, agent)
 
     def get_agents_in_env(
             self, context, plugin, env, group=None, active=None):
@@ -247,4 +277,5 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
                        'lbaas agent %(agent_id)s'),
                       {'loadbalancer_id': loadbalancer.id,
                        'agent_id': chosen_agent['id']})
+
             return chosen_agent

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -124,6 +124,10 @@ class F5DriverV2(object):
         post_fork_callback.__name__ += '_' + str(self.env)
         return post_fork_callback
 
+    def _handle_driver_error(self, context, loadbalancer,
+                             loadbalancer_id, status):
+        pass
+
 
 class EntityManager(object):
     '''Parent for all managers defined in this module.'''

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -19,12 +19,13 @@ from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 
 from neutron.api.v2 import attributes
-from neutron.common import constants as neutron_const
 from neutron.common import rpc as neutron_rpc
 from neutron.db import agents_db
 from neutron.extensions import portbindings
 from neutron.plugins.common import constants as plugin_constants
 from neutron_lbaas.db.loadbalancer import models
+from neutron_lbaas.services.loadbalancer import constants as nlb_constant
+from neutron_lib import constants as neutron_const
 
 from f5lbaasdriver.v2.bigip import constants_v2 as constants
 
@@ -43,54 +44,53 @@ class LBaaSv2PluginCallbacksRPC(object):
         topic = constants.TOPIC_PROCESS_ON_HOST_V2
         if self.driver.env:
             topic = topic + "_" + self.driver.env
-
         self.conn = neutron_rpc.create_connection(new=True)
         self.conn.create_consumer(
             topic,
-            [self,
-             agents_db.AgentExtRpcCallback(self.driver.plugin.db)],
+            [self, agents_db.AgentExtRpcCallback(self.driver.plugin.db)],
             fanout=False)
         self.conn.consume_in_threads()
 
-    # get a list of loadbalancer ids which are active on this agent host
+    # change the admin_state_up of the an agent
     @log_helpers.log_method_call
-    def get_active_loadbalancers_for_agent(self, context, host=None):
-        """Get a list of loadbalancers active on this host."""
+    def set_agent_admin_state(self, context, admin_state_up, host=None):
+        """Set the admin_up_state of an agent."""
+        if not host:
+            LOG.error('tried to set agent admin_state_up without host')
+            return False
         with context.session.begin(subtransactions=True):
-            if not host:
-                return []
-            agents = self.driver.plugin.db.get_lbaas_agents(
-                context,
-                filters={'host': [host]}
-            )
-            if not agents:
-                return []
-            elif len(agents) > 1:
-                LOG.warning('Multiple lbaas agents found on host %s' % host)
-            lbs = self.driver.plugin.db.list_loadbalancers_on_lbaas_agent(
-                context,
-                agents[0].id
-            )
-            lb_ids = [loadbalancer.id
-                      for loadbalancer in lbs]
-            active_lb_ids = set()
-            lbs = self.driver.plugin.db.get_loadbalancers(
-                context,
-                filters={
-                    'status': [plugin_constants.ACTIVE],
-                    'id': lb_ids,
-                    'admin_state_up': [True]
-                })
-            for lb in lbs:
-                active_lb_ids.add(lb.id)
-            return active_lb_ids
+            query = context.session.query(agents_db.Agent)
+            query = query.filter(
+                agents_db.Agent.agent_type ==
+                nlb_constant.AGENT_TYPE_LOADBALANCERV2,
+                agents_db.Agent.host == host)
+            try:
+                agent = query.one()
+                if not agent.admin_state_up == admin_state_up:
+                    agent.admin_state_up = admin_state_up
+                    context.session.add(agent)
+            except Exception as exc:
+                LOG.error('query for agent produced: %s' % str(exc))
+                return False
+        return True
+
+    # change the admin_state_up of the an agent
+    @log_helpers.log_method_call
+    def scrub_dead_agents(self, context, env, group, host=None):
+        """Remove all non-alive or admin down agents."""
+        LOG.debug('scrubing dead agent bindings')
+        with context.session.begin(subtransactions=True):
+            try:
+                self.driver.scheduler.scrub_dead_agents(
+                    context, self.driver.plugin, env, group=None)
+            except Exception as exc:
+                LOG.error('scub dead agents exception: %s' % str(exc))
+                return False
+        return True
 
     @log_helpers.log_method_call
     def get_service_by_loadbalancer_id(
-            self,
-            context,
-            loadbalancer_id=None,
-            host=None):
+            self, context, loadbalancer_id=None, host=None):
         """Get the complete service definition by loadbalancer_id."""
         service = {}
         with context.session.begin(subtransactions=True):
@@ -109,13 +109,11 @@ class LBaaSv2PluginCallbacksRPC(object):
                 # the preceeding get call returns a nested dict, unwind
                 # one level if necessary
                 agent = (agent['agent'] if 'agent' in agent else agent)
-                service = self.driver.service_builder.build(context,
-                                                            lb,
-                                                            agent)
+                service = self.driver.service_builder.build(
+                    context, lb, agent)
             except Exception as e:
                 LOG.error("Exception: get_service_by_loadbalancer_id: %s",
                           e.message)
-
             return service
 
     @log_helpers.log_method_call
@@ -123,14 +121,11 @@ class LBaaSv2PluginCallbacksRPC(object):
         """Get all loadbalancers for this group in this env."""
         loadbalancers = []
         plugin = self.driver.plugin
-
         with context.session.begin(subtransactions=True):
+            self.driver.scheduler.scrub_dead_agents(
+                context, plugin, env, group)
             agents = self.driver.scheduler.get_agents_in_env(
-                context,
-                self.driver.plugin,
-                env,
-                group)
-
+                context, plugin, env, group, active=None)
             for agent in agents:
                 agent_lbs = plugin.db.list_loadbalancers_on_lbaas_agent(
                     context,
@@ -151,19 +146,14 @@ class LBaaSv2PluginCallbacksRPC(object):
 
     @log_helpers.log_method_call
     def get_active_loadbalancers(self, context, env, group=None, host=None):
-        """Get all loadbalancers for this group in this env."""
+        """Get active loadbalancers for this group in this env."""
         loadbalancers = []
         plugin = self.driver.plugin
-
         with context.session.begin(subtransactions=True):
+            self.driver.scheduler.scrub_dead_agents(
+                context, plugin, env, group)
             agents = self.driver.scheduler.get_agents_in_env(
-                context,
-                self.driver.plugin,
-                env,
-                group=group,
-                active=True
-            )
-
+                context, plugin, env, group, active=None)
             for agent in agents:
                 agent_lbs = plugin.db.list_loadbalancers_on_lbaas_agent(
                     context,
@@ -171,7 +161,6 @@ class LBaaSv2PluginCallbacksRPC(object):
                 )
                 for lb in agent_lbs:
                     if lb.provisioning_status == plugin_constants.ACTIVE:
-
                         loadbalancers.append(
                             {
                                 'agent_host': agent['host'],
@@ -179,7 +168,6 @@ class LBaaSv2PluginCallbacksRPC(object):
                                 'tenant_id': lb.tenant_id
                             }
                         )
-
         if host:
             return [lb for lb in loadbalancers if lb['agent_host'] == host]
         else:
@@ -187,17 +175,14 @@ class LBaaSv2PluginCallbacksRPC(object):
 
     @log_helpers.log_method_call
     def get_pending_loadbalancers(self, context, env, group=None, host=None):
-        """Get all loadbalancers for this group in this env."""
+        """Get pending loadbalancers for this group in this env."""
         loadbalancers = []
         plugin = self.driver.plugin
-
         with context.session.begin(subtransactions=True):
+            self.driver.scheduler.scrub_dead_agents(
+                context, plugin, env, group)
             agents = self.driver.scheduler.get_agents_in_env(
-                context,
-                self.driver.plugin,
-                env,
-                group)
-
+                context, plugin, env, group, active=None)
             for agent in agents:
                 agent_lbs = plugin.db.list_loadbalancers_on_lbaas_agent(
                     context,
@@ -206,7 +191,6 @@ class LBaaSv2PluginCallbacksRPC(object):
                 for lb in agent_lbs:
                     if (lb.provisioning_status != plugin_constants.ACTIVE and
                             lb.provisioning_status != plugin_constants.ERROR):
-
                         loadbalancers.append(
                             {
                                 'agent_host': agent['host'],
@@ -214,34 +198,56 @@ class LBaaSv2PluginCallbacksRPC(object):
                                 'tenant_id': lb.tenant_id
                             }
                         )
-
         if host:
             return [lb for lb in loadbalancers if lb['agent_host'] == host]
         else:
             return loadbalancers
 
     @log_helpers.log_method_call
-    def update_loadbalancer_stats(self,
-                                  context,
-                                  loadbalancer_id=None,
-                                  stats=None):
+    def get_errored_loadbalancers(self, context, env, group=None, host=None):
+        """Get pending loadbalancers for this group in this env."""
+        loadbalancers = []
+        plugin = self.driver.plugin
+        with context.session.begin(subtransactions=True):
+            self.driver.scheduler.scrub_dead_agents(
+                context, plugin, env, group)
+            agents = self.driver.scheduler.get_agents_in_env(
+                context, plugin, env, group, active=None)
+            for agent in agents:
+                agent_lbs = plugin.db.list_loadbalancers_on_lbaas_agent(
+                    context,
+                    agent.id
+                )
+                for lb in agent_lbs:
+                    if (lb.provisioning_status == plugin_constants.ERROR):
+                        loadbalancers.append(
+                            {
+                                'agent_host': agent['host'],
+                                'lb_id': lb.id,
+                                'tenant_id': lb.tenant_id
+                            }
+                        )
+        if host:
+            return [lb for lb in loadbalancers if lb['agent_host'] == host]
+        else:
+            return loadbalancers
+
+    @log_helpers.log_method_call
+    def update_loadbalancer_stats(
+            self, context, loadbalancer_id=None, stats=None):
         """Update service stats."""
         with context.session.begin(subtransactions=True):
             try:
                 self.driver.plugin.db.update_loadbalancer_stats(
-                    context,
-                    loadbalancer_id,
-                    stats
+                    context, loadbalancer_id, stats
                 )
             except Exception as e:
                 LOG.error('Exception: update_loadbalancer_stats: %s',
                           e.message)
 
     @log_helpers.log_method_call
-    def update_loadbalancer_status(self, context,
-                                   loadbalancer_id=None,
-                                   status=None,
-                                   operating_status=None):
+    def update_loadbalancer_status(self, context, loadbalancer_id=None,
+                                   status=None, operating_status=None):
         """Agent confirmation hook to update loadbalancer status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -270,12 +276,9 @@ class LBaaSv2PluginCallbacksRPC(object):
         self.driver.plugin.db.delete_loadbalancer(context, loadbalancer_id)
 
     @log_helpers.log_method_call
-    def update_listener_status(
-            self,
-            context,
-            listener_id=None,
-            provisioning_status=plugin_constants.ERROR,
-            operating_status=None):
+    def update_listener_status(self, context, listener_id=None,
+                               provisioning_status=plugin_constants.ERROR,
+                               operating_status=None):
         """Agent confirmation hook to update listener status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -303,12 +306,9 @@ class LBaaSv2PluginCallbacksRPC(object):
         self.driver.plugin.db.delete_listener(context, listener_id)
 
     @log_helpers.log_method_call
-    def update_pool_status(
-            self,
-            context,
-            pool_id=None,
-            provisioning_status=plugin_constants.ERROR,
-            operating_status=None):
+    def update_pool_status(self, context, pool_id=None,
+                           provisioning_status=plugin_constants.ERROR,
+                           operating_status=None):
         """Agent confirmations hook to update pool status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -335,12 +335,9 @@ class LBaaSv2PluginCallbacksRPC(object):
         self.driver.plugin.db.delete_pool(context, pool_id)
 
     @log_helpers.log_method_call
-    def update_member_status(
-            self,
-            context,
-            member_id=None,
-            provisioning_status=None,
-            operating_status=None):
+    def update_member_status(self, context, member_id=None,
+                             provisioning_status=None,
+                             operating_status=None):
         """Agent confirmations hook to update member status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -368,11 +365,8 @@ class LBaaSv2PluginCallbacksRPC(object):
 
     @log_helpers.log_method_call
     def update_health_monitor_status(
-            self,
-            context,
-            health_monitor_id,
-            provisioning_status=plugin_constants.ERROR,
-            operating_status=None):
+            self, context, health_monitor_id,
+            provisioning_status=plugin_constants.ERROR, operating_status=None):
         """Agent confirmation hook to update health monitor status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -399,12 +393,9 @@ class LBaaSv2PluginCallbacksRPC(object):
         self.driver.plugin.db.delete_healthmonitor(context, healthmonitor_id)
 
     @log_helpers.log_method_call
-    def update_l7policy_status(
-            self,
-            context,
-            l7policy_id=None,
-            provisioning_status=plugin_constants.ERROR,
-            operating_status=None):
+    def update_l7policy_status(self, context, l7policy_id=None,
+                               provisioning_status=plugin_constants.ERROR,
+                               operating_status=None):
         """Agent confirmation hook to update l7 policy status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -433,13 +424,9 @@ class LBaaSv2PluginCallbacksRPC(object):
         self.driver.plugin.db.delete_l7policy(context, l7policy_id)
 
     @log_helpers.log_method_call
-    def update_l7rule_status(
-            self,
-            context,
-            l7rule_id=None,
-            l7policy_id=None,
-            provisioning_status=plugin_constants.ERROR,
-            operating_status=None):
+    def update_l7rule_status(self, context, l7rule_id=None, l7policy_id=None,
+                             provisioning_status=plugin_constants.ERROR,
+                             operating_status=None):
         """Agent confirmation hook to update l7 policy status."""
         with context.session.begin(subtransactions=True):
             try:
@@ -741,7 +728,7 @@ class LBaaSv2PluginCallbacksRPC(object):
     # which can not efficiently mapped back to a particulare agent
     @log_helpers.log_method_call
     def get_clusterwide_agent(self, context, env, group, host=None):
-        """Get an agent to perform clusterwide tasks"""
+        """Get an agent to perform clusterwide tasks."""
         LOG.debug('getting agent to perform clusterwide tasks')
         with context.session.begin(subtransactions=True):
             if (env, group) in self.cluster_wide_agents:

--- a/f5lbaasdriver/v2/bigip/test/test_agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/test/test_agent_scheduler.py
@@ -55,6 +55,27 @@ def test_schedule():
     assert agent
 
 
+def test_rebind_loadbalancers():
+
+    plugin = mock.MagicMock()
+    context = mock.MagicMock()
+    sched = agent_scheduler.TenantScheduler()
+    sched.get_agents_in_env = mock.MagicMock(name='get_agents_in_env')
+    agents_in_env = [{'id': 'test_agent_2_id',
+                      'alive': True,
+                      'admin_state_up': True,
+                      'configurations': {
+                          'environment_prefix': 'prod',
+                          'environment_group_number': 2}}]
+    sched.get_agents_in_env.return_value = agents_in_env
+    return_all = [type('test', (), {})()]
+    context.session.query.all = mock.MagicMock(name='all',
+                                               return_value=return_all)
+    context.session.add = mock.MagicMock(name='add', return_value=None)
+    sched.rebind_loadbalancers(context, plugin, 'prod',
+                               2, agents_in_env[0])
+
+
 def test_get_lbaas_agent_hosting_loadbalancer_none():
     mock_plugin = mock.MagicMock(name='plugin')
     mock_plugin.db.get_agent_hosting_loadbalancer.return_value = None
@@ -92,7 +113,17 @@ def test_deserialize_agent_configurations_is_dict():
 def test_schedule_get_active_agent():
     mock_plugin = mock.MagicMock(name='plugin')
     mock_plugin.db.get_agent_hosting_loadbalancer.return_value = \
-        {'agent': {'alive': True, 'id': 'test_agent_id'}}
+        {
+            'agent': {
+                'alive': True,
+                'id': 'test_agent_id',
+                'admin_state_up': True,
+                'configurations': {
+                    'environment_prefix': 'prod',
+                    'environment_group_number': 2
+                }
+            }
+        }
     mock_cxt = mock.MagicMock(name='context')
     lb_id = 'test_lb_id'
     sched = agent_scheduler.TenantScheduler()
@@ -106,7 +137,13 @@ def test_get_lbaas_agent_hosting_loadbalancer_agent_dead():
     mock_plugin = mock.MagicMock(name='plugin')
     fake_agent = {
         'agent': {
-            'alive': False, 'id': 'test_agent_id', 'configurations': {}
+            'alive': False,
+            'id': 'test_agent_id',
+            'admin_state_up': True,
+            'configurations': {
+                'environment_prefix': 'prod',
+                'environment_group_number': 2
+            }
         }
     }
     mock_plugin.db.get_agent_hosting_loadbalancer.return_value = fake_agent
@@ -121,7 +158,11 @@ def test_get_lbaas_agent_hosting_loadbalancer_agent_dead_has_env_gn():
     mock_plugin = mock.MagicMock(name='plugin')
     fake_agent = {
         'agent': {
-            'alive': False, 'id': 'test_agent_id', 'configurations': {
+            'alive': False,
+            'id': 'test_agent_id',
+            'admin_state_up': True,
+            'configurations': {
+                'environment_prefix': 'prod',
                 'environment_group_number': 2
             }
         }
@@ -136,19 +177,24 @@ def test_get_lbaas_agent_hosting_loadbalancer_agent_dead_has_env_gn():
 
 def test_get_lbaas_agent_hosting_loadbalancer_agent_dead_env_agents_active():
     mock_plugin = mock.MagicMock(name='plugin')
-    fake_agent = {
-        'agent': {
-            'alive': False, 'id': 'test_agent_id', 'configurations': {
-                'environment_group_number': 2
-            }
-        }
-    }
+    fake_agent = {'agent': {'alive': False,
+                            'id': 'test_agent_id',
+                            'admin_state_up': True,
+                            'configurations': {'environment_prefix': 'prod',
+                                               'environment_group_number': 2}}}
     mock_plugin.db.get_agent_hosting_loadbalancer.return_value = fake_agent
     mock_cxt = mock.MagicMock(name='context')
     sched = agent_scheduler.TenantScheduler()
     sched.get_agents_in_env = mock.MagicMock(name='get_agents_in_env')
-    agents_in_env = [{'fake_agent': {}}]
+    agents_in_env = [
+        {'fake_agent': {'id': 'test_agent_2_id',
+                        'alive': True,
+                        'admin_state_up': True,
+                        'configurations': {'environment_prefix': 'prod',
+                                           'environment_group_number': 2}}}]
     sched.get_agents_in_env.return_value = agents_in_env
+    sched.rebind_loadbalancers = mock.MagicMock(name='rebind_loadbalancers')
+    sched.rebind_loadbalancers.return_value = agents_in_env[0]
     res = sched.get_lbaas_agent_hosting_loadbalancer(
         mock_plugin, mock_cxt, 'test_lb_id', env='test_env')
     assert res == {'agent': agents_in_env[0]}


### PR DESCRIPTION
This is the PR John created a couple few months back minus the orphaned object support, which was already added.  I have added support in the agent to handle a more declarative style of service application and I believe all these can be moved in conjunction.  This is one piece of the change, please DO NOT MERGE.  We can have a planned review so that I can go over the changes.

@richbrowne

What issues does this address?

Agent Fix #730 - Agent resiliency and orphaned object support

What's this change do?

It adds driver support for new RPC calls for orphaned object support.
It adds the ability for the driver to rebind loadbalancers to active agents.
It causes the scheduler to look at the admin_state_up attribute for eligible agents

Where should the reviewer start?

Drinking

Any background context?

These are the merged changes for f5-openstack-agent issue 730