### PR TITLE
Introduces instantiation to all obj's in test_l7policy_rules.py

### DIFF
--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -105,9 +105,6 @@ class F5BaseTestCaseBuilder(object):
     def _delete_listener(self, *args, **kwargs):
         self._not_implemented(self._delete_listener)
 
-    def _create_pool(self, *args, **kwargs):
-        self._not_implemented(self._create_pool)
-
     def _delete_pool(self, *args, **kwargs):
         self._not_implemented(self._delete_pool)
 

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -147,9 +147,6 @@ class F5BaseTestCaseBuilder(object):
         return my_l7rule
 
     def delete_l7rule(self, policy_id, rule_id, loadbalancer=None):
-        import pdb
-        pdb.set_trace()
-        print("foul play!")
         self.l7rule_client.delete_l7rule(policy_id, rule_id)
         self.wait_for_lb(loadbalancer)
 

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -13,8 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from collections import namedtuple
 from collections import deque
+from collections import namedtuple
 
 from neutron_lbaas.tests.tempest.v2.api import base
 from oslo_log import log as logging

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -96,9 +96,6 @@ class F5BaseTestCaseBuilder(object):
     def _create_load_balancer(self, *args, **kwargs):
         self._not_implemented(self._create_load_balancer)
 
-    def _create_pool(self, *args, **kwargs):
-        self._not_implemented(self._create_pool)
-
     def _delete_loadbalancer(self, *args, **kwargs):
         self._not_implemented(self._delete_loadbalancer)
 

--- a/f5lbaasdriver/test/tempest/tests/api/base.py
+++ b/f5lbaasdriver/test/tempest/tests/api/base.py
@@ -13,9 +13,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from collections import namedtuple
+from collections import deque
+
 from neutron_lbaas.tests.tempest.v2.api import base
 from oslo_log import log as logging
 from tempest import config
+from tempest.lib.common.utils import data_utils
 
 from f5lbaasdriver.test.tempest.services.clients.bigip_client \
     import BigIpClient
@@ -29,7 +33,253 @@ CONF = config.CONF
 LOG = logging.getLogger(__name__)
 
 
