### PR TITLE
Mitaka.neutron db clear

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -13,11 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import subprocess
-
-from collections import namedtuple
-from time import sleep
-
 from neutron_lbaas.tests.tempest.v2.api import base
 from oslo_log import log as logging
 from tempest import config
@@ -28,6 +23,8 @@ from f5lbaasdriver.test.tempest.services.clients import \
     plugin_rpc_client
 from f5lbaasdriver.test.tempest.tests.api.bigip_interaction import \
     BigIpInteraction
+from f5lbaasdriver.test.tempest.tests.api.neutron_interaction import \
+    NeutronInteraction
 
 CONF = config.CONF
 
@@ -51,6 +48,7 @@ class F5BaseTestCase(base.BaseTestCase):
         with the first address in CONF.f5_lbaasv2_driver.icontrol_hostname.
         """
         super(F5BaseTestCase, cls).resource_setup()
+        NeutronInteraction.store_config()
         BigIpInteraction.store_config()
 
         cls.bigip_clients = []
@@ -72,6 +70,7 @@ class F5BaseTestCase(base.BaseTestCase):
 
     def tearDown(self):
         """Performs basic teardown operations for inheriting test classes"""
+        NeutronInteraction.check_config()
         BigIpInteraction.check_resulting_cfg()
         super(F5BaseTestCase, self).tearDown()
 
@@ -83,6 +82,7 @@ class F5BaseAdminTestCase(base.BaseTestCase):
     def resource_setup(cls):
         """Initialize the client objects."""
         super(F5BaseAdminTestCase, cls).resource_setup()
+        NeutronInteraction.store_config()
         BigIpInteraction.store_config()
         cls.plugin_rpc = (
             plugin_rpc_client.F5PluginRPCClient()
@@ -95,6 +95,6 @@ class F5BaseAdminTestCase(base.BaseTestCase):
 
     def tearDown(self):
         """Performs basic teardown operation for inheriting test classes"""
+        NeutronInteraction.check_config()
         BigIpInteraction.check_resulting_cfg()
         super(F5BaseAdminTestCase, self).tearDown()
-        

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -26,6 +26,8 @@ from f5lbaasdriver.test.tempest.services.clients.bigip_client \
     import BigIpClient
 from f5lbaasdriver.test.tempest.services.clients import \
     plugin_rpc_client
+from f5lbaasdriver.test.tempest.tests.api.bigip_interaction import \
+    BigIpInteraction
 
 CONF = config.CONF
 
@@ -35,81 +37,7 @@ LOG = logging.getLogger(__name__)
 class F5BaseTestCase(base.BaseTestCase):
     """This class picks non-admin credentials and run the tempest tests."""
 
-    config_file = "/tmp/tempest.bigip.cfg"
     _lbs_to_delete = []
-
-    @staticmethod
-    def __exec_shell(stdin, shell=False):
-        Result = namedtuple('Result', 'stdout, stdin, stderr, exit_status')
-        try:
-            stdout = subprocess.check_output(stdin, shell=shell)
-            stderr = ''
-            exit_status = 0
-        except subprocess.CalledProcessError as error:
-            stderr = str(error)
-            stdout = error.output
-            exit_status = error.returncode
-
-        return Result(stdout, stdin, stderr, exit_status)
-
-    @classmethod
-    def _get_current_bigip_cfg(cls):
-        """Get and return the current BIG-IP Config
-
-        This method will perform the action of collecting BIG-IP config data.
-        """
-        results = cls.__exec_shell(cls.__extract_cmd, shell=True)
-        if results.exit_status:
-            raise RuntimeError(
-                "Could not extract bigip data!\nstderr:'{}'"
-                ";stdout'{}' ({})".format(results.stderr, results.stdout,
-                                          results.exit_status))
-        return results.stdout
-
-    @classmethod
-    def _get_existing_bigip_cfg(cls):
-        """Extracts the BIG-IP config and stores it within instance
-
-        This method will hold a copy of the existing BIG-IP config for later
-        comparison.
-        """
-        result = cls._get_current_bigip_cfg()
-        with open(cls.config_file, 'w') as fh:
-            fh.write(result)
-
-    @classmethod
-    def _get_exiting_neutron_cfg(cls):
-        """Place holder for attaining neutron's current cfg before test"""
-        pass
-
-    @classmethod
-    def _resulting_bigip_cfg(cls):
-        result = cls._get_current_bigip_cfg()
-        with open(cls.config_file) as fh:
-            try:
-                assert result == fh.read(), \
-                    "Test was unable to clean up BIG-IP cfg"
-            except AssertionError:
-                cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'load'),
-                                 shell=True)
-                sleep(5)  # after nuke, BIG-IP needs a delay...
-                raise
-
-    @classmethod
-    def _resulting_neutron_db(cls):
-        """Place holder for sanity check code for pollutted neutron DB"""
-        pass
-
-    @classmethod
-    def check_resulting_cfg(cls):
-        """Check the current BIG-IP cfg agianst previous Reset upon Error
-
-        This classmethod will check the current BIG-IP config and raise if
-        there are any changes from the previous snap-shot.  Upon raise, the
-        method will attempt to clear the BIG-IP back to the previous config
-        """
-        cls._resulting_bigip_cfg()
-        cls._resulting_neutron_db()
 
     @classmethod
     def resource_setup(cls):
