### PR TITLE
Assure BIG-IP cleared to starting state between tests

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -67,7 +67,7 @@ class F5BaseTestCase(base.BaseTestCase):
 
     def tearDown(self):
         """Performs basic teardown operations for inheriting test classes"""
-        BigIpInteraction.check_resulting_cfg()
+        BigIpInteraction.check_resulting_cfg(self.__name__)
         super(F5BaseTestCase, self).tearDown()
 
 
@@ -90,5 +90,5 @@ class F5BaseAdminTestCase(base.BaseTestCase):
 
     def tearDown(self):
         """Performs basic teardown operation for inheriting test classes"""
-        BigIpInteraction.check_resulting_cfg()
+        BigIpInteraction.check_resulting_cfg(self.__name__)
         super(F5BaseAdminTestCase, self).tearDown()

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -13,11 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import subprocess
-
-from collections import namedtuple
-from time import sleep
-
 from neutron_lbaas.tests.tempest.v2.api import base
 from oslo_log import log as logging
 from tempest import config
@@ -97,4 +92,3 @@ class F5BaseAdminTestCase(base.BaseTestCase):
         """Performs basic teardown operation for inheriting test classes"""
         BigIpInteraction.check_resulting_cfg()
         super(F5BaseAdminTestCase, self).tearDown()
-        

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -26,6 +26,8 @@ from f5lbaasdriver.test.tempest.services.clients.bigip_client \
     import BigIpClient
 from f5lbaasdriver.test.tempest.services.clients import \
     plugin_rpc_client
+from f5lbaasdriver.test.tempest.tests.api.bigip_interaction import \
+    BigIpInteraction
 
 CONF = config.CONF
 
@@ -35,81 +37,7 @@ LOG = logging.getLogger(__name__)
 class F5BaseTestCase(base.BaseTestCase):
     """This class picks non-admin credentials and run the tempest tests."""
 
-    config_file = "/tmp/tempest.bigip.cfg"
     _lbs_to_delete = []
-
-    @staticmethod
-    def __exec_shell(stdin, shell=False):
-        Result = namedtuple('Result', 'stdout, stdin, stderr, exit_status')
-        try:
-            stdout = subprocess.check_output(stdin, shell=shell)
-            stderr = ''
-            exit_status = 0
-        except subprocess.CalledProcessError as error:
-            stderr = str(error)
-            stdout = error.output
-            exit_status = error.returncode
-
-        return Result(stdout, stdin, stderr, exit_status)
-
-    @classmethod
-    def _get_current_bigip_cfg(cls):
-        """Get and return the current BIG-IP Config
-
-        This method will perform the action of collecting BIG-IP config data.
-        """
-        results = cls.__exec_shell(cls.__extract_cmd, shell=True)
-        if results.exit_status:
-            raise RuntimeError(
-                "Could not extract bigip data!\nstderr:'{}'"
-                ";stdout'{}' ({})".format(results.stderr, results.stdout,
-                                          results.exit_status))
-        return results.stdout
-
-    @classmethod
-    def _get_existing_bigip_cfg(cls):
-        """Extracts the BIG-IP config and stores it within instance
-
-        This method will hold a copy of the existing BIG-IP config for later
-        comparison.
-        """
-        result = cls._get_current_bigip_cfg()
-        with open(cls.config_file, 'w') as fh:
-            fh.write(result)
-
-    @classmethod
-    def _get_exiting_neutron_cfg(cls):
-        """Place holder for attaining neutron's current cfg before test"""
-        pass
-
-    @classmethod
-    def _resulting_bigip_cfg(cls):
-        result = cls._get_current_bigip_cfg()
-        with open(cls.config_file) as fh:
-            try:
-                assert result == fh.read(), \
-                    "Test was unable to clean up BIG-IP cfg"
-            except AssertionError:
-                cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'load'),
-                                 shell=True)
-                sleep(5)  # after nuke, BIG-IP needs a delay...
-                raise
-
-    @classmethod
-    def _resulting_neutron_db(cls):
-        """Place holder for sanity check code for pollutted neutron DB"""
-        pass
-
-    @classmethod
-    def check_resulting_cfg(cls):
-        """Check the current BIG-IP cfg agianst previous Reset upon Error
-
-        This classmethod will check the current BIG-IP config and raise if
-        there are any changes from the previous snap-shot.  Upon raise, the
-        method will attempt to clear the BIG-IP back to the previous config
-        """
-        cls._resulting_bigip_cfg()
-        cls._resulting_neutron_db()
 
     @classmethod
     def resource_setup(cls):
