### PR TITLE
Merge from Mitaka broke driver compatability with Neutron

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -45,7 +45,7 @@ class LBaaSv2PluginCallbacksRPC(object):
         if self.driver.env:
             topic = topic + "_" + self.driver.env
 
-        self.conn = neutron_rpc.create_connection(new=True)
+        self.conn = neutron_rpc.create_connection()
 
         self.conn.create_consumer(
             topic,


### PR DESCRIPTION
The connection_create function does not take any args in Newton.
This was a change from Mitaka where the parameter was optional.  Remove
the parameter to fix.

