### PR TITLE
Ocata Development LBaaSv2 driver issue with ML2 portbinding extension

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -540,10 +540,6 @@ class LBaaSv2PluginCallbacksRPC(object):
                 port_data[portbindings.VNIC_TYPE] = vnic_type
                 port_data[portbindings.PROFILE] = binding_profile
 
-                #if ('binding:capabilities' in
-                #        portbindings.EXTENDED_ATTRIBUTES_2_0['ports']):
-                #    port_data['binding:capabilities'] = {
-                #        'port_filter': False}
                 port = self.driver.plugin.db._core_plugin.create_port(
                     context, {'port': port_data})
                 # Because ML2 marks ports DOWN by default on creation
@@ -704,9 +700,6 @@ class LBaaSv2PluginCallbacksRPC(object):
             port_data[portbindings.VNIC_TYPE] = vnic_type
             port_data[portbindings.PROFILE] = binding_profile
 
-            #extended_attrs = portbindings.EXTENDED_ATTRIBUTES_2_0['ports']
-            #if 'binding:capabilities' in extended_attrs:
-            #    port_data['binding:capabilities'] = {'port_filter': False}
             port = self.driver.plugin.db._core_plugin.create_port(
                 context, {'port': port_data})
             # Because ML2 marks ports DOWN by default on creation

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -540,10 +540,10 @@ class LBaaSv2PluginCallbacksRPC(object):
                 port_data[portbindings.VNIC_TYPE] = vnic_type
                 port_data[portbindings.PROFILE] = binding_profile
 
-                if ('binding:capabilities' in
-                        portbindings.EXTENDED_ATTRIBUTES_2_0['ports']):
-                    port_data['binding:capabilities'] = {
-                        'port_filter': False}
+                #if ('binding:capabilities' in
+                #        portbindings.EXTENDED_ATTRIBUTES_2_0['ports']):
+                #    port_data['binding:capabilities'] = {
+                #        'port_filter': False}
                 port = self.driver.plugin.db._core_plugin.create_port(
                     context, {'port': port_data})
                 # Because ML2 marks ports DOWN by default on creation
@@ -704,9 +704,9 @@ class LBaaSv2PluginCallbacksRPC(object):
             port_data[portbindings.VNIC_TYPE] = vnic_type
             port_data[portbindings.PROFILE] = binding_profile
 
-            extended_attrs = portbindings.EXTENDED_ATTRIBUTES_2_0['ports']
-            if 'binding:capabilities' in extended_attrs:
-                port_data['binding:capabilities'] = {'port_filter': False}
+            #extended_attrs = portbindings.EXTENDED_ATTRIBUTES_2_0['ports']
+            #if 'binding:capabilities' in extended_attrs:
+            #    port_data['binding:capabilities'] = {'port_filter': False}
             port = self.driver.plugin.db._core_plugin.create_port(
                 context, {'port': port_data})
             # Because ML2 marks ports DOWN by default on creation

--- a/f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py
@@ -1,10 +1,24 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import mock
 import pytest
 
 import neutron.api.v2.attributes
 from neutron_lib import constants as neutron_const
 
-import f5lbaasdriver.v2.bigip.plugin_rpc 
+import f5lbaasdriver.v2.bigip.plugin_rpc
 
 
 @pytest.fixture
@@ -19,20 +33,24 @@ def fully_mocked_target(init):
 @pytest.fixture
 def neutron_attributes(request):
     hold_attributes = neutron.api.v2.attributes
+
     def finalizer():
         neutron.api.v2.attributes = hold_attributes
     request.addfinalizer(finalizer)
     neutron.api.v2.attributes = mock.Mock()
     return neutron.api.v2.attributes
 
+
 @pytest.fixture
 def neutron_extensions(request):
     hold_extensions = neutron.extensions
+
     def finalizer():
         neutron.extensions = hold_extensions
     request.addfinalizer(finalizer)
     neutron.extensions = mock.Mock()
     return neutron.extensions
+
 
 def test_create_port_on_subnet(fully_mocked_target, neutron_attributes,
                                neutron_extensions):
