### PR TITLE
[OPENSTACK-2686] Match rule requirement changes

### DIFF
--- a/f5lbaasdriver/v2/bigip/device_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/device_scheduler.py
@@ -73,14 +73,20 @@ class DeviceSchedulerNG(object):
         if (
             lb_name
             and cfg.CONF.special_lb_name_prefix
-            and lb_name.startswith(cfg.CONF.special_lb_name_prefix)
+            # it is now required SPECIAL_XXXXXXXX included in lb_name;
+            # which means abc_SPECIAL_XXXXXXXX or SPECIAL_XXXXXXXX_def
+            # or ghi_SPECIAL_XXXXXXXX_jk can all satisfy. Earlier rule
+            # was lb_name starts with special_lb_name_prefix and ends
+            # with XXXXXXXX (the first 8 char of inactive device uuid)
+            and cfg.CONF.special_lb_name_prefix in lb_name
         ):
             inactive_devices = self.load_inactive_device_groups()
             LOG.debug("inactive_devices here is %s ", inactive_devices)
             for each in inactive_devices:
                 id_prefix = each["id"][:8]
-                length = len(cfg.CONF.special_lb_name_prefix)
-                if lb_name.endswith(id_prefix, length):
+                match_regex = cfg.CONF.special_lb_name_prefix + id_prefix
+                if match_regex in lb_name:
+                    LOG.debug("match_regex here is %s ", match_regex)
                     LOG.debug("chooses inactive device here %s ", each["id"])
                     LOG.debug(each)
                     the_inactive_dev.append(each)

--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -312,11 +312,11 @@ class EntityManager(object):
                 if (
                     name
                     and cfg.CONF.special_lb_name_prefix
-                    and name.startswith(cfg.CONF.special_lb_name_prefix)
+                    and cfg.CONF.special_lb_name_prefix in name
                 ):
                     id_prefix = device_id[:8]
-                    length = len(cfg.CONF.special_lb_name_prefix)
-                    if name.endswith(id_prefix, length):
+                    match_regex = cfg.CONF.special_lb_name_prefix + id_prefix
+                    if match_regex in name:
                         LOG.debug("choose inactive device here %s ", device_id)
                         return agent, device
 


### PR DESCRIPTION
Old rule: lb name starts with special_lb_name_prefix value and ends with firts 8 char of inactive device uuid. Default value of special_lb_name_prefix is SPECIAL_ . It means SPECIAL_XXXXXXXX, SPECIAL_ABC_XXXXXXXX can satisfy.

Rule now: lb name includes SPECIAL_XXXXXXXX. It means abc_SPECIAL_XXXXXXXX, SPECIAL_XXXXXXXX_def or
ghi_SPECIAL_XXXXXXXX_jk can satisfy.
Notice that SPECIAL_ is the special_lb_name_prefix value and it can be configured.