@@ -123,8 +51,7 @@ class F5BaseTestCase(base.BaseTestCase):
         with the first address in CONF.f5_lbaasv2_driver.icontrol_hostname.
         """
         super(F5BaseTestCase, cls).resource_setup()
-        cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'save'), True)
-        # Where the neutron db collection between resource setups goes
+        BigIpInteraction.store_config()
 
         cls.bigip_clients = []
         for host in CONF.f5_lbaasv2_driver.icontrol_hostname.split(","):
@@ -139,14 +66,13 @@ class F5BaseTestCase(base.BaseTestCase):
         )
 
     def setUp(self):
-        """Performs basic teardown operations for assocaited tests"""
-        self._get_existing_bigip_cfg()
-        self._get_exiting_neutron_cfg()
+        """Performs basic setup operations for inheriting test classes"""
+        BigIpInteraction.store_existing()
         super(F5BaseTestCase, self).setUp()
 
     def tearDown(self):
-        """Performs basic teardown operations for assocaited tests"""
-        self.check_resulting_cfg()
+        """Performs basic teardown operations for inheriting test classes"""
+        BigIpInteraction.check_resulting_cfg()
         super(F5BaseTestCase, self).tearDown()
 
 
@@ -157,6 +83,18 @@ class F5BaseAdminTestCase(base.BaseTestCase):
     def resource_setup(cls):
         """Initialize the client objects."""
         super(F5BaseAdminTestCase, cls).resource_setup()
+        BigIpInteraction.store_config()
         cls.plugin_rpc = (
             plugin_rpc_client.F5PluginRPCClient()
         )
+
+    def setUp(self):
+        """Performs basic setup operation for inheriting test classes"""
+        BigIpInteraction.store_existing()
+        super(F5BaseAdminTestCase, self).setUp()
+
+    def tearDown(self):
+        """Performs basic teardown operation for inheriting test classes"""
+        BigIpInteraction.check_resulting_cfg()
+        super(F5BaseAdminTestCase, self).tearDown()
+        

--- a/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/bigip_interaction.py
@@ -1,0 +1,122 @@
+# Copyright 2015, 2016 Rackspace Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import subprocess
+import os
+
+from collections import namedtuple
+
+"""Module for test-based interactions with the BIG-IP
+
+    This module offers classes and methods that can be used to interact with the
+    BIG-IP's configuration.  As a part of this, tests can peform necessary standup
+    and teardown actions.
+"""
+
+
+class BigIpInteraction(object):
+    """BigIpInteraction class object used for BIG-IP test interaction
+
+    This is a standard class with a list of useful methods that perform
+    different stand up and teardown actions around storing and establishing a
+    baseline for the BIG-IP's config and recalling it from memory.
+    """
+    config_file = "/tmp/agent_only.bigip.cfg"
+    _lbs_to_delete = []
+    __ssh_cfg = '/home/ubuntu/testenv_symbols/testenv_ssh_config'
+    __ssh_cmd = \
+        str("ssh -F {} openstack_bigip").format(__ssh_cfg)
+    __extract_cmd = '''{} << EOF
+tmsh -c \"cd /;
+list sys folder recursive one-line" | cut -d " " -f3 |
+while read f; do echo \"====================\";
+echo \"Folder $f\"; tmsh -c "cd /$f; list\"; done;
+exit
+EOF'''.format(__ssh_cmd)
+    __ucs_cmd_fmt = "{} tmsh {} /sys ucs /tmp/backup.ucs"
+
+
+    @staticmethod
+    def __exec_shell(stdin, shell=False):
+        """An internal method"""
+        Result = namedtuple('Result', 'stdout, stdin, stderr, exit_status')
+        try:
+            stdout = subprocess.check_output(stdin, shell=shell)
+            stderr = ''
+            exit_status = 0
+        except subprocess.CalledProcessError as error:
+            stderr = str(error)
+            stdout = error.output
+            exit_status = error.returncode
+
+        return Result(stdout, stdin, stderr, exit_status)
+
+    @classmethod
+    def _get_current_bigip_cfg(cls):
+        """Get and return the current BIG-IP Config
+
+        This method will perform the action of collecting BIG-IP config data.
+        """
+        results = cls.__exec_shell(cls.__extract_cmd, shell=True)
+        if results.exit_status:
+            raise RuntimeError(
+                "Could not extract bigip data!\nstderr:'{}'"
+                ";stdout'{}' ({})".format(results.stderr, results.stdout,
+                                          results.exit_status))
+        return results.stdout
+
+    @classmethod
+    def _get_existing_bigip_cfg(cls):
+        """Extracts the BIG-IP config and stores it within instance
+
+        This method will hold a copy of the existing BIG-IP config for later
+        comparison.
+        """
+        result = cls._get_current_bigip_cfg()
+        with open(cls.config_file, 'w') as fh:
+            fh.write(result)
+
+    @classmethod
+    def _resulting_bigip_cfg(cls):
+        result = cls._get_current_bigip_cfg()
+        with open(cls.config_file) as fh:
+            try:
+                assert result == fh.read(), \
+                    "Test was unable to clean up BIG-IP cfg"
+            except AssertionError:
+                cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'load'),
+                                 shell=True)
+                sleep(5)  # after nuke, BIG-IP needs a delay...
+                raise
+
+    @classmethod
+    def check_resulting_cfg(cls):
+        """Check the current BIG-IP cfg agianst previous Reset upon Error
+
+        This classmethod will check the current BIG-IP config and raise if
+        there are any changes from the previous snap-shot.  Upon raise, the
+        method will attempt to clear the BIG-IP back to the previous config
+        """
+        cls._resulting_bigip_cfg()
+
+    @classmethod
+    def store_config(cls):
+        """Performs a backup at the UCS level of the BIG-IP"""
+        cls.__exec_shell(cls.__ucs_cmd_fmt.format(cls.__ssh_cmd, 'save'), True)
+
+    @classmethod
+    def store_existing(cls):
+        """Performs operation to store existing config state of BIG-IP"""
+        cls._get_existing_bigip_cfg()

--- a/f5lbaasdriver/test/tempest/tests/api/neutron_interaction.py
+++ b/f5lbaasdriver/test/tempest/tests/api/neutron_interaction.py
@@ -1,0 +1,178 @@
+# Copyright 2015, 2016 Rackspace Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import pdb
+import re
+import subprocess
+import uuid
+
+from collections import namedtuple
+from time import sleep
+
+from bigip_interaction import BigIpInteraction
+
+"""Module for test-based interactions with the BIG-IP
+
+    This module offers classes and methods that can be used to interact with
+    the BIG-IP's configuration.  As a part of this, tests can peform necessary
+    standup and teardown actions.
+"""
+
+
+class NeutronInteraction(object):
+    """NeutronInteraction class object used for Neutron test interaction
+
+    This is a standard class with a list of useful methods that perform
+    different stand up and teardown actions around storing and establishing a
+    baseline for the Neutron's config and recalling it from memory.
+    """
+    backup_file = "/tmp/neutron_db.sql"
+    dirty_file = "/tmp/neutron_db_dirty_{}.sql"
+    __ssh_cfg = "/home/ubuntu/testenv_symbols/testenv_ssh_config"
+    __ssh_cmd = \
+        "ssh -F {} openstack_master_0".format(__ssh_cfg)
+    __extract_neutron_cfg = """{} << EOF
+sudo grep -e '^connection' /etc/neutron/neutron.conf
+exit
+EOF
+""".format(__ssh_cmd)
+    __extract_cmd = '{} mysqldump -u {} -p{} -h {} {} > {}'
+    # connection=mysql+pymysql://user:pw@host/db
+    __line_parse = \
+        re.compile('^connection=mysql\+pymysql://([^:]+):([^@]+)@([^/]+)/(\w+)')
+    __Creds = namedtuple('Creds', 'username, password, hostname, database')
+    __restore_cmd = "{} mysql -u {} -p{} -h {} {} < {}"
+
+    @staticmethod
+    def __exec_shell(stdin, shell=False):
+        """An internal method"""
+        Result = namedtuple('Result', 'stdout, stdin, stderr, exit_status')
+        try:
+            stdout = subprocess.check_output(stdin, shell=shell)
+            stderr = ''
+            exit_status = 0
+        except subprocess.CalledProcessError as error:
+            stderr = str(error)
+            stdout = error.output
+            exit_status = error.returncode
+
+        return Result(stdout, stdin, stderr, exit_status)
+
+    @staticmethod
+    def _handle_results(results):
+        """Handle simple results"""
+        if results.exit_status:
+            raise RuntimeError(
+                "Could not extract bigip data!\nstderr:'{}'"
+                ";stdout'{}' ({})".format(results.stderr, results.stdout,
+                                          results.exit_status))
+
+    @classmethod
+    def __get_connection(cls):
+        results = cls.__exec_shell(cls.__extract_neutron_cfg, shell=True)
+        cls._handle_results(results)
+        pdb.set_trace()
+        for line in results.stdout.split("\n"):
+            match = cls.__line_parse.search(line)
+            if match:
+                connection = cls.__Creds(*match.groups())
+                break
+        else:
+            raise RuntimeError("Could not perform neutron action")
+        return connection
+
+    @classmethod
+    def _get_current_neutron_cfg(cls, connection=None):
+        """Get and return the current Neutron DB Config
+
+        This method will perform the action of backing up the Neutron DB config
+        data.
+        """
+        if not connection:
+            connection = cls.__get_connection()
+        results = \
+            cls.__exec_shell(
+                cls.__extract_cmd.format(
+                    cls.__ssh_cmd, connection.username, connection.password,
+                    connection.hostname, connection.database, cls.backup_file),
+                True)
+        cls._handle_results(results)
+        return results.stdout
+
+    @classmethod
+    def _get_existing_neutron_cfg(cls):
+        """Extracts the Neutron DB cfg and stores it within instance
+
+        This method will hold a copy of the existing Neutron DB cfg for later
+        comparison.
+        """
+        result = cls._get_current_neutron_cfg()
+        with open(cls.backup_file, 'w') as fh:
+            fh.write(result)
+
+    @classmethod
+    def __restore_neutron_db(cls, connection=None):
+        if not connection:
+            connection = cls.__get_connection()
+        results = \
+            cls.__exec_shell(
+                cls.__restore_cmd.format(
+                    cls.__ssh_cmd, connection.username, connection.password,
+                    connection.hostname, connection.database, cls.backup_file),
+                True)
+        cls._handle_results(results)
+
+    @classmethod
+    def _extract_diff(cls, result):
+        my_id = uuid.uuid4()
+        dirty_file = cls.dirty_file.format(my_id)
+        with open(dirty_file, 'w') as fh:
+            fh.write(result)
+        diff_file = "/tmp/{}.diff".format(my_id)
+        cmd = \
+            "diff -u {} {} > {}".format(cls.backup_file, dirty_file, diff_file)
+        cls.__exec_shell(cmd, True)
+        return diff_file
+
+    @classmethod
+    def _resulting_neutron_cfg(cls):
+        connection = cls.__get_connection()
+        result = cls._get_current_neutron_cfg(connection=connection)
+        try:
+            with open(cls.backup_file) as fh:
+                content = fh.read()
+            assert result == content, \
+                "Test was unable to clean up Neutron cfg"
+        except AssertionError as err:
+            cls.__restore_neutron_db(connection=connection)
+            my_diff_file = cls._extract_diff(content)
+            bigip_diff_file = BigIpInteraction.force_clear()
+            sleep(3)  # let all cfg propogate...
+            raise AssertionError(
+                "{} (diff: {}, bigip_diff: {})".format(
+                    err, my_diff_file, bigip_diff_file))
+        except (IOError, OSError):
+            raise RuntimeError("Was unable to open backup file.  Perhaps "
+                               "out-of-order extraction?")
+
+    @classmethod
+    def check_config(cls):
+        cls._resulting_neutron_cfg()
+
+    @classmethod
+    def store_config(cls):
+        if not os.path.isfile(cls.backup_file):
+            cls._get_existing_neutron_cfg()


### PR DESCRIPTION
Adding Neutron DB Tempest sanity checking

Fixes #841

Problem:
* Tests could potentially depend on a polluted state
  * Neutron settings and/or DB state
* Tests were silently dieing due to BIG-IP polluted state

Analysis:
* BIG-IP interaction elemeent enhanced to handle storing diffs
  * Each test differentiated by a uuid that is in the name of the diff file
  * This is provided in the assertion error traceback
Expected Example:
`bigip_diff: /tmp/bigip_diff_9f69eb11-05b0-4783-93e9-8fa298140d02.cfg`
* Neutron DB diffs are generated
Expected Example:
`diff: /tmp/38e577f7-17fc-48de-b819-9fd64a832114.diff`
Totaling:
`AssertionError: Test was unable to clean up Neutron cfg (diff: /tmp/38e577f7-17fc-48de-b819-9fd64a832114.diff, bigip_diff: /tmp/bigip_diff_9f69eb11-05b0-4783-93e9-8fa298140d02.cfg)`

Tests:
This is a major test enhancement and may result in a lot of tests flagged as problematic

@richbrowne @jlongstaf 
#### What issues does this address?
Fixes #841 

#### What's this change do?
This change will start at the `startUp` of each test and store the Neutron DB temporarily, locally and then validate against the current state of it during `tearDown`.

If it is discovered that they differ, then a diff is taken, and stored under:
`/tmp/<uuid4_0>.diff`
With a diff snap-shot of the BIG-IP:
`/tmp/bigip_diff_<uuid4_1>.diff`
And config file:
`/tmp/bigip_dirty_<uuid4_1>.diff`

#### Where should the reviewer start?
Under the `neutron_interaction.py` notice where it is referenced in the `base.py` and where it tells the BigIpInteraction class to store its config under the `bigip_interaction.py`.

None of these classes are ever substantiated.  All of these diffs should be uniquely identifiable based upon the uuid's generated.

#### Any background context?
Many of our tests share states between tests.  The current theory is that this is resulting in a polluted state between tests resulting in unpredictable behavior.  This unpredictability is what may be causing the intermittent failures seen in nightly results.