@@ -51,7 +69,7 @@ def test_create_port_on_subnet(fully_mocked_target, neutron_attributes,
         setattr(portbindings, attr, attr)
     fake_args['vnic_type'] = portbindings.VNIC_NORMAL
     # fake validation data...
-    subnet = {'id': 'subnet_id', 'tenant_id': 'tenant_id', 
+    subnet = {'id': 'subnet_id', 'tenant_id': 'tenant_id',
               'network_id': 'network_id'}
     port = {'id': 'id'}
     device_ips = [{'subnet_id': subnet['id']}]

--- a/f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py
@@ -1,0 +1,87 @@
+import mock
+import pytest
+
+import neutron.api.v2.attributes
+from neutron_lib import constants as neutron_const
+
+import f5lbaasdriver.v2.bigip.plugin_rpc 
+
+
+@pytest.fixture
+@mock.patch("f5lbaasdriver.v2.bigip.plugin_rpc.LBaaSv2PluginCallbacksRPC."
+            "__init__")
+def fully_mocked_target(init):
+    init.return_value = None
+    target = f5lbaasdriver.v2.bigip.plugin_rpc.LBaaSv2PluginCallbacksRPC()
+    return target
+
+
+@pytest.fixture
+def neutron_attributes(request):
+    hold_attributes = neutron.api.v2.attributes
+    def finalizer():
+        neutron.api.v2.attributes = hold_attributes
+    request.addfinalizer(finalizer)
+    neutron.api.v2.attributes = mock.Mock()
+    return neutron.api.v2.attributes
+
+@pytest.fixture
+def neutron_extensions(request):
+    hold_extensions = neutron.extensions
+    def finalizer():
+        neutron.extensions = hold_extensions
+    request.addfinalizer(finalizer)
+    neutron.extensions = mock.Mock()
+    return neutron.extensions
+
+def test_create_port_on_subnet(fully_mocked_target, neutron_attributes,
+                               neutron_extensions):
+    portbindings = neutron_extensions.portbindings
+    target = fully_mocked_target
+    context = mock.Mock()
+    # fake data manipulations....
+    # args...
+    fake_args = ['subnet_id', 'mac_address', 'name', 'host', 'device_id',
+                 'vnic_type', 'binding_profile']
+    portbindings_attrs = ['VNIC_NORMAL', 'HOST_ID', 'VNIC_TYPE', 'PROFILE']
+    fake_args = {x: x for x in fake_args}
+    fake_args['binding_profile'] = {}
+    # port bindings...
+    for attr in portbindings_attrs:
+        setattr(portbindings, attr, attr)
+    fake_args['vnic_type'] = portbindings.VNIC_NORMAL
+    # fake validation data...
+    subnet = {'id': 'subnet_id', 'tenant_id': 'tenant_id', 
+              'network_id': 'network_id'}
+    port = {'id': 'id'}
+    device_ips = [{'subnet_id': subnet['id']}]
+    port_data = {
+        'tenant_id': subnet['tenant_id'],
+        'name': fake_args['name'],
+        'network_id': subnet['network_id'],
+        'mac_address': fake_args['mac_address'],
+        'admin_state_up': True,
+        'device_owner': 'network:f5lbaasv2',
+        'status': neutron_const.PORT_STATUS_ACTIVE,
+        'fixed_ips': device_ips,
+        'device_id': fake_args['device_id'],
+        'binding:host_id': fake_args['host'],
+        'binding:vnic_type': portbindings.VNIC_NORMAL,
+        'binding:profile': {}}
+    update_data = {'status': neutron_const.PORT_STATUS_ACTIVE}
+    expected_create_port_args = (context, {'port': port_data})
+    expected_update_port_args = \
+        (context, port['id'], {'port': update_data})
+    # attach our mock interactions...
+    target.driver = mock.Mock()
+    target.driver.plugin.db._core_plugin.get_subnet.return_value = subnet
+    target.driver.plugin.db._core_plugin.create_port.return_value = port
+    # test...
+    assert port == target.create_port_on_subnet(context, **fake_args)
+    # validate...
+    assert target.driver.plugin.db._core_plugin.get_subnet.call_count
+    assert target.driver.plugin.db._core_plugin.create_port.call_count
+    assert target.driver.plugin.db._core_plugin.create_port.\
+        call_args_list[0][0] == expected_create_port_args
+    assert target.driver.plugin.db._core_plugin.update_port.\
+        call_args_list[0][0] == expected_update_port_args


### PR DESCRIPTION
Issues:
Fixes #894

Problem: Ocata Development LBaaSv2 driver issue with ML2 portbinding extension

Analysis: as neutron.extensions.portbindings.EXTENDED_NEUTRON_CONST_2_0 dicti
          -onar is absent in Ocata, i commented out the lines wherever the
          attribute "binding:capabilities" was encountered in the code.

Tests: Created and ran unit test f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py

@jlongstaf 
#### What issues does this address? 
Ocata Development LBaaSv2 driver issue with ML2 portbinding extension

Fixes #894 
WIP #<issueid>
...

#### What's this change do? 
Runs the code smoothly when the missing attribute "binding:capabilities" which is  absent in the ocata release is commented out in the code. 

#### Where should the reviewer start?
The reviewer should start with methods "create_port_on_subnet" and "create_port_on_network"

#### Any background context?
This is the issue created by John Gruber and is about Ocata development. 