### PR TITLE
[OPENSTACK-2842]: designate a device to rebuild lb tree.

### DIFF
--- a/f5lbaasdriver/v2/bigip/device_scheduler.py
+++ b/f5lbaasdriver/v2/bigip/device_scheduler.py
@@ -160,6 +160,33 @@ class DeviceSchedulerNG(object):
         else:
             return candidates[0]
 
+    def designate_device(self, context, lb, add_device=[]):
+        '''Return a designated device
+
+        when a user rebuilds a loadbalancer with a single device id,
+        the process takes it as designated device. The method returns
+        a designated device regardless of the device's tenant id, the
+        scheduler filters or the status of device.
+        '''
+
+        LOG.debug(
+            "the allocate loadbalancer %s to designate device %s" %
+            (lb.id, add_device)
+        )
+
+        if not add_device:
+            raise NoEligibleLbaasDevice(loadbalancer_id=lb.id)
+
+        candidate = {}
+        device_id = add_device[0]
+        candidate = self.load_device(context, device_id)
+        LOG.debug("the designate device candidates is: %s", candidate)
+
+        if not candidate:
+            raise NoEligibleLbaasDevice(loadbalancer_id=lb.id)
+        else:
+            return candidate
+
     def load_devices(self, context, filters=None):
         # Switch to admin context, so that driver code can query
         # devices onboared by admin when processing user request


### PR DESCRIPTION
this patch is for rebuild lb tree with a designated device.

`neutron lbaas-loadbalancer-rebuild recreate --device 129a26ec-e060-4ce8-96e3-aee312a32339`

there are 3 kinds of ports that need to update the lb_mac and vtep: selfip port, snatip port, and vip port.

when the lb_mac changes, these ports need to update their lb_mac. when the vtep changes, these ports need to delete and create again.

vip port:
  the neutron server creates vip port. The rebuild process is
  beyond the scope of the f5 openstack agent. (so if vip port needs to
  delete and create? when vtep changes.)
  the only thing the f5 openstack agent can do that is f5 driver will
  always update vip with new lb_mac and vtep.

selfip and snatip port:
  f5 agent creates selfip and snatip port.
  If the f5 agent finds the port already exists in Neutron DB (maybe the
  designated bigip device is the same device name as the original bigip
  device):

    1. When lb_mac changes, the f5 agent will update port
    2. When vtep changes, the f5 agent will delete the port first and then create the new port with new info. we do not back the old port, so it is the risk of losing port data, but we may rebuild the port again.

  If the f5 agent finds the port does not exist in Neutron DB (desginated bigip
  and original bigip have different device names):

    The f5 agent will create the new port and it does not delete the
    original selfip/snatip port. It means the Neutron DB may have
    data remnant of useless selfip/snatip port.

