### PR TITLE
Changes to the driver to make it "pike" release compatible.

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -19,7 +19,7 @@ from f5lbaasdriver.v2.bigip import constants_v2 as constants
 
 from neutron.common import rpc as neutron_rpc
 from neutron.db import agents_db
-from neutron.extensions import portbindings
+from neutron_lib.api.definitions import portbindings
 from neutron.plugins.common import constants as plugin_constants
 
 from neutron_lbaas.db.loadbalancer import models

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -19,12 +19,12 @@ from f5lbaasdriver.v2.bigip import constants_v2 as constants
 
 from neutron.common import rpc as neutron_rpc
 from neutron.db import agents_db
-from neutron_lib.api.definitions import portbindings
 from neutron.plugins.common import constants as plugin_constants
 
 from neutron_lbaas.db.loadbalancer import models
 from neutron_lbaas.services.loadbalancer import constants as nlb_constant
 
+from neutron_lib.api.definitions import portbindings
 from neutron_lib import constants as neutron_const
 
 from oslo_log import helpers as log_helpers


### PR DESCRIPTION
Issues: Some modules are defined under different library in "Pike" release.
Fixes #<issueid>

Problem: Changes to the driver to make it "pike" release compatible.

Analysis: The module "portbindings.VNIC_NORMAL" is defined under different
          library in Pike. Made the required change.

Tests: Changes to the driver to make it "pike" release compatible.

@jlongstaf 
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?
The change help in connecting to the neutron server. The change is made to the plugin_rpc.py file
#### Where should the reviewer start?
Start at the beginning of plugin_rpc.py file.
#### Any background context?