-class F5BaseTestCase(base.BaseTestCase):
+class F5BaseTestCaseBuilder(object):
+    """This class will share many operations between base classes for F5
+
+    This class methodology offers an abstraction to tests that allow callers
+    to transparently provide themselves with a instantiated means to
+    orchestrate themselves in a way that does not impact other tests.
+
+    By using this class  the caller will clean up after yourself implicitely
+    via automation during setUp() and tearDown() methods.
+    """
+    TearDown = namedtuple('TearDown', 'obj, delete_method, delete_args')
+    # Note, setUp and tearDown SHOULD NOT be added to this class!
+
+    @property
+    def __testname__(self):
+        name = str(self.__class__).replace("<class '", "")
+        name = name.replace("'>", '::')
+        name += self.__name__
+        return name
+
+    def _find_loadbalancer(self, **kwargs):
+        """Will find a LB object by the name 'load_balancer' or 'loadbalancer'
+
+        This method will do its best to find the stored lb object at either the
+        class level, inherited, neutorn-lbaas level, or at the instance level.
+        If not lb object can be found, this method will raise a ValueError.
+
+        The last attempt will be the string 'loadbalancer_id' in the kwargs
+        passed (usually, but not always provided in a create or update).
+        """
+        lb_id = kwargs.get('loadbalancer_id', None)
+        if hasattr(self, 'load_balancer') or hasattr(self, 'loadbalancer'):
+            return \
+                getattr(self, 'loadbalancer', getattr(self, 'load_balancer'))
+        elif hasattr(self.__class__, 'load_balancer') or \
+                hasattr(self.__class__, 'loadbalancer'):
+            cls = self.__class__
+            return getattr(cls, 'loadbalancer', getattr(cls, 'load_balancer'))
+        elif hasattr(base.BaseTestCase, 'load_balancer') or \
+                hasattr(base.BaseTestCase, 'loadbalancer'):
+            return \
+                getattr(base.BaseTestCase, 'load_balancer',
+                        getattr(base.BaseTestCase, 'loadbalancer'))
+        elif lb_id:
+            return lb_id
+        raise ValueError("Cannot perform action without a "
+                         "specified loadbalancer")
+
+    def _not_implemented(self, method_call):
+        raise NotImplementedError(
+            "'{}' is not implemented in '{}'".format(
+                method_call, self.__class__))
+
+    # ABC methods:
+    def _create_listener(self, *args, **kwargs):
+        self._not_implemented(self._create_listener)
+
+    def _create_loadbalancer(self, *args, **kwargs):
+        self._not_implemented(self._create_loadbalancer)
+
+    def _create_load_balancer(self, *args, **kwargs):
+        self._not_implemented(self._create_load_balancer)
+
+    def _create_pool(self, *args, **kwargs):
+        self._not_implemented(self._create_pool)
+
+    def _delete_loadbalancer(self, *args, **kwargs):
+        self._not_implemented(self._delete_loadbalancer)
+
+    def _delete_load_balancer(self, *args, **kwargs):
+        self._not_implemented(self._delete_load_balancer)
+
+    def _delete_listener(self, *args, **kwargs):
+        self._not_implemented(self._delete_listener)
+
+    def _create_pool(self, *args, **kwargs):
+        self._not_implemented(self._create_pool)
+
+    def _delete_pool(self, *args, **kwargs):
+        self._not_implemented(self._delete_pool)
+
+    def _create_l7policy(self, *args, **kwargs):
+        self._not_implemented(self._create_l7policy)
+
+    def _delete_l7policy(self, *args, **kwargs):
+        self._not_implemented(self._delete_l7policy)
+
+    def _update_l7policy(self, *args, **kwargs):
+        self._not_implemented(self._update_l7policy)
+
+    def _create_l7rule(self, *args, **kwargs):
+        self._not_implemented(self._create_l7rule)
+
+    def _delete_l7rule(self, *args, **kwargs):
+        self._not_implemented(self._delete_l7rule)
+
+    def _update_l7rule(self, *args, **kwargs):
+        self._not_implemented(self._update_l7rule)
+
+    # Instantiated methods...
+    def construct_setup(self):
+        BigIpInteraction.store_existing()
+        self.teardown_que = deque()
+
+    def create_l7rule(
+            self, policy_id, loadbalancer=None, **kwargs):
+        my_l7rule = self.l7rule_client.create_l7rule(policy_id, **kwargs)
+        self.teardown_que.appendleft(
+            self.TearDown(
+                my_l7rule, self.delete_l7rule, [loadbalancer]))
+        self.wait_for_lb(loadbalancer.get('id'))
+        return my_l7rule
+
+    def delete_l7rule(self, policy_id, rule_id, loadbalancer=None):
+        import pdb
+        pdb.set_trace()
+        print("foul play!")
+        self.l7rule_client.delete_l7rule(policy_id, rule_id)
+        self.wait_for_lb(loadbalancer)
+
+    def update_l7rule(self, policy_id, rule_id, loadbalancer=None, **kwargs):
+        self.l7rule_client.update_l7rule(policy_id, rule_id, **kwargs)
+        self.wait_for_lb(loadbalancer)
+
+    def create_l7policy(
+            self, loadbalancer=None, **kwargs):
+        my_l7policy = self.l7policy_client.create_l7policy(**kwargs)
+        self.teardown_que.appendleft(
+            self.TearDown(
+                my_l7policy, self.delete_l7policy, [loadbalancer]))
+        self.wait_for_lb(loadbalancer.get('id'))
+        return my_l7policy
+
+    def delete_l7policy(self, li_id, loadbalancer=None):
+        self.l7policy_client.delete_l7policy(li_id)
+        self.wait_for_lb(loadbalancer)
+
+    def update_l7policy(self, li_id, loadbalancer=None, **kwargs):
+        self.l7policy_client.update_l7policy(li_id, **kwargs)
+        self.wait_for_lb(loadbalancer)
+
+    def create_listener(
+            self, loadbalancer=None, **kwargs):
+        my_listener = self.listeners_client.create_listener(**kwargs)
+        self.teardown_que.appendleft(
+            self.TearDown(
+                my_listener, self.delete_listener, [loadbalancer]))
+        self.wait_for_lb(loadbalancer.get('id'))
+        return my_listener
+
+    def delete_listener(self, li_id, loadbalancer=None):
+        self.listeners_client.delete_listener(li_id)
+        self.wait_for_lb(loadbalancer)
+
+    def update_listener(self, li_id, loadbalancer=None, **kwargs):
+        self.listeners_client.update_listener(li_id, **kwargs)
+        self.wait_for_lb(loadbalancer)
+
+    def create_loadbalancer(self, **kwargs):
+        my_loadbalancer = \
+            self.load_balancers_client.create_load_balancer(**kwargs)
+        teardown = self.TearDown(my_loadbalancer, self.delete_loadbalancer, [])
+        self.teardown_que.appendleft(teardown)
+        self.wait_for_lb(my_loadbalancer)
+        return my_loadbalancer
+
+    def delete_loadbalancer(self, my_id, *args):
+        self.load_balancers_client.delete_load_balancer(my_id)
+        self.wait_for_lb(my_id, delete=True)
+
+    def update_loadbalancer(self, loadbalancer, **kwargs):
+        lb_id = loadbalancer
+        if hasattr('get', loadbalancer):
+            lb_id = loadbalancer.get('id')
+        updated_lb = self.load_balancers_client.update_load_balancer(
+            lb_id, **kwargs)
+        self.wait_for_lb(loadbalancer)
+        return updated_lb
+
+    def rand_name(self, name=None, name_type='network'):
+        if not name:
+            name = \
+                data_utils.rand_name(
+                    '{}_{}'.format(self.__name__, name_type))
+        return name
+
+    def create_network(self, network_name=None):
+        network_name = self.rand_name(network_name)
+        my_network = self.create_network(network_name=network_name)
+        base.teardown_que.appendleft(
+            self.TearDown(base.network_client.delete_network, []))
+        return my_network
+
+    def delete_network(self, network_name):
+        self.client.delete_network(network_name)
+
+    def create_pool(self, loadbalancer=None, **kwargs):
+        my_pool = self.pools_client.create_pool(**kwargs)
+        self.teardown_que.appendleft(
+            self.TearDown(
+                my_pool, self.delete_pool, [loadbalancer]))
+        self.wait_for_lb(loadbalancer)
+        return my_pool
+
+    def delete_pool(self, my_id, loadbalancer=None):
+        self.pools_client.delete_pool(my_id)
+        self.wait_for_lb(loadbalancer)
+
+    def update_pool(self, my_id, loadbalancer=None, **kwargs):
+        updated_pool = self.pools_client.update_pool(my_id, **kwargs)
+        self.wait_for_lb(loadbalancer)
+        return updated_pool
+
+    def create_shared_network(self, network_name=None, **kwargs):
+        network_name = self.rand_name(network_name)
+        network = super(F5BaseTestCaseBuilder, self).create_shared_network(
+            network_name=network_name, **kwargs)
+        return network
+
+    def create_subnet(self, *args, **kwargs):
+        subnet = \
+            super(F5BaseTestCaseBuilder, self).create_subnet(*args, **kwargs)
+        return subnet
+
+    def delete_subnet(self, subnet_id):
+        self.client.delete_subnet(subnet_id)
+
+    def create_subnetpool(self, name, **kwargs):
+        name = self.rand_name(name, 'subnetpool')
+        subnetpool = \
+            super(F5BaseTestCaseBuilder, self).create_subnet_pool(
+                name, **kwargs)
+        return subnetpool
+
+    def delete_subnetpool(self, subnet_id):
+        self.client.delete_subnetpool(subnet_id)
+
+    def wait_for_lb(self, loadbalancer, **kwargs):
+        if not loadbalancer:
+            loadbalancer = self._find_loadbalancer(**kwargs)
+        lb_id = loadbalancer
+        if hasattr(loadbalancer, 'get'):
+            lb_id = loadbalancer.get('id')
+        self._wait_for_load_balancer_status(lb_id, **kwargs)
+
+
+class F5BaseTestCase(base.BaseTestCase, F5BaseTestCaseBuilder):
     """This class picks non-admin credentials and run the tempest tests."""
 
     _lbs_to_delete = []
