### PR TITLE
Fixes #900 - prep docs for next release

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -37,7 +37,7 @@ The |agent-long| uses iControl REST API calls to apply the desired configuration
 Guides
 ------
 
-See the `F5 Driver for OpenStack LBaaSv2 user documentation`_.
+See the |driver-long| `user documentation`_.
 
 .. index::
    triple: lbaasv2-driver; downloads; debian
@@ -148,7 +148,7 @@ Take the steps below to tell Neutron to use the F5 service provider driver and t
 
 #. Add 'F5Networks' to the ``service_providers`` section of the Neutron LBaaS config file: :file:`/etc/neutron/neutron_lbaas.conf` as shown below.
 
-   .. code-block:: text
+   .. code-block:: console
       :emphasize-lines: 4
 
       $ vim /etc/neutron/neutron_lbaas.conf
@@ -159,7 +159,7 @@ Take the steps below to tell Neutron to use the F5 service provider driver and t
 
 #. Add the LBaaSv2 service plugin to the ``[DEFAULT]`` section of the Neutron config file: :file:`/etc/neutron/neutron.conf`.
 
-   .. code-block:: text
+   .. code-block:: console
 
       $ vi /etc/neutron/neutron.conf
       ...
@@ -175,7 +175,7 @@ Take the steps below to tell Neutron to use the F5 service provider driver and t
 
 #. Restart Neutron
 
-   .. code-block:: text
+   .. code-block:: console
 
       $ sudo service neutron-server restart    \\ Ubuntu
       $ sudo systemctl restart neutron-server  \\ CentOS
@@ -184,25 +184,9 @@ Take the steps below to tell Neutron to use the F5 service provider driver and t
 What's Next
 -----------
 
-`Configure and start`_ the |agent-long|.
-
-.. seealso::
-
-   `F5 Driver for OpenStack LBaaSv2 user documentation`_
-
+`Configure and start the F5 Agent`_.
 
 .. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver.svg?branch=stable/newton
     :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv2-driver
     :alt: Build Status
 
-
-.. _OpenStack Neutron: https://docs.openstack.org/neutron/latest/
-.. _F5 Agent for OpenStack Neutron: /products/openstack/latest/agent/
-.. _F5 Driver for OpenStack LBaaSv2 user documentation: /cloud/openstack/latest/lbaas
-.. _Neutron LBaaS API: https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0
-.. _available F5 agent: /products/openstack/latest/agent/
-.. _F5 Service Provider Package: /cloud/openstack/latest/lbaas-prep
-.. _Download the latest debian package: |f5_lbaasv2_driver_deb_url|
-.. _Download the latest rpm package: |f5_lbaasv2_driver_rpm_url|
-.. _Partners: /cloud/openstack/latest/support/partners.html
-.. _Configure and start: /products/openstack/latest/agent/index.html#configure-the-agent-long

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -369,18 +369,36 @@ rst_epilog = '''
     <a class="btn btn-info" href="https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v%(version)s/f5-openstack-lbaasv2-driver-%(version)s-1.el7.noarch.rpm">RPM package</a>
 .. |release-notes| raw:: html
 
-    <a class="btn btn-success" href="https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/tag/v%(version)s/">Release Notes</a>
+    <a class="btn btn-success" href="%(base_url)s/products/openstack/lbaasv2-driver/v%(version)s/">Release Notes</a>
 .. |agent-long| replace:: F5 Agent for OpenStack Neutron
 .. |agent| replace:: :code:`f5-openstack-agent`
 .. |driver| replace:: :code:`f5-openstack-lbaasv2-driver`
 .. |driver-long| replace:: F5 Driver for OpenStack LBaaSv2
 .. |agent-url| raw:: html
     
-    <a target="_blank" href="http://clouddocs.f5.com/products/openstack/agent/%(openstack_release)s">F5 Agent for OpenStack Neutron</a>
+    <a target="_blank" href="%(base_url)s/products/openstack/agent/%(openstack_release)s">F5 Agent for OpenStack Neutron</a>
 .. |driver-short| replace:: F5 driver
+.. _OpenStack Neutron: https://docs.openstack.org/neutron/%(openstack_release_l)s/
+.. _F5 Agent for OpenStack Neutron: %(base_url)s/products/openstack/%(version)s/agent/
+.. _user documentation: %(base_url)s/cloud/openstack/latest/lbaas
+.. _Neutron LBaaS API: https://wiki.openstack.org/wiki/Neutron/LBaaS/API_2.0
+.. _available F5 agent: %(base_url)s/products/openstack/%(version)s/agent/
+.. _F5 Service Provider Package: %(base_url)s/cloud/openstack/latest/lbaas-prep
+.. _Download the latest debian package: |f5_lbaasv2_driver_deb_url|
+.. _Download the latest rpm package: |f5_lbaasv2_driver_rpm_url|
+.. _Partners: %(base_url)s/cloud/openstack/latest/support/partners.html
+.. _Configure and start the F5 Agent: %(base_url)s/products/openstack/%(version)s/agent/index.html#configure-the-agent-long
+.. _Capacity-based Scale out: %(base_url)s/cloud/openstack/v1/lbaas/lbaas-differentiated-service-environments.html
+.. _Differentiated Service Environments: %(base_url)s/cloud/openstack/v1/lbaas/lbaas-capacity-based-scaleout.html
 ''' % {
   'openstack_release': openstack_release,
   'openstack_release_l': openstack_release.lower(),
   'f5_lbaasv2_driver_shim_url': f5_lbaasv2_driver_shim_url,
-  'version': version
+  'version': version,
+   'base_url': 'http://clouddocs.f5.com'
 }
+
+# Links to external sites (i.e., outside of clouddocs)
+# Use: :issues:`287` would transform to "issue 287" and link to issue #287 in GitHub
+extlinks = {'issues': ('https://github.com/F5Networks/f5-openstack-lbaasv2-driver/issues/%s',
+                          'issue ')}

--- a/docs/environment-generator.rst
+++ b/docs/environment-generator.rst
@@ -30,5 +30,3 @@ See the `Differentiated Service Environments`_ documentation for more informatio
 
 See `Capacity-Based Scale Out`_ to learn about agent redundancy and scale out for differentiated service environments.
 
-.. _Capacity-based Scale out: /cloud/openstack/v1/lbaas/lbaas-differentiated-service-environments.html
-.. _Differentiated Service Environments: /cloud/openstack/v1/lbaas/lbaas-capacity-based-scaleout.html


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #900 

#### What's this change do?
- updates the URL for the release notes to point to a clouddocs location instead of GitHub
- changes how relative links to other clouddocs locations are handled so they're not ignored by the linkcheck
- updates the highlight format used for code-blocks
- adds ability to easily reference GitHub issues using the following syntax:
```
:issues:`1224`
```
 
#### Where should the reviewer start?

#### Any background context?