@@ -123,8 +51,7 @@ class F5BaseTestCase(base.BaseTestCase):
         with the first address in CONF.f5_lbaasv2_driver.icontrol_hostname.
         """
         super(F5BaseTestCase, cls).resource_setup()
-        cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'save'), True)
-        # Where the neutron db collection between resource setups goes
+        BigIpInteraction.store_config()
 
         cls.bigip_clients = []
         for host in CONF.f5_lbaasv2_driver.icontrol_hostname.split(","):
@@ -139,14 +66,13 @@ class F5BaseTestCase(base.BaseTestCase):
         )
 
     def setUp(self):
-        """Performs basic teardown operations for assocaited tests"""
-        self._get_existing_bigip_cfg()
-        self._get_exiting_neutron_cfg()
+        """Performs basic setup operations for inheriting test classes"""
+        BigIpInteraction.store_existing()
         super(F5BaseTestCase, self).setUp()
 
     def tearDown(self):
-        """Performs basic teardown operations for assocaited tests"""
-        self.check_resulting_cfg()
+        """Performs basic teardown operations for inheriting test classes"""
+        BigIpInteraction.check_resulting_cfg()
         super(F5BaseTestCase, self).tearDown()
 
 
@@ -157,6 +83,18 @@ class F5BaseAdminTestCase(base.BaseTestCase):
     def resource_setup(cls):
         """Initialize the client objects."""
         super(F5BaseAdminTestCase, cls).resource_setup()
+        BigIpInteraction.store_config()
         cls.plugin_rpc = (
             plugin_rpc_client.F5PluginRPCClient()
         )
+
+    def setUp(self):
+        """Performs basic setup operation for inheriting test classes"""
+        BigIpInteraction.store_existing()
+        super(F5BaseAdminTestCase, self).setUp()
+
+    def tearDown(self):
+        """Performs basic teardown operation for inheriting test classes"""
+        BigIpInteraction.check_resulting_cfg()
+        super(F5BaseAdminTestCase, self).tearDown()
+        

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -17,7 +17,6 @@
 import datetime
 import os
 import subprocess
-
 from collections import namedtuple
 from time import sleep
 

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -1,18 +1,21 @@
-# Copyright 2015, 2016 Rackspace Inc.
-# All Rights Reserved.
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
 #
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+import datetime
+import os
 import subprocess
 
 from collections import namedtuple
@@ -23,7 +26,24 @@ from time import sleep
     This module offers classes and methods that can be used to interact with
     the BIG-IP's configuration.  As a part of this, tests can peform necessary
     standup and teardown actions.
+
+    Upon teardown, if the module discoves a diff between the snap-shotted copy
+    of the BIG-IP's starting config and the post-test config, then a diff file
+    is generated.  This diff file is generated using linux's `which diff` app.
+
+    The format of the file and the file's location depends upon the test
+    instance and the test's name as follows:
+        /tmp/tempest_bigip_<test>_<year><month><day><hour><minute><second>.diff
+    Example:
+        /tmp/tempest_bigip_test_foo_20170703222336.diff
+        or 2017/07/03 22:23:36 or 10:23:36 PM on Jul 3 2017
+    The time is derived during compile time of the tests, not during runtime.
+    This assures that all diff files generated during a single test run have
+    the same timestamp in the filename; thus, it is expected that some files
+    may not have the same creation date epoch as the timestamp in the filename.
 """
+
+my_epoch = datetime.datetime.now().strftime('%Y%m%d%H%M%S')  # epoch
 
 
 class BigIpInteraction(object):