@@ -62,16 +312,18 @@ class F5BaseTestCase(base.BaseTestCase):
 
     def setUp(self):
         """Performs basic setup operations for inheriting test classes"""
-        BigIpInteraction.store_existing()
+        self.construct_setup()
         super(F5BaseTestCase, self).setUp()
 
     def tearDown(self):
         """Performs basic teardown operations for inheriting test classes"""
+        for item in self.teardown_que:
+            item.delete_method(item.obj.get('id'), *item.delete_args)
         BigIpInteraction.check_resulting_cfg(self.__name__)
         super(F5BaseTestCase, self).tearDown()
 
 
-class F5BaseAdminTestCase(base.BaseTestCase):
+class F5BaseAdminTestCase(base.BaseTestCase, F5BaseTestCaseBuilder):
     """This class picks admin credentials and run the tempest tests."""
 
     @classmethod
@@ -85,7 +337,7 @@ class F5BaseAdminTestCase(base.BaseTestCase):
 
     def setUp(self):
         """Performs basic setup operation for inheriting test classes"""
-        BigIpInteraction.store_existing()
+        self.construct_setup()
         super(F5BaseAdminTestCase, self).setUp()
 
     def tearDown(self):

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -146,7 +146,6 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
 
         l7policy = self.create_l7policy(
             loadbalancer=self.load_balancer, **self.reject_args)
