### PR TITLE
Add agent liveness check to scheduler

### DIFF
--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -100,8 +100,10 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
                                             active=None)
 
         for agent in all_agents:
+
             if not plugin.db.is_eligible_agent(active=True, agent=agent):
-                if not agent['admin_state_up']:
+                agent_dead = plugin.db.is_agent_down(agent['heartbeat_timestamp'])
+                if not agent['admin_state_up'] or agent_dead:
                     return_agents.append(agent)
         return return_agents
 

--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -102,7 +102,8 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
         for agent in all_agents:
 
             if not plugin.db.is_eligible_agent(active=True, agent=agent):
-                agent_dead = plugin.db.is_agent_down(agent['heartbeat_timestamp'])
+                agent_dead = plugin.db.is_agent_down(
+                    agent['heartbeat_timestamp'])
                 if not agent['admin_state_up'] or agent_dead:
                     return_agents.append(agent)
         return return_agents


### PR DESCRIPTION
It is not sufficient to check the admin state of the agent, we must also add a liveness test.


