### PR TITLE
OPENSTACK-2959: we need to update port before build service object

### DIFF
--- a/f5lbaasdriver/v2/bigip/driver_v2.py
+++ b/f5lbaasdriver/v2/bigip/driver_v2.py
@@ -810,15 +810,16 @@ class LoadBalancerManager(EntityManager):
         try:
             agent, device = self._schedule_agent_and_device(
                 context, loadbalancer, device_id=device_id)
+
+            if device_id:
+                self.migrate_vipport(context, agent, device, loadbalancer)
+
             # NOTE(qzhao): Call agent to rebuild LB.
             service = self._create_service(context, loadbalancer, agent)
 
             device["rm_selfip_port"] = rm_selfip_port
             service["device"] = device
             agent_host = agent['host']
-
-            if device_id:
-                self.migrate_vipport(context, agent, device, loadbalancer)
 
             if rebuild_all:
                 self._allocate_acl_groups(context, service)


### PR DESCRIPTION
when migrating lb tree from A device to B device, the agent uses network information from the service object.

so when need to update the network first, then build network info into the service object.

then the agent can use a new network (physical info, VLAN) from the service object.