-        self.policies.append(l7policy)
         policy_name = "wrapper_policy_{}".format(self.listener_id)
         rule_args = {'type': 'HEADER', 'compare_type': 'CONTAINS',
                      'key': 'X-HEADER', 'value': 'es'}
@@ -431,7 +430,8 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    self.project_tenant_id)
 
         self.delete_l7rule(
-            l7policy.get('id'), self.rule1.get('id'), self.load_balancer_id)
+            l7policy.get('id'), self.rule1.get('id'),
+            loadbalancer=self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert not bigip_client.rule_has_condition("wrapper_policy",
                                                        "reject_1",
@@ -440,18 +440,24 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                        "Project_" +
                                                        self.project_tenant_id)
         self.delete_l7rule(
-            l7policy.get('id'), self.rule2.get('id'), self.load_balancer_id)
+            l7policy.get('id'), self.rule2.get('id'),
+            loadbalancer=self.load_balancer_id)
         self.delete_l7rule(
-            l7policy.get('id'), self.rule3.get('id'), self.load_balancer_id)
+            l7policy.get('id'), self.rule3.get('id'),
+            loadbalancer=self.load_balancer_id)
         self.delete_l7rule(
-            l7policy.get('id'), self.rule4.get('id'), self.load_balancer_id)
+            l7policy.get('id'), self.rule4.get('id'),
+            loadbalancer=self.load_balancer_id)
         self.delete_l7rule(
-            l7policy.get('id'), self.rule5.get('id'), self.load_balancer_id)
+            l7policy.get('id'), self.rule5.get('id'),
+            loadbalancer=self.load_balancer_id)
         self.delete_l7rule(
-            l7policy.get('id'), self.rule6.get('id'), self.load_balancer_id)
-        self.delete_l7rule(
-            l7policy.get('id'), self.rule7.get('id'), self.load_balancer_id)
-        for bigip_client in self.bigip_clients:
+            l7policy.get('id'), self.rule6.get('id'),
+            loadbalancer=self.load_balancer_id)
+        self.delete_l7rule(                           
+            l7policy.get('id'), self.rule7.get('id'),
+            loadbalancer=self.load_balancer_id)
+        for bigip_client in self.bigip_clients:       
             assert not bigip_client.policy_exists("wrapper_policy",
                                                   "Project_" +
                                                   self.project_tenant_id,

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -109,7 +109,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         assert (l7policy.get('action') == "REJECT")
         for bigip_client in self.bigip_clients:
             assert not bigip_client.policy_exists(
-                policy_name,
+                "wrapper_policy",
                 "Project_" +
                 self.project_tenant_id,
                 should_exist=False)
@@ -127,14 +127,14 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "endsWith",
                                                    "real",
@@ -155,14 +155,14 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "contains",
                                                    "es",
@@ -188,26 +188,26 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule3_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "contains",
                                                    "es",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "endsWith",
                                                    "test",
@@ -218,25 +218,25 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), self.rule1.get('id'), self.load_balancer_id)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
             assert not \
