### PR TITLE
Fix link to release notes; change how release notes link is generated

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -16,12 +16,13 @@ F5 Driver for OpenStack LBaaSv2
    :titlesonly:
    :hidden:
 
+   RELEASE-NOTES
    environment-generator
 
 version |version|
 -----------------
 
-|release-notes|
+:ref:`Release Notes`
 
 The |driver-long| is a Neutron LBaaSv2 service provider driver (``f5lbaasdriver``) that runs within the `OpenStack Neutron`_ controller.
 The |driver-short| is an alternative to the default Neutron LBaaS service provider driver.

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,7 +1,9 @@
-:orphan: true
+.. index:: Release Notes; |version|
 
-Release Notes for F5 Driver for OpenStack LBaaSv2
-=================================================
+.. _Release Notes:
+
+Release Notes
+=============
 
 v9.5.0 (Mitaka)
 ---------------

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,4 +1,4 @@
-.. index:: Release Notes; |version|
+.. index:: Release Notes
 
 .. _Release Notes:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,9 +77,6 @@ author = u'F5 Networks'
 version = VERSION
 release = VERSION
 
-# The short X.Y version.
-vxy = "(VERSION | cut -d . -f 1,2)"
-
 # OpenStack release
 openstack_release = "Mitaka"
 
@@ -361,9 +358,6 @@ rst_epilog = '''
 .. |rpm-download| raw:: html
     
     <a class="btn btn-info" href="https://github.com/F5Networks/f5-openstack-lbaasv2-driver/releases/download/v%(version)s/f5-openstack-lbaasv2-driver-%(version)s-1.el7.noarch.rpm">RPM package</a>
-.. |release-notes| raw:: html
-
-    <a class="btn btn-success" href="%(base_url)s/products/openstack/lbaasv2-driver/%(openstack_release_l)s/v%(vx-y)s/">Release Notes</a>
 .. |agent-long| replace:: F5 Agent for OpenStack Neutron
 .. |agent| replace:: :code:`f5-openstack-agent`
 .. |driver| replace:: :code:`f5-openstack-lbaasv2-driver`
@@ -389,7 +383,6 @@ rst_epilog = '''
   'openstack_release_l': openstack_release.lower(),
   'f5_lbaasv2_driver_shim_url': f5_lbaasv2_driver_shim_url,
   'version': version,
-  'vx-y': release,
   'base_url': 'http://clouddocs.f5.com'
 }
 


### PR DESCRIPTION
@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?
When I merged PR #907, the way the version number is displayed, and the link to the Release Notes, broke. This PR fixes that issue. 

#### Where should the reviewer start?

#### Any background context?
