### PR TITLE
Fix for device_id exception raised when creating Neutron network port in HPB

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -15,6 +15,8 @@ u"""RPC Callbacks for F5® LBaaSv2 Plugins."""
 # limitations under the License.
 #
 
+import uuid
+
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 
@@ -536,6 +538,9 @@ class LBaaSv2PluginCallbacksRPC(object):
 
                 if device_id:
                     port_data['device_id'] = device_id
+                else:
+                    port_data['device_id'] = str(uuid.uuid5(
+                        uuid.NAMESPACE_DNS, str(host)))
                 port_data[portbindings.HOST_ID] = host
                 port_data[portbindings.VNIC_TYPE] = vnic_type
                 port_data[portbindings.PROFILE] = binding_profile
@@ -700,6 +705,9 @@ class LBaaSv2PluginCallbacksRPC(object):
             }
             if device_id:
                 port_data['device_id'] = device_id
+            else:
+                port_data['device_id'] = str(uuid.uuid5(
+                    uuid.NAMESPACE_DNS, str(host)))
             port_data[portbindings.HOST_ID] = host
             port_data[portbindings.VNIC_TYPE] = vnic_type
             port_data[portbindings.PROFILE] = binding_profile


### PR DESCRIPTION

Issues:
Fixes #930

Problem: create_port_on_network() fails to set a device_id in
port data unless one is passed into the function. Because the
agent calls this method without a device_id it will always
fail.

Analysis: Code was recently changed so that the passed in device_id
is always used, but failed to account for situations when device_id
is not given. Added additional code to set device_id to a uuid ID
when no device_id is given.