@@ -33,7 +53,9 @@ class BigIpInteraction(object):
     different stand up and teardown actions around storing and establishing a
     baseline for the BIG-IP's config and recalling it from memory.
     """
-    config_file = "/tmp/agent_only.bigip.cfg"
+    config_file = "/tmp/tempest_bigip_{}.cfg"
+    dirty_file = "/tmp/tempest_bigip_{}_{}.cfg"
+    diff_file = "/tmp/tempest_bigip_diff_{}_{}.cfg"
     _lbs_to_delete = []
     __ssh_cfg = '/home/ubuntu/testenv_symbols/testenv_ssh_config'
     __ssh_cmd = \
@@ -62,6 +84,14 @@ EOF'''.format(__ssh_cmd)
 
         return Result(stdout, stdin, stderr, exit_status)
 
+    @staticmethod
+    def __check_results(results):
+        if results.exit_status:
+            raise RuntimeError(
+                "Could not extract bigip data!\nstderr:'{}'"
+                ";stdout'{}' ({})".format(results.stderr, results.stdout,
+                                          results.exit_status))
+
     @classmethod
     def _get_current_bigip_cfg(cls):
         """Get and return the current BIG-IP Config
@@ -69,11 +99,7 @@ EOF'''.format(__ssh_cmd)
         This method will perform the action of collecting BIG-IP config data.
         """
         results = cls.__exec_shell(cls.__extract_cmd, shell=True)
-        if results.exit_status:
-            raise RuntimeError(
-                "Could not extract bigip data!\nstderr:'{}'"
-                ";stdout'{}' ({})".format(results.stderr, results.stdout,
-                                          results.exit_status))
+        cls.__check_results(results)
         return results.stdout
 
     @classmethod
@@ -88,28 +114,72 @@ EOF'''.format(__ssh_cmd)
             fh.write(result)
 
     @classmethod
-    def _resulting_bigip_cfg(cls):
-        result = cls._get_current_bigip_cfg()
-        with open(cls.config_file) as fh:
-            try:
-                assert result == fh.read(), \
-                    "Test was unable to clean up BIG-IP cfg"
-            except AssertionError:
-                cls.__exec_shell(
-                    cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'load'),
-                    shell=True)
-                sleep(5)  # after nuke, BIG-IP needs a delay...
-                raise
+    def __restore_from_backup(cls):
+        """An internal method"""
+        cls.__exec_shell(
+            cls.__ucs_cmd_fmt.format(
+                cls.__ssh_cmd, 'load'), shell=True)
 
     @classmethod
-    def check_resulting_cfg(cls):
+    def _resulting_bigip_cfg(cls, test_method):
+        """Checks the resulting BIG-IP config as it stands against snap shot
+
+        This method will raise upon discovery of a polluted config against snap
+        shot.  Upon a raise, it will also:
+            * restore from backup
+            * Sleep 5 seconds to asssure the BIG-IP is ready for REST cmds
+            * Generate a diff file against the polluted config
+        """
+        try:
+            with open(cls.config_file) as fh:
+                content = fh.read()
+            diff_file = cls.__collect_diff(content, test_method)
+            os.path.remove(diff_file)
+        except AssertionError as err:
+            cls.__restore_from_backup()
+            sleep(5)  # after nuke, BIG-IP needs a delay...
+            raise AssertionError(
+                "BIG-IP cfg was polluted by test!! (diff: {})".format(err))
+
+    @classmethod
+    def _collect_diff(cls):
+        """An accessible diff collection without a frame.
+
+        This method can force the collection of a diff at any time during the
+        testing process and does not necessarily require a difference between
+        snapshot and current BIG-IP config.
+        """
+        result = cls._get_current_bigip_cfg()
+        try:
+            diff_file = cls.__collect_diff(result)
+        except AssertionError as err:
+            diff_file = str(err)
+        return diff_file
+
+    @classmethod
+    def __collect_diff(cls, result, test_method):
+        """An internal method"""
+        dirty_file = cls.dirty_file.format(test_method, my_epoch)
+        with open(dirty_file, 'w') as fh:
+            fh.write(result)
+        diff_file = cls.diff_file.format(test_method, my_epoch)
+        cmd = "diff -u {} {} > {}".format(
+            cls.config_file, dirty_file, diff_file)
+        result = cls.__exec_shell(cmd, True)
+        cls.__check_results(result)
+        if os.path.getsize(diff_file) > 0:
+            raise AssertionError(diff_file)
+        return diff_file
+
+    @classmethod
+    def check_resulting_cfg(cls, test_method):
         """Check the current BIG-IP cfg agianst previous Reset upon Error
 
         This classmethod will check the current BIG-IP config and raise if
         there are any changes from the previous snap-shot.  Upon raise, the
         method will attempt to clear the BIG-IP back to the previous config
         """
