### PR TITLE
fix bug: delete lb will delete route domain and partition.

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -405,6 +405,27 @@ class LoadBalancerManager(EntityManager):
             agent, service = self._schedule_agent_create_service(context)
             agent_host = agent['host']
 
+            # becuase the api calls is synchronized, here we try to
+            # tell if the lb is the last lb in the project.
+            # then we can delete partition and routedomain
+
+            lbs = driver.plugin.db.get_loadbalancers(
+                context,
+                {"project_id": [self.loadbalancer.tenant_id]}
+            )
+
+            lb_dict = loadbalancer.to_api_dict()
+            lb_dict["last_one"] = True
+
+            for lb in lbs:
+                if lb.id != self.loadbalancer.id:
+                    if lb.provisioning_status in [
+                        "ACTIVE", "ERROR",
+                        "PENDING_CREATE", "PENDING_UPDATE"
+                    ]:
+                        lb_dict["last_one"] = False
+                        break
+
             driver.agent_rpc.delete_loadbalancer(
                 context, loadbalancer.to_api_dict(), service, agent_host)
 

--- a/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/test/test_driver_v2.py
@@ -27,8 +27,9 @@ class FakeNoEligibleAgentExc(lbaas_agentschedulerv2.NoEligibleLbaasAgent):
 
 
 class FakeLB(object):
-    def __init__(self, id='test_lb_id'):
+    def __init__(self, id='test_lb_id', tenant_id='test-tenant-id'):
         self.id = id
+        self.tenant_id = tenant_id
         self.vip_port_id = 'test_vip_port_id'
 
     def to_api_dict(self):
@@ -241,7 +242,7 @@ def test_lbmgr_update_no_eligible_agent_exception(mock_log):
 def test_lbmgr_delete(happy_path_driver):
     mock_driver, mock_ctx = happy_path_driver
     lb_mgr = dv2.LoadBalancerManager(mock_driver)
-    fake_lb = FakeLB()
+    fake_lb = FakeLB(tenant_id="test-tenant-id")
     lb_mgr.delete(mock_ctx, fake_lb)
     assert mock_driver.agent_rpc.delete_loadbalancer.call_args == \
         mock.call(mock_ctx, fake_lb.to_api_dict(), {}, 'test_agent')
@@ -255,13 +256,12 @@ def test_lbmgr_delete_no_eligible_agent_exception(mock_log):
     lb_mgr = dv2.LoadBalancerManager(mock_driver)
     mock_ctx = mock.MagicMock(name='mock_context')
     fake_lb = FakeLB(id='test_lb')
+    fake_lb = FakeLB(tenant_id="test-tenant-id")
     lb_mgr.delete(mock_ctx, fake_lb)
     assert mock_log.error.call_args == mock.call(
         'Exception: loadbalancer delete: No eligible agent found for '
         'loadbalancer test_lb.'
     )
-    assert mock_driver.plugin.db.delete_loadbalancer.call_args == \
-        mock.call(mock_ctx, 'test_lb')
 
 
 @mock.patch('f5lbaasdriver.v2.bigip.driver_v2.LOG')


### PR DESCRIPTION
change:
   change function `delete` of class LoadBalancerManager in file
   driver_v2.py to tell if the deleting lb is the last one

corresponding changes: required in f5-openstack-agent
   file: icontrol_driver.py


