### PR TITLE
Adding 2018 to all copyright notices.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2016 F5 Networks Inc.
+Copyright (c) 2016-2018, F5 Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. raw:: html
 
    <!--
-   Copyright 2016-2017 F5 Networks Inc.
+   Copyright (c) 2016-2018, F5 Networks, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ See `Contributing <CONTRIBUTING.md>`_.
 Copyright
 ---------
 
-Copyright 2015-2017 F5 Networks Inc.
+Copyright (c) 2015-2018, F5 Networks, Inc.
 
 Support
 -------

--- a/f5lbaasdriver/utils/add_environment.py
+++ b/f5lbaasdriver/utils/add_environment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/utils/environment_library.py
+++ b/f5lbaasdriver/utils/environment_library.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ NEUTRON_LBAASCONF_BAK_PATH =\
 ENVMODULETEMPLATE = '''\
 #!/usr/bin/env python
 
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/utils/remote_add_environment.py
+++ b/f5lbaasdriver/utils/remote_add_environment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/utils/test/test_environment_library.py
+++ b/f5lbaasdriver/utils/test/test_environment_library.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/agent_rpc.py
+++ b/f5lbaasdriver/v2/bigip/agent_rpc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""RPC Calls to Agents for F5® LBaaSv2."""
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Schedule agent to bind to a load balancer."""
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/constants_v2.py
+++ b/f5lbaasdriver/v2/bigip/constants_v2.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 u"""Constants for F5® LBaaSv2 Driver."""
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/disconnected_service.py
+++ b/f5lbaasdriver/v2/bigip/disconnected_service.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""F5 Networks® LBaaSv2 Driver Implementation."""
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/exceptions.py
+++ b/f5lbaasdriver/v2/bigip/exceptions.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""F5 Networks® LBaaSv2 Exceptions."""
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/neutron_client.py
+++ b/f5lbaasdriver/v2/bigip/neutron_client.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""Service Module for F5® LBaaSv2."""
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""RPC Callbacks for F5® LBaaSv2 Plugins."""
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/service_builder.py
+++ b/f5lbaasdriver/v2/bigip/service_builder.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 u"""Service Module for F5® LBaaSv2."""
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/test/test_agent_scheduler.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_callback_functions.py
+++ b/f5lbaasdriver/v2/bigip/test/test_callback_functions.py
@@ -1,4 +1,4 @@
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_member.py
+++ b/f5lbaasdriver/v2/bigip/test/test_member.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_neutron_client.py
+++ b/f5lbaasdriver/v2/bigip/test/test_neutron_client.py
@@ -1,4 +1,4 @@
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/test/test_plugin_rpc.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5lbaasdriver/v2/bigip/test/test_service_builder.py
+++ b/f5lbaasdriver/v2/bigip/test/test_service_builder.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/from_agent/test_create_tls_container.py
+++ b/test/functional/from_agent/test_create_tls_container.py
@@ -4,7 +4,7 @@ test_requirements = {'devices':         [],
                      'openstack_infra': []}
 
 '''
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/test_CLUDS.py
+++ b/test/functional/test_CLUDS.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/test_environment_add.py
+++ b/test/functional/test_environment_add.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/test_registry_callback.py
+++ b/test/functional/test_registry_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Issues: Adding 2018 to all copyright notices.
Fixes #<issueid>

Problem: All the copyright notices were not updated with the latest year.

Analysis: Updated all copyright notices with 2018 year.

Tests: No tests

@jlongstaf 
#### What issues does this address? Updation of all copyright notices with "2018" year
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