-        cls._resulting_bigip_cfg()
+        cls._resulting_bigip_cfg(test_method)
 
     @classmethod
     def store_config(cls):
@@ -120,3 +190,15 @@ EOF'''.format(__ssh_cmd)
     def store_existing(cls):
         """Performs operation to store existing config state of BIG-IP"""
         cls._get_existing_bigip_cfg()
+
+    @classmethod
+    def force_clear(cls):
+        """Forces a clear reload from back up of the BIG-IP's config.
+
+        This method should only be used when it is assumed and known that the
+        BIG-IP's config is polluted and a diff will be forcably taken with a
+        forced reset of the BIG-IP to the snap-shot results.
+        """
+        diff_file = cls._collect_diff()
+        cls.__restore_from_backup()
+        return diff_file

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -17,6 +17,7 @@
 import datetime
 import os
 import subprocess
+
 from collections import namedtuple
 from time import sleep
 

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -14,15 +14,15 @@
 #    under the License.
 
 import subprocess
-import os
 
 from collections import namedtuple
+from time import sleep
 
 """Module for test-based interactions with the BIG-IP
 
-    This module offers classes and methods that can be used to interact with the
-    BIG-IP's configuration.  As a part of this, tests can peform necessary standup
-    and teardown actions.
+    This module offers classes and methods that can be used to interact with
+    the BIG-IP's configuration.  As a part of this, tests can peform necessary
+    standup and teardown actions.
 """
 
 
@@ -46,7 +46,6 @@ echo \"Folder $f\"; tmsh -c "cd /$f; list\"; done;
 exit
 EOF'''.format(__ssh_cmd)
     __ucs_cmd_fmt = "{} tmsh {} /sys ucs /tmp/backup.ucs"
-
 
     @staticmethod
     def __exec_shell(stdin, shell=False):
@@ -96,8 +95,9 @@ EOF'''.format(__ssh_cmd)
                 assert result == fh.read(), \
                     "Test was unable to clean up BIG-IP cfg"
             except AssertionError:
-                cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'load'),
-                                 shell=True)
+                cls.__exec_shell(
+                    cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'load'),
+                    shell=True)
                 sleep(5)  # after nuke, BIG-IP needs a delay...
                 raise
 

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -160,7 +160,7 @@ EOF'''
         try:
             with open(cls.config_file.format(my_epoch)) as fh:
                 content = fh.read()
