### PR TITLE
Remove leftover references to systest artifacts.

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,4 +1,0 @@
-[DEFAULT]
-test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} OS_LOG_CAPTURE=${OS_LOG_CAPTURE:-1} ${PYTHON:-python} -m subunit.run discover -t ./ ${OS_TEST_PATH:-./f5lbaasdriver/test/tempest/tests/api} $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,6 @@ setup(name='f5-openstack-lbaasv2-driver',
       long_description=readme(),
       version=f5lbaasdriver.__version__,
       entry_points={
-          'tempest.test_plugins': [
-              'f5-lbaasv2-driver-tempest-plugin = '
-              'f5lbaasdriver.test.tempest.plugin:F5LBaaSv2DriverTempestPlugin'
-          ],
           'console_scripts': ['add_f5agent_environment='
                               'f5lbaasdriver.utils.add_environment:main']},
       author='f5-openstack-lbaasv2-driver',

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,6 @@ whitelist_externals=/usr/local/bin/py.test
 install_command=/usr/local/bin/pip install {opts} {packages}
 list_dependencies_command=/usr/local/bin/pip freeze
 
-[testenv:tempest]
-passenv = TEMPEST_CONFIG_DIR
-setenv =
-  OS_TEST_PATH={toxinidir}/f5lbaasdriver/test/tempest/tests
-changedir = f5lbaasdriver/test/tempest/tests/
-commands = py.test {posargs}
-
 [testenv:functional]
 deps =
   -rrequirements.test.txt


### PR DESCRIPTION
- When we recently removed systest artifacts from our product repos,
  we missed a few.  This commit removes those leftovers.