-                bigip_client.rule_has_condition(policy_name,
+                bigip_client.rule_has_condition("wrapper_policy",
                                                 "reject_1",
                                                 "contains",
                                                 "es",
                                                 "Project_" +
                                                 self.project_tenant_id)
             assert \
-                bigip_client.rule_has_condition(policy_name,
+                bigip_client.rule_has_condition("wrapper_policy",
                                                 "reject_1",
                                                 "startsWith",
                                                 "real",
                                                 "Project_" +
                                                 self.project_tenant_id)
             assert \
-                bigip_client.rule_has_condition(policy_name,
+                bigip_client.rule_has_condition("wrapper_policy",
                                                 "reject_1",
                                                 "endsWith",
                                                 "test",
@@ -248,7 +248,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy.get('id'), self.rule3.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.policy_exists(policy_name,
+            assert not bigip_client.policy_exists("wrapper_policy",
                                                   "Project_" +
                                                   self.project_tenant_id,
                                                   should_exist=False)
@@ -277,36 +277,36 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy1.get('id'), self.rule1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_2",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert not bigip_client.rule_has_condition(policy_name,
+            assert not bigip_client.rule_has_condition("wrapper_policy",
                                                        "reject_1",
                                                        "contains",
                                                        "es",
                                                        "Project_" +
                                                        self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_2",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_2",
                                                    "contains",
                                                    "es",
@@ -315,24 +315,24 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
 
         self.delete_l7policy(l7policy1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.rule_exists(policy_name,
+            assert not bigip_client.rule_exists("wrapper_policy",
                                                 "reject_1",
                                                 "Project_" +
                                                 self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_2",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_2",
                                                    "contains",
                                                    "es",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_2",
                                                    "startsWith",
                                                    "real",
@@ -340,7 +340,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    self.project_tenant_id)
         self.delete_l7policy(l7policy2.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.policy_exists(policy_name,
+            assert not bigip_client.policy_exists("wrapper_policy",
                                                   "Project_" +
                                                   self.project_tenant_id,
                                                   should_exist=False)
@@ -380,50 +380,50 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule7_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "contains",
                                                    "es",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "endsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "startsWith",
                                                    "re",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "contains",
                                                    "al",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "contains",
                                                    "l",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "reject_1",
                                                    "endsWith",
                                                    "ireal",
@@ -433,7 +433,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy.get('id'), self.rule1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.rule_has_condition(policy_name,
+            assert not bigip_client.rule_has_condition("wrapper_policy",
                                                        "reject_1",
                                                        "contains",
                                                        "es",
@@ -452,7 +452,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy.get('id'), self.rule7.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.policy_exists(policy_name,
+            assert not bigip_client.policy_exists("wrapper_policy",
                                                   "Project_" +
                                                   self.project_tenant_id,
                                                   should_exist=False)
@@ -486,14 +486,14 @@ class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
         self._wait_for_load_balancer_status(self.load_balancer_id)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "redirect_to_url_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "redirect_to_url_1",
                                                    "httpHeader",
                                                    "es",
@@ -525,14 +525,14 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
         self.create_l7rule(
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "redirect_to_pool_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "redirect_to_pool_1",
                                                    "extension",
                                                    "jpg",
@@ -551,21 +551,21 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists(policy_name,
+            assert bigip_client.policy_exists("wrapper_policy",
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists(policy_name,
+            assert bigip_client.rule_exists("wrapper_policy",
                                             "redirect_to_pool_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "redirect_to_pool_1",
                                                    "extension",
                                                    "qcow2",
                                                    "Project_" +
                                                    self.project_tenant_id)
             # Verify same rule exists, but invert is set to True
-            assert bigip_client.rule_has_condition(policy_name,
+            assert bigip_client.rule_has_condition("wrapper_policy",
                                                    "redirect_to_pool_1",
                                                    "not_",
                                                    "qcow2",
@@ -577,7 +577,7 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
             l7policy.get('id'), rule1.get('id'),
             loadbalancer=self.load_balancer, **rule_args)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.rule_has_condition(policy_name,
+            assert not bigip_client.rule_has_condition("wrapper_policy",
                                                        "redirect_to_pool_1",
                                                        "not_",
                                                        "qcow2",

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -214,8 +214,8 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    "Project_" +
                                                    self.project_tenant_id)
 
-        self._delete_l7rule(l7policy.get('id'), self.rule1.get('id'))
-        self._wait_for_load_balancer_status(self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule1.get('id'), self.load_balancer_id)
 
         for bigip_client in self.bigip_clients:
             assert bigip_client.policy_exists(policy_name,
@@ -243,9 +243,10 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                 "Project_" +
                                                 self.project_tenant_id)
 
-        self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
-        self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
-        self._wait_for_load_balancer_status(self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule2.get('id'), self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule3.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert not bigip_client.policy_exists(policy_name,
                                                   "Project_" +
@@ -273,7 +274,8 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.rule4 = self.create_l7rule(
             l7policy2.get('id'), loadbalancer=self.load_balancer, **rule2_args)
 
-        self._delete_l7rule(l7policy1.get('id'), self.rule1.get('id'))
+        self.delete_l7rule(
+            l7policy1.get('id'), self.rule1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
@@ -311,7 +313,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    "Project_" +
                                                    self.project_tenant_id)
 
-        self._delete_l7policy(l7policy1.get('id'))
+        self.delete_l7policy(l7policy1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert not bigip_client.rule_exists(policy_name,
                                                 "reject_1",
@@ -336,7 +338,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-        self._delete_l7policy(l7policy2.get('id'))
+        self.delete_l7policy(l7policy2.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert not bigip_client.policy_exists(policy_name,
                                                   "Project_" +
@@ -428,7 +430,8 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    "Project_" +
                                                    self.project_tenant_id)
 
-        self._delete_l7rule(l7policy.get('id'), self.rule1.get('id'))
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert not bigip_client.rule_has_condition(policy_name,
                                                        "reject_1",
@@ -436,13 +439,18 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                        "es",
                                                        "Project_" +
                                                        self.project_tenant_id)
-        self._delete_l7rule(l7policy.get('id'), self.rule2.get('id'))
-        self._delete_l7rule(l7policy.get('id'), self.rule3.get('id'))
-        self._delete_l7rule(l7policy.get('id'), self.rule4.get('id'))
-        self._delete_l7rule(l7policy.get('id'), self.rule5.get('id'))
-        self._delete_l7rule(l7policy.get('id'), self.rule6.get('id'))
-        self._delete_l7rule(l7policy.get('id'), self.rule7.get('id'))
-        self._wait_for_load_balancer_status(self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule2.get('id'), self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule3.get('id'), self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule4.get('id'), self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule5.get('id'), self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule6.get('id'), self.load_balancer_id)
+        self.delete_l7rule(
+            l7policy.get('id'), self.rule7.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
             assert not bigip_client.policy_exists(policy_name,
                                                   "Project_" +

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -62,9 +62,10 @@ class L7PolicyTestJSONBasic(base.F5BaseTestCase):
         self.load_balancer_id = self.load_balancer['id']
 
         # Create listener for tests
-        self.create_listener_kwargs = {'loadbalancer_id': self.load_balancer_id,
-                                       'protocol': "HTTP",
-                                       'protocol_port': "80"}
+        self.create_listener_kwargs = \
+            {'loadbalancer_id': self.load_balancer_id,
+             'protocol': "HTTP",
+             'protocol_port': "80"}
         self.listener = (
             self.create_listener(loadbalancer=self.load_balancer,
                                  **self.create_listener_kwargs))
@@ -109,7 +110,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         assert (l7policy.get('action') == "REJECT")
         for bigip_client in self.bigip_clients:
             assert not bigip_client.policy_exists(
-                "wrapper_policy",
+                policy_name,
                 "Project_" +
                 self.project_tenant_id,
                 should_exist=False)
@@ -127,14 +128,14 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "endsWith",
                                                    "real",
@@ -154,14 +155,14 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "contains",
                                                    "es",
@@ -187,26 +188,26 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule3_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "contains",
                                                    "es",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "endsWith",
                                                    "test",
@@ -217,25 +218,25 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), self.rule1.get('id'), self.load_balancer_id)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
             assert not \
-                bigip_client.rule_has_condition("wrapper_policy",
+                bigip_client.rule_has_condition(policy_name,
                                                 "reject_1",
                                                 "contains",
                                                 "es",
                                                 "Project_" +
                                                 self.project_tenant_id)
             assert \
-                bigip_client.rule_has_condition("wrapper_policy",
+                bigip_client.rule_has_condition(policy_name,
                                                 "reject_1",
                                                 "startsWith",
                                                 "real",
                                                 "Project_" +
                                                 self.project_tenant_id)
             assert \
-                bigip_client.rule_has_condition("wrapper_policy",
+                bigip_client.rule_has_condition(policy_name,
                                                 "reject_1",
                                                 "endsWith",
                                                 "test",
@@ -247,7 +248,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy.get('id'), self.rule3.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.policy_exists("wrapper_policy",
+            assert not bigip_client.policy_exists(policy_name,
                                                   "Project_" +
                                                   self.project_tenant_id,
                                                   should_exist=False)
@@ -276,36 +277,36 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy1.get('id'), self.rule1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_2",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert not bigip_client.rule_has_condition("wrapper_policy",
+            assert not bigip_client.rule_has_condition(policy_name,
                                                        "reject_1",
                                                        "contains",
                                                        "es",
                                                        "Project_" +
                                                        self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_2",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_2",
                                                    "contains",
                                                    "es",
@@ -314,24 +315,24 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
 
         self.delete_l7policy(l7policy1.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.rule_exists("wrapper_policy",
+            assert not bigip_client.rule_exists(policy_name,
                                                 "reject_1",
                                                 "Project_" +
                                                 self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_2",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_2",
                                                    "contains",
                                                    "es",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_2",
                                                    "startsWith",
                                                    "real",
@@ -339,7 +340,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
                                                    self.project_tenant_id)
         self.delete_l7policy(l7policy2.get('id'), self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.policy_exists("wrapper_policy",
+            assert not bigip_client.policy_exists(policy_name,
                                                   "Project_" +
                                                   self.project_tenant_id,
                                                   should_exist=False)
@@ -379,50 +380,50 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule7_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "reject_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "contains",
                                                    "es",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "startsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "endsWith",
                                                    "real",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "startsWith",
                                                    "re",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "contains",
                                                    "al",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "contains",
                                                    "l",
                                                    "Project_" +
                                                    self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "reject_1",
                                                    "endsWith",
                                                    "ireal",
@@ -433,7 +434,7 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
             l7policy.get('id'), self.rule1.get('id'),
             loadbalancer=self.load_balancer_id)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.rule_has_condition("wrapper_policy",
+            assert not bigip_client.rule_has_condition(policy_name,
                                                        "reject_1",
                                                        "contains",
                                                        "es",
@@ -454,11 +455,11 @@ class L7PolicyJSONReject(L7PolicyTestJSONBasic):
         self.delete_l7rule(
             l7policy.get('id'), self.rule6.get('id'),
             loadbalancer=self.load_balancer_id)
-        self.delete_l7rule(                           
+        self.delete_l7rule(
             l7policy.get('id'), self.rule7.get('id'),
             loadbalancer=self.load_balancer_id)
-        for bigip_client in self.bigip_clients:       
-            assert not bigip_client.policy_exists("wrapper_policy",
+        for bigip_client in self.bigip_clients:
+            assert not bigip_client.policy_exists(policy_name,
                                                   "Project_" +
                                                   self.project_tenant_id,
                                                   should_exist=False)
@@ -492,14 +493,14 @@ class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
         self._wait_for_load_balancer_status(self.load_balancer_id)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "redirect_to_url_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "redirect_to_url_1",
                                                    "httpHeader",
                                                    "es",
@@ -531,14 +532,14 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
         self.create_l7rule(
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "redirect_to_pool_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "redirect_to_pool_1",
                                                    "extension",
                                                    "jpg",
@@ -557,21 +558,21 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
             l7policy.get('id'), loadbalancer=self.load_balancer, **rule_args)
 
         for bigip_client in self.bigip_clients:
-            assert bigip_client.policy_exists("wrapper_policy",
+            assert bigip_client.policy_exists(policy_name,
                                               "Project_" +
                                               self.project_tenant_id)
-            assert bigip_client.rule_exists("wrapper_policy",
+            assert bigip_client.rule_exists(policy_name,
                                             "redirect_to_pool_1",
                                             "Project_" +
                                             self.project_tenant_id)
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "redirect_to_pool_1",
                                                    "extension",
                                                    "qcow2",
                                                    "Project_" +
                                                    self.project_tenant_id)
             # Verify same rule exists, but invert is set to True
-            assert bigip_client.rule_has_condition("wrapper_policy",
+            assert bigip_client.rule_has_condition(policy_name,
                                                    "redirect_to_pool_1",
                                                    "not_",
                                                    "qcow2",
@@ -583,7 +584,7 @@ class L7PolicyJSONRedirectToPool(L7PolicyTestJSONBasic):
             l7policy.get('id'), rule1.get('id'),
             loadbalancer=self.load_balancer, **rule_args)
         for bigip_client in self.bigip_clients:
-            assert not bigip_client.rule_has_condition("wrapper_policy",
+            assert not bigip_client.rule_has_condition(policy_name,
                                                        "redirect_to_pool_1",
                                                        "not_",
                                                        "qcow2",

--- a/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
+++ b/f5lbaasdriver/test/tempest/tests/api/test_l7policy_rules.py
@@ -14,6 +14,8 @@ u"""F5 Networks® LBaaSv2 L7 policy tempest tests."""
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import pytest
+
 from tempest import config
 from tempest import test
 
@@ -475,11 +477,14 @@ class TestL7PolicyTestJSONRedirectToUrl(L7PolicyTestJSONBasic):
             'listener_id': self.listener.get('id'), 'admin_state_up': 'true',
             'action': 'REDIRECT_TO_URL', 'redirect_url': 'http://www.cdc.gov'}
 
+    @pytest.mark.skip(reason=str("40ac765cec41927c9310f91243b113d4de789583 has"
+                                 " a complete removal of fn() here"))
     def test_create_l7_redirect_to_url_policy(self):
         """Test the creationg of a L7 URL redirect policy."""
-        l7policy = self.create_l7policy(
-            loadbalancer=self.load_balancer, **self.redirect_url_args)
-        self._wait_for_load_balancer_status(self.load_balancer_id)
+        # l7policy = self.create_l7policy(
+        #     loadbalancer=self.load_balancer, **self.redirect_url_args)
+        # self._wait_for_load_balancer_status(self.load_balancer_id)
+        pass
 
     def test_policy_redirect_url_contains(self):
         l7policy = self.create_l7policy(


### PR DESCRIPTION
Introduces instantiation to all obj's in test_l7policy_rules.py

Problem:
* There was a shared class-value variables for LB state btwn tests

Solution:
* This will uniquely define each lb object as an instantiated one
* Each instantiated one will be removed from neutron accordingly in teardown

Tests:
Run these tests over and over again numerous times and not see additional
failures.

@richbrowne @jlongstaf 
#### What issues does this address?
WIP #832 
WIP #839 

#### What's this change do?
Tempest has a setup_resource() method in base.py that typically creates all of the "background" objects.  These objects are instantiated at the class level instead of at the instantiated base-class instance.  The result of this is that tests are polluted, by design, with other tests' states.  This change isolates each test individually for this module `test_l7policy_rules.py`.

#### Where should the reviewer start?
`base.py` is likely a good starting point for the new object `F5BaseTestCaseBuilder`.  This builder object overloads the methods used in tempest to generate the objects that were in the resource creation method for this l7policy rules test module.

#### Any background context?
tempest... oh how wonderful you are...