-            diff_file = cls.__collect_diff(content, test_method)
+            cls.__collect_diff(content, test_method)
         except AssertionError as err:
             cls.__restore_from_backup()
             sleep(5)  # after nuke, BIG-IP needs a delay...

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -1,0 +1,122 @@
+# Copyright 2015, 2016 Rackspace Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import subprocess
+import os
+
+from collections import namedtuple
+
+"""Module for test-based interactions with the BIG-IP
+
+    This module offers classes and methods that can be used to interact with the
+    BIG-IP's configuration.  As a part of this, tests can peform necessary standup
+    and teardown actions.
+"""
+
+
+class BigIpInteraction(object):
+    """BigIpInteraction class object used for BIG-IP test interaction
+
+    This is a standard class with a list of useful methods that perform
+    different stand up and teardown actions around storing and establishing a
+    baseline for the BIG-IP's config and recalling it from memory.
+    """
+    config_file = "/tmp/agent_only.bigip.cfg"
+    _lbs_to_delete = []
+    __ssh_cfg = '/home/ubuntu/testenv_symbols/testenv_ssh_config'
+    __ssh_cmd = \
+        str("ssh -F {} openstack_bigip").format(__ssh_cfg)
+    __extract_cmd = '''{} << EOF
+tmsh -c \"cd /;
+list sys folder recursive one-line" | cut -d " " -f3 |
+while read f; do echo \"====================\";
+echo \"Folder $f\"; tmsh -c "cd /$f; list\"; done;
+exit
+EOF'''.format(__ssh_cmd)
+    __ucs_cmd_fmt = "{} tmsh {} /sys ucs /tmp/backup.ucs"
+
+
+    @staticmethod
+    def __exec_shell(stdin, shell=False):
+        """An internal method"""
+        Result = namedtuple('Result', 'stdout, stdin, stderr, exit_status')
+        try:
+            stdout = subprocess.check_output(stdin, shell=shell)
+            stderr = ''
+            exit_status = 0
+        except subprocess.CalledProcessError as error:
+            stderr = str(error)
+            stdout = error.output
+            exit_status = error.returncode
+
+        return Result(stdout, stdin, stderr, exit_status)
+
+    @classmethod
+    def _get_current_bigip_cfg(cls):
+        """Get and return the current BIG-IP Config
+
+        This method will perform the action of collecting BIG-IP config data.
+        """
+        results = cls.__exec_shell(cls.__extract_cmd, shell=True)
+        if results.exit_status:
+            raise RuntimeError(
+                "Could not extract bigip data!\nstderr:'{}'"
+                ";stdout'{}' ({})".format(results.stderr, results.stdout,
+                                          results.exit_status))
+        return results.stdout
+
+    @classmethod
+    def _get_existing_bigip_cfg(cls):
+        """Extracts the BIG-IP config and stores it within instance
+
+        This method will hold a copy of the existing BIG-IP config for later
+        comparison.
+        """
+        result = cls._get_current_bigip_cfg()
+        with open(cls.config_file, 'w') as fh:
+            fh.write(result)
+
+    @classmethod
+    def _resulting_bigip_cfg(cls):
+        result = cls._get_current_bigip_cfg()
+        with open(cls.config_file) as fh:
+            try:
+                assert result == fh.read(), \
+                    "Test was unable to clean up BIG-IP cfg"
+            except AssertionError:
+                cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'load'),
+                                 shell=True)
+                sleep(5)  # after nuke, BIG-IP needs a delay...
+                raise
+
+    @classmethod
+    def check_resulting_cfg(cls):
+        """Check the current BIG-IP cfg agianst previous Reset upon Error
+
+        This classmethod will check the current BIG-IP config and raise if
+        there are any changes from the previous snap-shot.  Upon raise, the
+        method will attempt to clear the BIG-IP back to the previous config
+        """
+        cls._resulting_bigip_cfg()
+
+    @classmethod
+    def store_config(cls):
+        """Performs a backup at the UCS level of the BIG-IP"""
+        cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'save'), True)
+
+    @classmethod
+    def store_existing(cls):
+        """Performs operation to store existing config state of BIG-IP"""
+        cls._get_existing_bigip_cfg()


### PR DESCRIPTION
Issues:
WIP #832

Problem:
* Often cfg cruft on failed tests or misbehaving tests in tempest on BIGIP
  * This often results in tests that fail due to lingering cruft

Analysis:
* This will snap-shot the setUp's BIG-IP cfg
* Compare against the end-of test tearDown's cfg
* If these differ, then a raised assertionError occurs
  * This preserves catching tests red-handed
  * This preserves tests that would otherwise fail due to lingering
      cruft

Tests:
This is a test change for a test bug.

**Side node:**
* Ticket has changed from #832 to #841 for WIP purposes
  * This change more adaquitely addresses #841.

@jlongstaf @richbrowne 
#### What issues does this address?
WIP #841  

#### What's this change do?
Introduces into Tempest Tests a forced clear of the BIG-IP between tests.  This preserves the starting state of a test class as seen on the BIG-IP and stores it.  Then recalls it if a diff in the config is discovered.

#### Where should the reviewer start?
[`base.py`](https://github.com/ssorenso/f5-openstack-lbaasv2-driver/blob/mitaka.ucs_bigip_clear/f5lbaasdriver/test/tempest/tests/api/base.py)

#### Any background context?
This is to clear BIG-IP cfg items between tests.