### PR TITLE
Fix Unknown state set in error

### DIFF
--- a/f5lbaasdriver/v2/bigip/plugin_rpc.py
+++ b/f5lbaasdriver/v2/bigip/plugin_rpc.py
@@ -27,6 +27,7 @@ from neutron_lbaas.services.loadbalancer import constants as nlb_constant
 
 from neutron_lib.api.definitions import portbindings
 from neutron_lib import constants as neutron_const
+from neutron_lib import exceptions as q_exc
 
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
@@ -758,10 +759,17 @@ class LBaaSv2PluginCallbacksRPC(object):
                                                                    lbid)
                     lb_status[lbid] = lb_db.provisioning_status
 
+                except q_exc.NotFound:
+                    lb_status[lbid] = 'Unknown'
+
                 except Exception as e:
                     LOG.error('Exception: get_loadbalancer: %s',
                               e.message)
-                    lb_status[lbid] = 'Unknown'
+                    if 'could not be found' in e.message:
+                        lb_status[lbid] = 'Unknown'
+                    else:
+                        lb_status[lbid] = ''
+
         return lb_status
 
     # validate a list of pools id - assure they are not deleted
@@ -773,10 +781,17 @@ class LBaaSv2PluginCallbacksRPC(object):
                 try:
                     pool_db = self.driver.plugin.db.get_pool(context, poolid)
                     pool_status[poolid] = pool_db.provisioning_status
+
+                except q_exc.NotFound:
+                    pool_status[poolid] = 'Unknown'
+
                 except Exception as e:
                     LOG.error('Exception: get_pool: %s',
                               e.message)
-                    pool_status[poolid] = 'Unknown'
+                    if 'could not be found' in e.message:
+                        pool_status[poolid] = 'Unknown'
+                    else:
+                        pool_status[poolid] = ''
         return pool_status
 
     @log_helpers.log_method_call
@@ -803,10 +818,17 @@ class LBaaSv2PluginCallbacksRPC(object):
                                                            listener_id)
                     listener_status[listener_id] = \
                         listener_db.provisioning_status
+
+                except q_exc.NotFound:
+                    listener_status[listener_id] = 'Unknown'
+
                 except Exception as e:
                     LOG.error('Exception: get_listener: %s',
                               e.message)
-                    listener_status[listener_id] = 'Unknown'
+                    if 'could not be found' in e.message:
+                        listener_status[listener_id] = 'Unknown'
+                    else:
+                        listener_status[listener_id] = ''
         return listener_status
 
     # validate a list of l7policys id - assure they are not deleted


### PR DESCRIPTION
Problem: when validating object state, any Exception will cause
the state to be set to Unknown, which in turn causes ageents
to delete object.

Analysis: Need to only set Unknown when database raises NotFound
excecption, not for any exception. Added catching NotFound exception,
and additonal checking for generic Exception.

(cherry picked from commit a0afd56a68a918a9af935d522b0306b627cae54a)

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
