### PR TITLE
avoid getting lb from db

### DIFF
--- a/f5lbaasdriver/v2/bigip/agent_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/agent_scheduler.py
@@ -200,13 +200,12 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
         """
 
         with context.session.begin(subtransactions=True):
-            loadbalancer = plugin.db.get_loadbalancer(context, loadbalancer_id)
             # If the loadbalancer is hosted on an active agent
             # already, return that agent or one in its env
             lbaas_agent = self.get_lbaas_agent_hosting_loadbalancer(
                 plugin,
                 context,
-                loadbalancer.id,
+                loadbalancer_id,
                 env
             )
 
@@ -215,6 +214,14 @@ class TenantScheduler(agent_scheduler.ChanceScheduler):
                 LOG.debug(' Assigning task to agent %s.'
                           % (lbaas_agent['id']))
                 return lbaas_agent
+
+            # moving this part here so that this db call basically only called
+            # while creating lb. If it was for creating lb, then this call
+            # returns immediately. For other ops, it should have returned
+            # already above, so this db call is avoided.
+            LOG.info('get_loadbalancer start inside schedule')
+            loadbalancer = plugin.db.get_loadbalancer(context, loadbalancer_id)
+            LOG.info('get_loadbalancer end inside schedule')
 
             # There is no existing loadbalancer agent binding.
             # Find all active agent candidates in this env.


### PR DESCRIPTION
Let's avoid modifying the schedule() function's prototype
as that might impact too many places.

To avoid unnecesary db call when the lb was already scheduled
before. This seems to be a safer way which modifies the least
code. Seems a little risky if we try to use the lb passed from
member.pool.loadbalancer because this content from the
third-party might differ.

(cherry picked from commit 4e7eb0688b09b3d75cc9aff909b5f830fe8ed8f5)

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
